### PR TITLE
[WIP] Add a new tab widget for displaying metadata

### DIFF
--- a/web_client/js/metadataWidget.js
+++ b/web_client/js/metadataWidget.js
@@ -1,0 +1,18 @@
+girder.wrap(girder.views.MetadataWidget, 'render', function (render) {
+    if (!this.item || !this.item.get('largeImage')) {
+        return render.call(this);
+    }
+
+    girder.restRequest({
+        path: 'item/' + this.item.id + '/tiles'
+    }).then(_.bind(function (tiles) {
+
+        this.$el.html(girder.templates.largeImage_metadataWidget({
+            item: this.item,
+            title: this.title,
+            girder: girder,
+            largeImage: tiles
+        }));
+    }, this));
+    return this;
+});

--- a/web_client/stylesheets/metadataWidget.styl
+++ b/web_client/stylesheets/metadataWidget.styl
@@ -1,0 +1,2 @@
+.li-metadata-tabs
+  margin-top 10px

--- a/web_client/templates/largeImage_metadataWidget.jade
+++ b/web_client/templates/largeImage_metadataWidget.jade
@@ -1,0 +1,38 @@
+.g-widget-metadata-header
+  i.icon-tags #{title}
+.g-widget-metadata-container.li-metadata-tabs
+  ul.nav.nav-tabs(role="tablist")
+    li.active(role="presentation")
+      a(href="#li-metadata-image", role="tab", data-toggle="tab") Image
+    li(role="presentation")
+      a(href="#li-metadata-stain", role="tab", data-toggle="tab") Stain
+    li(role="presentation")
+      a(href="#li-metadata-clinical", role="tab", data-toggle="tab") Clinical
+    li(role="presentation")
+      a(href="#li-metadata-user", role="tab", data-toggle="tab") Custom
+
+  .tab-content
+    .tab-pane.active#li-metadata-image(role="tabpanel")
+      table.table.table-hover.table-condensed
+        thead
+          th Property
+          th Value
+        each value, key in largeImage
+          tr
+            td(scope="row") #{key}
+            td #{value}
+    .tab-pane#li-metadata-stain(role="tabpanel")
+      table.table.table-hover.table-condensed
+        thead
+          th Property
+          th Value
+    .tab-pane#li-metadata-clinical(role="tabpanel")
+      table.table.table-hover.table-condensed
+        thead
+          th Property
+          th Value
+    .tab-pane#li-metadata-user(role="tabpanel")
+      table.table.table-hover.table-condensed
+        thead
+          th Property
+          th Value


### PR DESCRIPTION
Following our discussion in the last meeting, this is a mock up for displaying multiple tabs in the metadata section.

![screen shot 2016-08-19 at 9 24 42 am](https://cloud.githubusercontent.com/assets/31890/17811142/2717fc1e-65ef-11e6-90d4-5ca5e7010c87.png)
