### PR TITLE
Add code to display annotations as geojson

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -9,7 +9,8 @@
     "npm": {
         "dependencies": {
             "geojs": "0.11.0",
-            "slideatlas-viewer": "4.0.3"
+            "slideatlas-viewer": "4.0.3",
+            "tinycolor2": "^1.4.1"
         }
     }
 }

--- a/web_client/annotations/convert.js
+++ b/web_client/annotations/convert.js
@@ -1,0 +1,29 @@
+import _ from 'underscore';
+
+import * as geometry from './geometry';
+import style from './style';
+
+function convertOne(annotation) {
+    const type = annotation.type;
+    if (!_.has(geometry, type)) {
+        return;
+    }
+    return {
+        type: 'Feature',
+        id: annotation.id,
+        geometry: geometry[type](annotation),
+        properties: style(annotation)
+    };
+}
+
+export default function convert(json) {
+    const features = _.chain(json)
+        .map(convertOne)
+        .compact()
+        .value();
+
+    return {
+        type: 'FeatureCollection',
+        features
+    };
+}

--- a/web_client/annotations/geometry/index.js
+++ b/web_client/annotations/geometry/index.js
@@ -1,0 +1,5 @@
+import rectangle from './rectangle';
+
+export {
+    rectangle
+};

--- a/web_client/annotations/geometry/rectangle.js
+++ b/web_client/annotations/geometry/rectangle.js
@@ -1,0 +1,27 @@
+import _ from 'underscore';
+import rotate from '../rotate';
+
+export default function rectangle(json) {
+    const center = json.center;
+    const x = center[0];
+    const y = center[1];
+    const height = json.height;
+    const width = json.width;
+    const rotation = json.rotation || 0;
+
+    const left = x - width / 2;
+    const right = x + width / 2;
+    const top = y - height / 2;
+    const bottom = y + height / 2;
+
+    return {
+        type: 'Polygon',
+        coordinates: [_.map([
+            [left, top],
+            [right, top],
+            [right, bottom],
+            [left, bottom],
+            [left, top]
+        ], rotate(rotation, center))]
+    };
+}

--- a/web_client/annotations/index.js
+++ b/web_client/annotations/index.js
@@ -1,0 +1,11 @@
+import convert from './convert';
+import rotate from './rotate';
+import style from './style';
+import * as geometry from './geometry';
+
+export {
+    convert,
+    rotate,
+    style,
+    geometry
+};

--- a/web_client/annotations/rotate.js
+++ b/web_client/annotations/rotate.js
@@ -1,0 +1,18 @@
+/**
+ * Returns a function that rotates a coordinate the given
+ * amount about a center point.
+ */
+export default function rotate(rotation, center) {
+    const cos = Math.cos(rotation);
+    const sin = Math.sin(rotation);
+    center = center || [0, 0];
+
+    return function (point) {
+        const x = point[0] - center[0];
+        const y = point[1] - center[1];
+        return [
+            x * cos - y * sin + center[0],
+            x * sin + y * cos + center[1]
+        ];
+    };
+}

--- a/web_client/annotations/style.js
+++ b/web_client/annotations/style.js
@@ -1,12 +1,37 @@
 import _ from 'underscore';
+import tc from 'tinycolor2';
 
 const props = [
-    'fillColor',
-    'lineColor',
     'lineWidth',
     'label'
 ];
 
+function colorAlpha(color) {
+    if (!color) {
+        return null;
+    }
+    color = tc(color);
+    return {
+        rgb: color.toHexString(),
+        alpha: color.getAlpha()
+    };
+}
+
 export default function style(json) {
-    return _.pick(json, ...props);
+    var color;
+    const style = _.pick(json, ...props);
+
+    color = colorAlpha(json.fillColor);
+    if (color) {
+        style.fillColor = color.rgb;
+        style.fillOpacity = color.alpha;
+    }
+
+    color = colorAlpha(json.lineColor);
+    if (color) {
+        style.strokeColor = color.rgb;
+        style.strokeOpacity = color.alpha;
+    }
+
+    return style;
 }

--- a/web_client/annotations/style.js
+++ b/web_client/annotations/style.js
@@ -1,0 +1,12 @@
+import _ from 'underscore';
+
+const props = [
+    'fillColor',
+    'lineColor',
+    'lineWidth',
+    'label'
+];
+
+export default function style(json) {
+    return _.pick(json, ...props);
+}

--- a/web_client/collections/AnnotationCollection.js
+++ b/web_client/collections/AnnotationCollection.js
@@ -1,0 +1,8 @@
+import Collection from 'girder/collections/Collection';
+import AnnotationModel from '../models/AnnotationModel';
+
+export default Collection.extend({
+    resourceName: 'annotation',
+    model: AnnotationModel,
+    pageLimit: 100
+});

--- a/web_client/collections/index.js
+++ b/web_client/collections/index.js
@@ -1,0 +1,5 @@
+import AnnotationCollection from './AnnotationCollection';
+
+export {
+    AnnotationCollection
+};

--- a/web_client/index.js
+++ b/web_client/index.js
@@ -1,3 +1,11 @@
+import * as annotations from './annotations';
 import * as views from './views';
+import * as collections from './collections';
+import * as models from './models';
 
-export { views };
+export {
+    views,
+    annotations,
+    collections,
+    models
+};

--- a/web_client/models/AnnotationModel.js
+++ b/web_client/models/AnnotationModel.js
@@ -1,0 +1,19 @@
+import Model from 'girder/models/Model';
+
+import convert from '../annotations/convert';
+
+export default Model.extend({
+    resourceName: 'annotation',
+
+    /**
+     * Return the annotation as a geojson FeatureCollection.
+     *
+     * WARNING: Not all annotations are representable in geojson.
+     * Annotation types that cannot be converted will be ignored.
+     */
+    geojson() {
+        const json = this.get('annotation') || {};
+        const elements = json.elements || [];
+        return convert(elements);
+    }
+});

--- a/web_client/models/index.js
+++ b/web_client/models/index.js
@@ -1,0 +1,5 @@
+import AnnotationModel from './AnnotationModel';
+
+export {
+    AnnotationModel
+};

--- a/web_client/views/imageViewerWidget/base.js
+++ b/web_client/views/imageViewerWidget/base.js
@@ -35,6 +35,14 @@ var ImageViewerWidget = View.extend({
             url += '?' + $.param(query);
         }
         return url;
+    },
+
+    drawAnnotation: function () {
+        throw new Error('Viewer does not support drawing annotations');
+    },
+
+    removeAnnotation: function () {
+        throw new Error('Viewer does not support drawing annotations');
     }
 });
 

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -10,6 +10,7 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
             staticRoot + '/built/plugins/large_image/extra/geojs.js',
             () => this.render()
         );
+        this._layers = {};
     },
 
     render: function () {
@@ -41,7 +42,25 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
             delete window.geo;
         }
         ImageViewerWidget.prototype.destroy.call(this);
+    },
+
+    drawAnnotation: function (annotation) {
+        var geojson = annotation.geojson();
+        var layer = this.viewer.createLayer('feature', {
+            features: ['point', 'line', 'polygon']
+        });
+        this._layers[annotation.id] = layer;
+        window.geo.createFileReader('jsonReader', {layer})
+            .read(geojson, () => this.viewer.draw());
+    },
+
+    removeAnnotation: function (annotation) {
+        var layer = this._layers[annotation.id];
+        if (layer) {
+            this.viewer.deleteLayer(layer);
+        }
     }
+
 });
 
 export default GeojsImageViewerWidget;

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -1,4 +1,5 @@
 import { staticRoot } from 'girder/rest';
+import events from 'girder/events';
 
 import ImageViewerWidget from './base';
 
@@ -11,6 +12,8 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
             () => this.render()
         );
         this._layers = {};
+
+        this.listenTo(events, 's:widgetDrawRegion', this.drawRegion);
     },
 
     render: function () {
@@ -59,6 +62,30 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
         if (layer) {
             this.viewer.deleteLayer(layer);
         }
+    },
+
+    drawRegion: function (model) {
+        if (!this.viewer) {
+            return;
+        }
+        var layer = this.viewer.createLayer('annotation');
+        layer.geoOn(
+            window.geo.event.annotation.state,
+            (evt) => {
+                var annotation = evt.annotation;
+                var left, top, width, height, c;
+                if (annotation.type() === 'rectangle') {
+                    c = annotation.coordinates();
+                    left = Math.round(c[0].x);
+                    top = Math.round(c[1].y);
+                    width = Math.round(c[2].x - left);
+                    height = Math.round(c[3].y - top);
+                    model.set('value', [left, top, width, height], {trigger: true});
+                    window.setTimeout(() => this.viewer.deleteLayer(layer), 10);
+                }
+            }
+        );
+        layer.mode('rectangle');
     }
 
 });


### PR DESCRIPTION
This adds an annotation model and collection.  The model contains a method to convert from our own annotation spec to geojson.  As noted in the code, this can't be done for all annotation element types.  For the moment, it **only** handles rectangle types to support the nuclei segmentation end-to-end demo.

A cleaner solution might be to do the conversion to geojson on the server, but ultimately, we will need to write custom code to render annotations directly as given.  This is just a stop gap solution to render basic types using existing functionality in geojs.