### PR TITLE
Remove the geojs viewer before creating a new one

### DIFF
--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -22,6 +22,7 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
             return;
         }
 
+        this._destroyViewer();
         var geo = window.geo; // this makes the style checker happy
 
         var w = this.sizeX, h = this.sizeY;
@@ -37,14 +38,18 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
     },
 
     destroy: function () {
-        if (this.viewer) {
-            this.viewer.exit();
-            this.viewer = null;
-        }
+        this._destroyViewer();
         if (window.geo) {
             delete window.geo;
         }
         ImageViewerWidget.prototype.destroy.call(this);
+    },
+
+    _destroyViewer: function () {
+        if (this.viewer) {
+            this.viewer.exit();
+            this.viewer = null;
+        }
     },
 
     drawAnnotation: function (annotation) {


### PR DESCRIPTION
When calling `render` multiple times on a geojs image viewer, the previous `map` object was not getting destroyed.  This resulted in duplicate layers inside the map node.