### PR TITLE
Change how the large_image config settings are accessed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,6 +183,8 @@ install:
   - cd $girder_path
   - pip install --no-cache-dir -U -r requirements.txt -r requirements-dev.txt -e .
   - pip install -r $main_path/requirements.txt -e .
+  # Make sure we have a prefered version of celery for Girder Worker
+  - pip install -U 'celery>=4'
   - python -c "import openslide;print openslide.__version__"
   # This was
   # - npm install

--- a/examples/average_color.py
+++ b/examples/average_color.py
@@ -6,6 +6,8 @@ import numpy
 
 import large_image
 
+large_image.cache_util.setConfig('cache_backend', 'python')
+
 
 def average_color(imagePath, magnification=None):
     """

--- a/plugin_tests/cache_test.py
+++ b/plugin_tests/cache_test.py
@@ -62,6 +62,14 @@ class LargeImageCacheTest(base.TestCase):
         except ImportError:
             self.fail('Could not import pylibmc.')
 
+    def testConfigFunctions(self):
+        from girder.plugins.large_image.cache_util import getConfig, setConfig
+        self.assertEquals(getConfig('cache_backend'), None)
+        self.assertEquals(getConfig('cache_backend', 'python'), 'python')
+        self.assertTrue(isinstance(getConfig(), dict))
+        setConfig('cache_backend', 'python')
+        self.assertEquals(getConfig('cache_backend'), 'python')
+
     def _testDecorator(self, specific_cache, maxNum=100):
         from girder.plugins.large_image.cache_util import cached, strhash
         temp = Fib()

--- a/server/cache_util/__init__.py
+++ b/server/cache_util/__init__.py
@@ -17,15 +17,15 @@
 #  limitations under the License.
 ###############################################################################
 
-from .cache import LruCacheMetaclass, tileCache, tileLock, strhash, methodcache
+from .cache import LruCacheMetaclass, strhash, methodcache, getTileCache
 try:
     from .memcache import MemCache
 except ImportError:
     MemCache = None
-from .cachefactory import CacheFactory, pickAvailableCache
+from .cachefactory import CacheFactory, pickAvailableCache, setConfig, getConfig
 from cachetools import cached, Cache, LRUCache
 
 
-__all__ = ('CacheFactory', 'tileCache', 'tileLock', 'MemCache', 'strhash',
+__all__ = ('CacheFactory', 'getTileCache', 'MemCache', 'strhash',
            'LruCacheMetaclass', 'pickAvailableCache', 'cached', 'Cache',
-           'LRUCache', 'methodcache')
+           'LRUCache', 'methodcache', 'setConfig', 'getConfig')

--- a/server/cache_util/cache.py
+++ b/server/cache_util/cache.py
@@ -30,6 +30,10 @@ except ImportError:
 from .cachefactory import CacheFactory, pickAvailableCache
 
 
+_tileCache = None
+_tileLock = None
+
+
 # If we have a resource module, ask to use as many file handles as the hard
 # limit allows, then calculate that how may tile sources we can have open based
 # on the actual limit.
@@ -176,6 +180,15 @@ class LruCacheMetaclass(type):
         return instance
 
 
-# Decide whether to use Memcached or cachetools
+def getTileCache():
+    """
+    Get the preferred tile cache and lock.
 
-tileCache, tileLock = CacheFactory().getCache()
+    :returns: tileCache and tileLock.
+    """
+    global _tileCache, _tileLock
+
+    if _tileCache is None:
+        # Decide whether to use Memcached or cachetools
+        _tileCache, _tileLock = CacheFactory().getCache()
+    return _tileCache, _tileLock

--- a/server/cache_util/cachefactory.py
+++ b/server/cache_util/cachefactory.py
@@ -41,6 +41,39 @@ except ImportError:
     psutil = None
 
 
+defaultConfig = {}
+
+
+def getConfig(key=None, default=None):
+    """
+    Get the config dictionary or a value from the cache config settings.
+
+    :param key: if None, return the config dictionary.  Otherwise, return the
+        value of the key if it is set or the default value if it is not.
+    :param default: a value to return if a key is requested and not set.
+    :returns: either the config dictionary or the value of a key.
+    """
+    if config:
+        curConfig = config.getConfig().get('large_image', defaultConfig)
+    else:
+        curConfig = defaultConfig
+    if key is None:
+        return curConfig
+    return curConfig.get(key, default)
+
+
+def setConfig(key, value):
+    """
+    Set a value in the cache config settings.
+
+    :param key: the key to set.
+    :param value: the value to store in the key.
+    """
+    curConfig = getConfig()
+    if curConfig.get(key) is not value:
+        curConfig[key] = value
+
+
 def pickAvailableCache(sizeEach, portion=8, maxItems=None):
     """
     Given an estimated size of an item, return how many of those items would
@@ -67,19 +100,10 @@ def pickAvailableCache(sizeEach, portion=8, maxItems=None):
 class CacheFactory():
     logged = False
 
-    def getConfig(self):
-        defaultConfig = {}
-        if config:
-            curConfig = config.getConfig().get('large_image', defaultConfig)
-        else:
-            curConfig = defaultConfig
-        return curConfig
-
     def getCacheSize(self, numItems):
         if numItems is None:
-            curConfig = self.getConfig()
             try:
-                portion = int(curConfig.get('cache_python_memory_portion', 8))
+                portion = int(getConfig('cache_python_memory_portion', 8))
                 if portion < 3:
                     portion = 3
             except ValueError:
@@ -88,7 +112,7 @@ class CacheFactory():
         return numItems
 
     def getCache(self, numItems=None):
-        curConfig = self.getConfig()
+        curConfig = getConfig()
         # memcached is the fallback default, if available.
         cacheBackend = curConfig.get('cache_backend', 'memcached')
         if cacheBackend:

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -20,7 +20,7 @@
 import math
 from six import BytesIO
 
-from ..cache_util import tileCache, tileLock, strhash, methodcache
+from ..cache_util import getTileCache, strhash, methodcache
 
 try:
     import girder
@@ -318,9 +318,6 @@ class LazyTileDict(dict):
 class TileSource(object):
     name = None
 
-    cache = tileCache
-    cache_lock = tileLock
-
     def __init__(self, jpegQuality=95, jpegSubsampling=0,
                  encoding='JPEG', edge=False, *args, **kwargs):
         """
@@ -333,6 +330,8 @@ class TileSource(object):
         :param edge: False to leave edge tiles whole, True or 'crop' to crop
             edge tiles, otherwise, an #rrggbb color to fill edges.
         """
+        self.cache, self.cache_lock = getTileCache()
+
         self.tileWidth = None
         self.tileHeight = None
         self.levels = None


### PR DESCRIPTION
This also delays when the cache is selected, so that the configuration can be altered after large_image is imported.  The average_color example demonstrates how this can be done.