### PR TITLE
Trigger g:imageRendered on every render

### DIFF
--- a/web_client/views/imageViewerWidget/base.js
+++ b/web_client/views/imageViewerWidget/base.js
@@ -15,7 +15,6 @@ var ImageViewerWidget = View.extend({
             this.sizeX = resp.sizeX;
             this.sizeY = resp.sizeY;
             this.render();
-            this.trigger('g:imageRendered', this);
         });
     },
 

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -28,6 +28,7 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
         this.viewer = geo.map(params.map);
         this.viewer.createLayer('osm', params.layer);
 
+        this.trigger('g:imageRendered', this);
         return this;
     },
 

--- a/web_client/views/imageViewerWidget/leaflet.js
+++ b/web_client/views/imageViewerWidget/leaflet.js
@@ -56,6 +56,7 @@ var LeafletImageViewerWidget = ImageViewerWidget.extend({
             ],
             attributionControl: false
         });
+        this.trigger('g:imageRendered', this);
         return this;
     },
 

--- a/web_client/views/imageViewerWidget/openlayers.js
+++ b/web_client/views/imageViewerWidget/openlayers.js
@@ -57,6 +57,7 @@ var OpenlayersImageViewerWidget = ImageViewerWidget.extend({
             }),
             logo: false
         });
+        this.trigger('g:imageRendered', this);
         return this;
     },
 

--- a/web_client/views/imageViewerWidget/openseadragon.js
+++ b/web_client/views/imageViewerWidget/openseadragon.js
@@ -41,6 +41,7 @@ var OpenseadragonImageViewerWidget = ImageViewerWidget.extend({
                 ajaxWithCredentials: true
             }
         });
+        this.trigger('g:imageRendered', this);
         return this;
     },
 

--- a/web_client/views/imageViewerWidget/slideatlas.js
+++ b/web_client/views/imageViewerWidget/slideatlas.js
@@ -54,6 +54,7 @@ var SlideAtlasImageViewerWidget = ImageViewerWidget.extend({
         });
         this.viewer = this.el.saViewer;
 
+        this.trigger('g:imageRendered', this);
         return this;
     },
 


### PR DESCRIPTION
I moved the `g:imageRendered` event into the `render` method of each class.  This is necessary for applications to be able to bind to events on the viewer object itself.  This is used by this commit on HistomicsTK https://github.com/DigitalSlideArchive/HistomicsTK/pull/235/commits/23dee917f43fb98abb97f7e10c12d996c9164098.