### PR TITLE
Speed up annotation validation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,6 +183,8 @@ install:
   - cd $girder_path
   - pip install --no-cache-dir -U -r requirements.txt -r requirements-dev.txt -e .
   - pip install -r $main_path/requirements.txt -e .
+  # Make sure we have a prefered version of celery for Girder Worker
+  - pip install -U 'celery>=4'
   - python -c "import openslide;print openslide.__version__"
   # This was
   # - npm install

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -84,7 +84,7 @@ set_property(TEST server_large_image.sources APPEND PROPERTY ENVIRONMENT
 
 add_python_test(import PLUGIN large_image BIND_SERVER)
 
-add_python_test(large_image PLUGIN large_image
+add_python_test(large_image PLUGIN large_image BIND_SERVER
   # There is a bug in cmake that fails when external data files are added to
   # multiple tests, so comment out the external data directive.
   # EXTERNAL_DATA
@@ -110,6 +110,15 @@ add_python_test(examples PLUGIN large_image
   # "plugins/large_image/sample_image.ptif"
   )
 set_property(TEST server_large_image.examples APPEND PROPERTY ENVIRONMENT
+  "LARGE_IMAGE_DATA=${PROJECT_BINARY_DIR}/data/plugins/large_image")
+
+add_python_test(annotations PLUGIN large_image BIND_SERVER
+  # There is a bug in cmake that fails when external data files are added to
+  # multiple tests, so comment out the external data directive.
+  # EXTERNAL_DATA
+  # "plugins/large_image/sample_Easy1.png"
+  )
+set_property(TEST server_large_image.annotations APPEND PROPERTY ENVIRONMENT
   "LARGE_IMAGE_DATA=${PROJECT_BINARY_DIR}/data/plugins/large_image")
 
 add_web_client_test(

--- a/plugin_tests/annotations_test.py
+++ b/plugin_tests/annotations_test.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#############################################################################
+
+import os
+
+from girder import config
+from tests import base
+
+from . import common
+
+
+# boiler plate to start and stop the server
+
+os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_TEST_PORT', '20200')
+config.loadConfig()  # Must reload config to pickup correct port
+
+
+def setUpModule():
+    base.enabledPlugins.append('large_image')
+    base.startServer(False)
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class LargeImageAnnotationTest(common.LargeImageCommonTest):
+    def testAnnotationSchema(self):
+        from girder.plugins.large_image.models import annotation
+        schema = annotation.AnnotationSchema
+        self.assertIsNotNone(schema.annotationSchema)
+        self.assertIsNotNone(schema.annotationElementSchema)
+
+    def testAnnotationCreate(self):
+        annotModel = self.model('annotation', 'large_image')
+        file = self._uploadFile(os.path.join(
+            os.environ['LARGE_IMAGE_DATA'], 'sample_Easy1.png'))
+        itemId = str(file['itemId'])
+        annotation = {
+            'name': 'testAnnotation',
+            'elements': [{
+                'type': 'rectangle',
+                'center': [10, 20, 0],
+                'width': 5,
+                'height': 10,
+            }]
+        }
+        result = annotModel.createAnnotation({'_id': itemId}, self.admin, annotation)
+        self.assertIn('_id', result)
+        annotId = result['_id']
+        result = annotModel.load(annotId)
+        self.assertEqual(len(result['annotation']['elements']), 1)
+
+    def testSimilarElementStructure(self):
+        ses = self.model('annotation', 'large_image')._similarElementStructure
+        self.assertTrue(ses('a', 'a'))
+        self.assertFalse(ses('a', 'b'))
+        self.assertTrue(ses(10, 10))
+        self.assertTrue(ses(10, 11))
+        self.assertFalse(ses(10, 10.0))
+        self.assertTrue(ses({'a': 10}, {'a': 12}))
+        self.assertFalse(ses({'a': 10}, {'a': 'b'}))
+        self.assertFalse(ses({'a': 10, 'b': 11}, {'a': 10}))
+        self.assertFalse(ses({'a': 10, 'b': 11}, {'a': 10, 'c': 11}))
+        self.assertTrue(ses({'id': '012345678901234567890123'},
+                            {'id': '01234567890123456789ffff'}))
+        self.assertFalse(ses({'id': '012345678901234567890123'},
+                             {'id': '01234567890123456789----'}))
+        self.assertTrue(ses([1, 2, 3, 4], [2, 3, 4, 5]))
+        self.assertFalse(ses([1, 2, 3, 4], [2, 3, 4, 5, 6]))
+        self.assertFalse(ses([1, 2, 3, 4], [2, 3, 4, 'a']))
+        self.assertTrue(ses({'points': [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+        ]}, {'points': [
+            [10, 11, 12],
+            [13, 14, 15],
+            [16, 17, 18],
+            [19, 20, 21.1],
+        ]}))
+        self.assertFalse(ses({'points': [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+        ]}, {'points': [
+            [10, 11, 12],
+            [13, 14, 15],
+            [16, 17, 18],
+            [19, 20, 'b'],
+        ]}))
+
+    # Add tests for:
+    # load
+    # remove
+    # save
+    # updateAnnotaton
+    # validate
+    # _onItemRemove

--- a/server/models/annotation.py
+++ b/server/models/annotation.py
@@ -21,9 +21,12 @@ import datetime
 import enum
 import jsonschema
 import six
+import re
+import time
 from six.moves import range
 
 from girder import events
+from girder import logger
 from girder.constants import AccessType
 from girder.models.model_base import Model, ValidationException
 
@@ -296,6 +299,24 @@ class AnnotationSchema:
         ]
     }
 
+    annotationElementSchema = {
+        '$schema': 'http://json-schema.org/schema#',
+        # Shape subtypes are mutually exclusive, so for  efficiency, don't use
+        # 'oneOf'
+        'anyOf': [
+            # If we include the baseShapeSchema, then shapes that are as-yet
+            #  invented can be included.
+            # baseShapeSchema,
+            arrowShapeSchema,
+            circleShapeSchema,
+            ellipseShapeSchema,
+            pointShapeSchema,
+            polylineShapeSchema,
+            rectangleShapeSchema,
+            rectangleGridShapeSchema,
+        ]
+    }
+
     annotationSchema = {
         '$schema': 'http://json-schema.org/schema#',
         'id': '/girder/plugins/large_image/models/annotation',
@@ -316,22 +337,7 @@ class AnnotationSchema:
             },
             'elements': {
                 'type': 'array',
-                'items': {
-                    # Shape subtypes are mutually exclusive, so for
-                    #  efficiency. don't use 'oneOf'
-                    'anyOf': [
-                        # If we include the baseShapeSchema, then shapes that
-                        # are as-yet invented can be included.
-                        # baseShapeSchema,
-                        arrowShapeSchema,
-                        circleShapeSchema,
-                        ellipseShapeSchema,
-                        pointShapeSchema,
-                        polylineShapeSchema,
-                        rectangleShapeSchema,
-                        rectangleGridShapeSchema,
-                    ]
-                },
+                'items': annotationElementSchema,
                 # We want to ensure unique element IDs, if they are set.  If
                 # they are not set, we assign them from Mongo.
                 'title': 'Image Markup',
@@ -352,6 +358,13 @@ class Annotation(Model):
     stored as independent models to (eventually) permit faster spatial
     searching.
     """
+
+    validatorAnnotation = jsonschema.Draft4Validator(
+        AnnotationSchema.annotationSchema)
+    validatorAnnotationElement = jsonschema.Draft4Validator(
+        AnnotationSchema.annotationElementSchema)
+    idRegex = re.compile('^[0-9a-f]{24}$')
+    numberInstance = six.integer_types + (float, )
 
     class Skill(enum.Enum):
         NOVICE = 'novice'
@@ -480,6 +493,7 @@ class Annotation(Model):
         :returns: the saved document.  If it is a new document, the _id has
                   been added.
         """
+        starttime = time.time()
         replace_one = self.collection.replace_one
         insert_one = self.collection.insert_one
         version = self.model(
@@ -525,6 +539,7 @@ class Annotation(Model):
         result = super(Annotation, self).save(annotation, *args, **kwargs)
         self.collection.replace_one = replace_one
         self.collection.insert_one = insert_one
+        logger.debug('Saved annotation in %5.3fs' % (time.time() - starttime))
         return result
 
     def updateAnnotation(self, annotation, updateUser=None):
@@ -539,12 +554,81 @@ class Annotation(Model):
         annotation['updatedId'] = updateUser['_id']
         return self.save(annotation)
 
+    def _similarElementStructure(self, a, b, parentKey=None):  # noqa
+        """
+        Compare two elements to determine if they are similar enough that if
+        one validates, the other should, too.  This is called recursively to
+        validate dictionaries.  In general, types must be the same,
+        dictionaries must contain the same keys, arrays must be the same
+        length.  The only differences that are allowed are numerical values may
+        be different, ids may be different, and point arrays may contain
+        different numbers of elements.
+
+        :param a: first element
+        :param b: second element
+        :param parentKey: if set, the key of the dictionary that used for this
+            part of the comparison.
+        :returns: True if the elements are similar.  False if they are not.
+        """
+        # This function exceeds the recommended complexity, but since it is
+        # needs to be relatively fast, breaking it into smaller functions is
+        # probably undesireable.
+        if type(a) != type(b):
+            return False
+        if isinstance(a, dict):
+            if len(a) != len(b):
+                return False
+            for k in a:
+                if k not in b:
+                    return False
+                if k == 'id':
+                    if not isinstance(b[k], six.string_types) or not self.idRegex.match(b[k]):
+                        return False
+                elif parentKey != 'label' or k != 'value':
+                    if not self._similarElementStructure(a[k], b[k], k):
+                        return False
+        elif isinstance(a, list):
+            if len(a) != len(b):
+                if parentKey != 'points' or len(a) < 3 or len(b) < 3:
+                    return False
+                # If this is an array of points, let it pass
+                for idx in range(len(b)):
+                    if (len(b[idx]) != 3 or
+                            not isinstance(b[idx][0], self.numberInstance) or
+                            not isinstance(b[idx][1], self.numberInstance) or
+                            not isinstance(b[idx][2], self.numberInstance)):
+                        return False
+                return True
+            for idx in range(len(a)):
+                if not self._similarElementStructure(a[idx], b[idx], parentKey):
+                    return False
+        elif not isinstance(a, self.numberInstance):
+            return a == b
+        # Either a number or the dictionary or list comparisons passed
+        return True
+
     def validate(self, doc):
+        starttime = time.time()
         try:
-            jsonschema.validate(doc.get('annotation'),
-                                AnnotationSchema.annotationSchema)
+            # This block could just use the json validator:
+            #   jsonschema.validate(doc.get('annotation'),
+            #                       AnnotationSchema.annotationSchema)
+            # but this is very slow.  Instead, validate the main structure and
+            # then validate each element.  If sequential elements are similar
+            # in structure, skip validating them.
+            annot = doc.get('annotation')
+            elements = annot.get('elements', [])
+            annot['elements'] = []
+            self.validatorAnnotation.validate(annot)
+            lastValidatedElement = None
+            for element in elements:
+                if not self._similarElementStructure(element, lastValidatedElement):
+                    self.validatorAnnotationElement.validate(element)
+                    lastValidatedElement = element
+            annot['elements'] = elements
         except jsonschema.ValidationError as exp:
             raise ValidationException(exp)
+        logger.debug('Validated in %5.3fs' % (time.time() - starttime))
         elementIds = [entry['id'] for entry in
                       doc['annotation'].get('elements', []) if 'id' in entry]
         if len(set(elementIds)) != len(elementIds):


### PR DESCRIPTION
Use the jsonschema.validate for large annotations is prohibitively slow.  However, since large annotations are largely similar, use that similarity to do some of the validation.  One a test of 338,695 rectangles this changed the validation time from 460 seconds to 5 seconds.

Add some tests for the annotation model.