### PR TITLE
Support drawing annotations with geojs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,6 +183,8 @@ install:
   - cd $girder_path
   - pip install --no-cache-dir -U -r requirements.txt -r requirements-dev.txt -e .
   - pip install -r $main_path/requirements.txt -e .
+  # Make sure we have a prefered version of celery for Girder Worker
+  - pip install -U 'celery>=4'
   - python -c "import openslide;print openslide.__version__"
   # This was
   # - npm install

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -127,6 +127,11 @@ add_web_client_test(
   "${CMAKE_CURRENT_LIST_DIR}/plugin_tests/client/geojsSpec.js"
   PLUGIN large_image)
 
+add_web_client_test(
+  geojs-annotations
+  "${CMAKE_CURRENT_LIST_DIR}/plugin_tests/client/geojsAnnotationSpec.js"
+  PLUGIN large_image)
+
 #add_puglint_test(
 #  large_image
 #  "${CMAKE_CURRENT_LIST_DIR}/web_client/templates")

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -168,7 +168,7 @@ describe('Annotations', function () {
                 lineWidth: 2
             });
             expect(obj).toEqual({
-                lineWidth: 2
+                strokeWidth: 2
             });
         });
     });
@@ -189,7 +189,7 @@ describe('Annotations', function () {
             expect(features[0].id).toBe('a');
 
             var properties = features[0].properties;
-            expect(properties.lineWidth).toBe(2);
+            expect(properties.strokeWidth).toBe(2);
             expect(properties.fillColor).toBe('#000000');
             expect(properties.fillOpacity).toBe(0);
             expect(properties.strokeColor).toBe('#000000');
@@ -211,7 +211,7 @@ describe('Annotations', function () {
             expect(features[0].id).toBe('a');
 
             var properties = features[0].properties;
-            expect(properties.lineWidth).toBe(2);
+            expect(properties.strokeWidth).toBe(2);
             expect(properties.fillColor).toBe('#000000');
             expect(properties.fillOpacity).toBe(0);
             expect(properties.strokeColor).toBe('#000000');

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -120,6 +120,16 @@ describe('Annotations', function () {
                 ]
             );
         });
+
+        it('point', function () {
+            var obj = largeImage.annotations.geometry.point({
+                type: 'point',
+                id: 'a',
+                center: [1, 2, 0]
+            });
+            expect(obj.type).toBe('Point');
+            expect(obj.coordinates).toEqual([1, 2]);
+        });
     });
 
     describe('style', function () {

--- a/plugin_tests/client/geojsAnnotationSpec.js
+++ b/plugin_tests/client/geojsAnnotationSpec.js
@@ -9,66 +9,20 @@ girderTest.addScripts([
 
 describe('geojs-annotations', function () {
     var large_image, geojs;
+    var fillColor = 'rgba(0,0,0,0)';
+    var lineColor = 'rgb(0,0,0)';
+    var lineWidth = 2;
 
     beforeEach(function () {
         large_image = girder.plugins.large_image;
         geojs = large_image.annotations.geojs;
     });
 
-    it('common', function () {
-        var style;
-        var annotation = {
-            options: function () {
-                return {
-                    style: style
-                };
-            }
-        };
-
-        style = {
-            fill: false,
-            stroke: false
-        };
-        expect(geojs.common(annotation)).toEqual({
-            fillColor: 'rgba(0, 0, 0, 0)',
-            lineColor: 'rgba(0, 0, 0, 0)'
-        });
-
-        style = {
-            fill: true,
-            fillColor: {r: 1, g: 0, b: 0},
-            stroke: true,
-            strokeColor: {r: 0, g: 1, b: 0}
-        };
-        expect(geojs.common(annotation)).toEqual({
-            fillColor: 'rgb(255, 0, 0)',
-            lineColor: 'rgb(0, 255, 0)'
-        });
-
-        style = {
-            fill: true,
-            fillColor: {r: 1, g: 0, b: 0},
-            fillOpacity: 0.5,
-            stroke: true,
-            strokeColor: {r: 0, g: 1, b: 0},
-            strokeOpacity: 0.5
-        };
-        expect(geojs.common(annotation)).toEqual({
-            fillColor: 'rgba(255, 0, 0, 0.5)',
-            lineColor: 'rgba(0, 255, 0, 0.5)'
-        });
-    });
-
     it('convert', function () {
-        var style = {fill: false, stroke: false};
         var type;
         var coordinates;
+
         var annotation = {
-            options: function () {
-                return {
-                    style: style
-                };
-            },
             type: function () {
                 return type;
             },
@@ -88,8 +42,9 @@ describe('geojs-annotations', function () {
         expect(geojs.convert(annotation)).toEqual({
             type: 'point',
             center: [0, 0, 0],
-            fillColor: 'rgba(0, 0, 0, 0)',
-            lineColor: 'rgba(0, 0, 0, 0)'
+            fillColor: fillColor,
+            lineColor: lineColor,
+            lineWidth: lineWidth
         });
     });
 
@@ -114,7 +69,11 @@ describe('geojs-annotations', function () {
             stroke: false
         };
         var coordinates;
+        var type = type;
         var annotation = {
+            type: function () {
+                return type;
+            },
             options: function () {
                 return {
                     style: style
@@ -126,16 +85,19 @@ describe('geojs-annotations', function () {
         };
 
         it('point', function () {
+            type = 'point';
             coordinates = [{x: 1, y: 2}];
             expect(geojs.types.point(annotation)).toEqual({
                 type: 'point',
                 center: [1, 2, 0],
-                fillColor: 'rgba(0, 0, 0, 0)',
-                lineColor: 'rgba(0, 0, 0, 0)'
+                fillColor: fillColor,
+                lineColor: lineColor,
+                lineWidth: lineWidth
             });
         });
 
         it('rectangle', function () {
+            type = 'rectangle';
             coordinates = [
                 {x: 1, y: 2},
                 {x: 1, y: 4},
@@ -148,12 +110,15 @@ describe('geojs-annotations', function () {
                 width: 2,
                 height: 2,
                 rotation: 0,
-                fillColor: 'rgba(0, 0, 0, 0)',
-                lineColor: 'rgba(0, 0, 0, 0)'
+                fillColor: fillColor,
+                lineColor: lineColor,
+                lineWidth: lineWidth,
+                normal: [0, 0, 1]
             });
         });
 
         it('rotated rectangle', function () {
+            type = 'rectangle';
             coordinates = [
                 {x: 0, y: -1},
                 {x: -1, y: 0},
@@ -166,12 +131,15 @@ describe('geojs-annotations', function () {
                 width: Math.sqrt(2),
                 height: Math.sqrt(2),
                 rotation: Math.PI / 4,
-                fillColor: 'rgba(0, 0, 0, 0)',
-                lineColor: 'rgba(0, 0, 0, 0)'
+                fillColor: fillColor,
+                lineColor: lineColor,
+                lineWidth: lineWidth,
+                normal: [0, 0, 1]
             });
         });
 
         it('polygon', function () {
+            type = 'polygon';
             coordinates = [
                 {x: 0, y: 0},
                 {x: 1, y: 0},
@@ -187,8 +155,9 @@ describe('geojs-annotations', function () {
                     [1, 1, 0],
                     [0, 1, 0]
                 ],
-                fillColor: 'rgba(0, 0, 0, 0)',
-                lineColor: 'rgba(0, 0, 0, 0)'
+                fillColor: fillColor,
+                lineColor: lineColor,
+                lineWidth: lineWidth
             });
         });
     });

--- a/plugin_tests/client/geojsAnnotationSpec.js
+++ b/plugin_tests/client/geojsAnnotationSpec.js
@@ -1,0 +1,161 @@
+/* globals girder, girderTest, describe, it, expect, waitsFor, runs */
+/* eslint-disable camelcase */
+
+girderTest.addScripts([
+    '/clients/web/static/built/plugins/jobs/plugin.min.js',
+    '/clients/web/static/built/plugins/worker/plugin.min.js',
+    '/clients/web/static/built/plugins/large_image/plugin.min.js'
+]);
+
+describe('geojs-annotations', function () {
+    var large_image, geojs;
+
+    beforeEach(function () {
+        large_image = girder.plugins.large_image;
+        geojs = large_image.annotations.geojs;
+    });
+
+    it('common', function () {
+        var style;
+        var annotation = {
+            options: function () {
+                return {
+                    style: style
+                };
+            }
+        };
+
+        style = {
+            fill: false,
+            stroke: false
+        };
+        expect(geojs.common(annotation)).toEqual({
+            fillColor: 'rgba(0, 0, 0, 0)',
+            lineColor: 'rgba(0, 0, 0, 0)'
+        });
+
+        style = {
+            fill: true,
+            fillColor: {r: 1, g: 0, b: 0},
+            stroke: true,
+            strokeColor: {r: 0, g: 1, b: 0}
+        };
+        expect(geojs.common(annotation)).toEqual({
+            fillColor: 'rgb(255, 0, 0)',
+            lineColor: 'rgb(0, 255, 0)'
+        });
+
+        style = {
+            fill: true,
+            fillColor: {r: 1, g: 0, b: 0},
+            fillOpacity: 0.5,
+            stroke: true,
+            strokeColor: {r: 0, g: 1, b: 0},
+            strokeOpacity: 0.5
+        };
+        expect(geojs.common(annotation)).toEqual({
+            fillColor: 'rgba(255, 0, 0, 0.5)',
+            lineColor: 'rgba(0, 255, 0, 0.5)'
+        });
+    });
+
+    describe('coordinates', function () {
+        it('point', function () {
+            expect(geojs.coordinates.point({x: 1, y: 2})).toEqual([1, 2, 0]);
+            expect(geojs.coordinates.point({x: 1, y: 2, z: 3})).toEqual([1, 2, 3]);
+        });
+
+        it('array', function () {
+            expect(geojs.coordinates.array([{x: 1, y: 2}])).toEqual([[1, 2, 0]]);
+            expect(geojs.coordinates.array([
+                {x: 1, y: 2, z: 3},
+                {x: 2, y: 3, z: 4}
+            ])).toEqual([[1, 2, 3], [2, 3, 4]]);
+        });
+    });
+
+    describe('types', function () {
+        var style = {
+            fill: false,
+            stroke: false
+        };
+        var coordinates;
+        var annotation = {
+            options: function () {
+                return {
+                    style: style
+                };
+            },
+            coordinates: function () {
+                return coordinates;
+            }
+        };
+
+        it('point', function () {
+            coordinates = [{x: 1, y: 2}];
+            expect(geojs.types.point(annotation)).toEqual({
+                type: 'point',
+                center: [1, 2, 0],
+                fillColor: 'rgba(0, 0, 0, 0)',
+                lineColor: 'rgba(0, 0, 0, 0)'
+            });
+        });
+
+        it('rectangle', function () {
+            coordinates = [
+                {x: 1, y: 2},
+                {x: 1, y: 4},
+                {x: 3, y: 4},
+                {x: 3, y: 2}
+            ];
+            expect(geojs.types.rectangle(annotation)).toEqual({
+                type: 'rectangle',
+                center: [2, 3, 0],
+                width: 2,
+                height: 2,
+                rotation: 0,
+                fillColor: 'rgba(0, 0, 0, 0)',
+                lineColor: 'rgba(0, 0, 0, 0)'
+            });
+        });
+
+        it('rotated rectangle', function () {
+            coordinates = [
+                {x: 0, y: -1},
+                {x: -1, y: 0},
+                {x: 0, y: 1},
+                {x: 1, y: 0}
+            ];
+            expect(geojs.types.rectangle(annotation)).toEqual({
+                type: 'rectangle',
+                center: [0, 0, 0],
+                width: Math.sqrt(2),
+                height: Math.sqrt(2),
+                rotation: Math.PI / 4,
+                fillColor: 'rgba(0, 0, 0, 0)',
+                lineColor: 'rgba(0, 0, 0, 0)'
+            });
+        });
+
+        it('polygon', function () {
+            coordinates = [
+                {x: 0, y: 0},
+                {x: 1, y: 0},
+                {x: 1, y: 1},
+                {x: 0, y: 1}
+            ];
+            expect(geojs.types.polygon(annotation)).toEqual({
+                type: 'polyline',
+                closed: true,
+                points: [
+                    [0, 0, 0],
+                    [1, 0, 0],
+                    [1, 1, 0],
+                    [0, 1, 0]
+                ],
+                fillColor: 'rgba(0, 0, 0, 0)',
+                lineColor: 'rgba(0, 0, 0, 0)'
+            });
+        });
+    });
+});

--- a/plugin_tests/client/geojsAnnotationSpec.js
+++ b/plugin_tests/client/geojsAnnotationSpec.js
@@ -59,6 +59,40 @@ describe('geojs-annotations', function () {
         });
     });
 
+    it('convert', function () {
+        var style = {fill: false, stroke: false};
+        var type;
+        var coordinates;
+        var annotation = {
+            options: function () {
+                return {
+                    style: style
+                };
+            },
+            type: function () {
+                return type;
+            },
+            coordinates: function () {
+                return coordinates;
+            }
+        };
+
+        // invalid type
+        type = 'not valid';
+        expect(function () {
+            geojs.convert(annotation);
+        }).toThrow();
+
+        type = 'point';
+        coordinates = [{x: 0, y: 0}];
+        expect(geojs.convert(annotation)).toEqual({
+            type: 'point',
+            center: [0, 0, 0],
+            fillColor: 'rgba(0, 0, 0, 0)',
+            lineColor: 'rgba(0, 0, 0, 0)'
+        });
+    });
+
     describe('coordinates', function () {
         it('point', function () {
             expect(geojs.coordinates.point({x: 1, y: 2})).toEqual([1, 2, 0]);

--- a/server/models/annotation.py
+++ b/server/models/annotation.py
@@ -111,7 +111,8 @@ class AnnotationSchema:
                         'type': 'string',
                         'enum': ['point']
                     },
-                    'center': coordSchema
+                    'center': coordSchema,
+                    'fillColor': colorSchema
                 },
                 'required': ['type', 'center'],
                 'patternProperties': baseShapePatternProperties,

--- a/web_client/annotations/defaults/index.js
+++ b/web_client/annotations/defaults/index.js
@@ -1,7 +1,9 @@
 import rectangle from './rectangle';
 import polyline from './polyline';
+import point from './point';
 
 export {
     rectangle,
-    polyline
+    polyline,
+    point
 };

--- a/web_client/annotations/defaults/point.js
+++ b/web_client/annotations/defaults/point.js
@@ -1,5 +1,5 @@
 export default {
-    fillColor: 'rgba(0,0,0,0)',
     lineColor: 'rgb(0,0,0)',
-    lineWidth: 2
+    lineWidth: 2,
+    fillColor: 'rgba(0,0,0,0)'
 };

--- a/web_client/annotations/defaults/rectangle.js
+++ b/web_client/annotations/defaults/rectangle.js
@@ -1,6 +1,6 @@
 export default {
     fillColor: 'rgba(0,0,0,0)',
-    lineColor: 'rgba(0,0,0,1)',
+    lineColor: 'rgb(0,0,0)',
     lineWidth: 2,
     rotation: 0,
     normal: [0, 0, 1]

--- a/web_client/annotations/geojs/common.js
+++ b/web_client/annotations/geojs/common.js
@@ -10,6 +10,7 @@ import * as defaults from '../defaults';
  *
  * @param {annotation} annotation A geojs native annotation object
  * @param {string} type Override the detected output type
+ * @returns {object}
  */
 function common(annotation, type) {
     type = type || annotation.type();

--- a/web_client/annotations/geojs/common.js
+++ b/web_client/annotations/geojs/common.js
@@ -1,0 +1,50 @@
+import tc from 'tinycolor2';
+import _ from 'underscore';
+
+/**
+ * Generate an rgba string from a color value and opacity.
+ */
+function color(value, opacity) {
+    // geojs uses [0,1] color scales
+    var c = tc.fromRatio(value);
+    if (_.isNumber(opacity)) {
+        c.setAlpha(opacity);
+    }
+    return c.toRgbString();
+}
+
+/**
+ * Generate an rgba string from a particular component of
+ * a geojs style object.  property should be 'stroke' or 'fill'.
+ */
+function setColorType(style, property) {
+    const value = style[property + 'Color'];
+    const opacity = style[property + 'Opacity'];
+    const present = style[property];
+
+    // set the color to 100% transparent if the property is off
+    if (!present) {
+        return color(value, 0);
+    }
+
+    return color(value, opacity);
+}
+
+/**
+ * Convert properties from geojs options to annotation
+ * elements that all types have in common.  At the moment,
+ * this handles style information, but could be expanded
+ * to handle labels, names, id's, etc.
+ */
+function common(annotation) {
+    const style = annotation.options().style;
+    const fillColor = setColorType(style, 'fill');
+    const lineColor = setColorType(style, 'stroke');
+
+    return {
+        fillColor,
+        lineColor
+    };
+}
+
+export default common;

--- a/web_client/annotations/geojs/common.js
+++ b/web_client/annotations/geojs/common.js
@@ -1,50 +1,17 @@
-import tc from 'tinycolor2';
-import _ from 'underscore';
-
-/**
- * Generate an rgba string from a color value and opacity.
- */
-function color(value, opacity) {
-    // geojs uses [0,1] color scales
-    var c = tc.fromRatio(value);
-    if (_.isNumber(opacity)) {
-        c.setAlpha(opacity);
-    }
-    return c.toRgbString();
-}
-
-/**
- * Generate an rgba string from a particular component of
- * a geojs style object.  property should be 'stroke' or 'fill'.
- */
-function setColorType(style, property) {
-    const value = style[property + 'Color'];
-    const opacity = style[property + 'Opacity'];
-    const present = style[property];
-
-    // set the color to 100% transparent if the property is off
-    if (!present) {
-        return color(value, 0);
-    }
-
-    return color(value, opacity);
-}
+import * as defaults from '../defaults';
 
 /**
  * Convert properties from geojs options to annotation
  * elements that all types have in common.  At the moment,
  * this handles style information, but could be expanded
  * to handle labels, names, id's, etc.
+ *
+ * @param {annotation} annotation A geojs native annotation object
+ * @param {string} type Override the detected output type
  */
-function common(annotation) {
-    const style = annotation.options().style;
-    const fillColor = setColorType(style, 'fill');
-    const lineColor = setColorType(style, 'stroke');
-
-    return {
-        fillColor,
-        lineColor
-    };
+function common(annotation, type) {
+    type = type || annotation.type();
+    return defaults[type] || {};
 }
 
 export default common;

--- a/web_client/annotations/geojs/common.js
+++ b/web_client/annotations/geojs/common.js
@@ -1,3 +1,5 @@
+import _ from 'underscore';
+
 import * as defaults from '../defaults';
 
 /**
@@ -11,7 +13,7 @@ import * as defaults from '../defaults';
  */
 function common(annotation, type) {
     type = type || annotation.type();
-    return defaults[type] || {};
+    return _.extend({}, defaults[type] || {});
 }
 
 export default common;

--- a/web_client/annotations/geojs/convert.js
+++ b/web_client/annotations/geojs/convert.js
@@ -2,6 +2,13 @@ import _ from 'underscore';
 
 import * as types from './types';
 
+/**
+ * Convert a geojs annotation object into an annotation
+ * element defined by the json schema.
+ *
+ * @param {annotation} annotation A geojs annotation object
+ * @returns {object}
+ */
 function convert(annotation) {
     var type = annotation.type();
     if (!_.has(types, type)) {

--- a/web_client/annotations/geojs/convert.js
+++ b/web_client/annotations/geojs/convert.js
@@ -1,0 +1,15 @@
+import _ from 'underscore';
+
+import * as types from './types';
+
+function convert(annotation) {
+    var type = annotation.type();
+    if (!_.has(types, type)) {
+        throw new Error(
+            `Unknown annotation type "${type}"`
+        );
+    }
+    return types[type](annotation);
+}
+
+export default convert;

--- a/web_client/annotations/geojs/coordinates/array.js
+++ b/web_client/annotations/geojs/coordinates/array.js
@@ -1,0 +1,12 @@
+import _ from 'underscore';
+import point from './point';
+
+/**
+ * Convert an array of point objects to an array of
+ * annotation coordinates.
+ */
+function array(a) {
+    return _.map(a, point);
+}
+
+export default array;

--- a/web_client/annotations/geojs/coordinates/index.js
+++ b/web_client/annotations/geojs/coordinates/index.js
@@ -1,0 +1,7 @@
+import point from './point';
+import array from './array';
+
+export {
+    point,
+    array
+};

--- a/web_client/annotations/geojs/coordinates/point.js
+++ b/web_client/annotations/geojs/coordinates/point.js
@@ -1,0 +1,9 @@
+/**
+ * Convert a geojs point object to an annotation
+ * coordinate.
+ */
+function point(pt) {
+    return [pt.x, pt.y, pt.z || 0];
+}
+
+export default point;

--- a/web_client/annotations/geojs/index.js
+++ b/web_client/annotations/geojs/index.js
@@ -1,0 +1,9 @@
+import * as types from './types';
+import * as coordinates from './coordinates';
+import common from './common';
+
+export {
+    types,
+    coordinates,
+    common
+};

--- a/web_client/annotations/geojs/index.js
+++ b/web_client/annotations/geojs/index.js
@@ -1,9 +1,11 @@
 import * as types from './types';
 import * as coordinates from './coordinates';
 import common from './common';
+import convert from './convert';
 
 export {
     types,
     coordinates,
-    common
+    common,
+    convert
 };

--- a/web_client/annotations/geojs/types/index.js
+++ b/web_client/annotations/geojs/types/index.js
@@ -1,0 +1,9 @@
+import point from './point';
+import rectangle from './rectangle';
+import polygon from './polygon';
+
+export {
+    point,
+    rectangle,
+    polygon
+};

--- a/web_client/annotations/geojs/types/point.js
+++ b/web_client/annotations/geojs/types/point.js
@@ -1,0 +1,19 @@
+import _ from 'underscore';
+
+import common from '../common';
+import pointCoordinate from '../coordinates/point';
+
+/**
+ * Convert a geojs point annotation to the large_image
+ * annotation schema.
+ */
+function point(annotation) {
+    const element = common(annotation);
+
+    return _.extend(element, {
+        type: 'point',
+        center: pointCoordinate(annotation.coordinates()[0])
+    });
+}
+
+export default point;

--- a/web_client/annotations/geojs/types/polygon.js
+++ b/web_client/annotations/geojs/types/polygon.js
@@ -1,0 +1,17 @@
+import _ from 'underscore';
+
+import common from '../common';
+import array from '../coordinates/array';
+
+function polygon(annotation) {
+    const element = common(annotation);
+    const coordinates = array(annotation.coordinates());
+
+    return _.extend(element, {
+        type: 'polyline',
+        closed: true,
+        points: coordinates
+    });
+}
+
+export default polygon;

--- a/web_client/annotations/geojs/types/polygon.js
+++ b/web_client/annotations/geojs/types/polygon.js
@@ -4,7 +4,7 @@ import common from '../common';
 import array from '../coordinates/array';
 
 function polygon(annotation) {
-    const element = common(annotation);
+    const element = common(annotation, 'polyline');
     const coordinates = array(annotation.coordinates());
 
     return _.extend(element, {

--- a/web_client/annotations/geojs/types/polygon.js
+++ b/web_client/annotations/geojs/types/polygon.js
@@ -3,6 +3,10 @@ import _ from 'underscore';
 import common from '../common';
 import array from '../coordinates/array';
 
+/**
+ * Convert a geojs polygon annotation to the large_image
+ * annotation schema.
+ */
 function polygon(annotation) {
     const element = common(annotation, 'polyline');
     const coordinates = array(annotation.coordinates());

--- a/web_client/annotations/geojs/types/rectangle.js
+++ b/web_client/annotations/geojs/types/rectangle.js
@@ -1,0 +1,30 @@
+import _ from 'underscore';
+
+import common from '../common';
+
+function rectangle(annotation) {
+    const element = common(annotation);
+    const [p1, p2, p3, p4] = annotation.coordinates();
+    const top = [p3.x - p2.x, p3.y - p2.y];
+    const left = [p2.x - p1.x, p2.y - p1.y];
+
+    // determine the rotation of the top line of the rectangle
+    const rotation = Math.atan2(top[1], top[0]);
+    const height = Math.sqrt(left[0] * left[0] + left[1] * left[1]);
+    const width = Math.sqrt(top[0] * top[0] + top[1] * top[1]);
+    const center = [
+        0.25 * (p1.x + p2.x + p3.x + p4.x),
+        0.25 * (p1.y + p2.y + p3.y + p4.y),
+        0
+    ];
+
+    return _.extend(element, {
+        type: 'rectangle',
+        center,
+        width,
+        height,
+        rotation
+    });
+}
+
+export default rectangle;

--- a/web_client/annotations/geojs/types/rectangle.js
+++ b/web_client/annotations/geojs/types/rectangle.js
@@ -2,6 +2,10 @@ import _ from 'underscore';
 
 import common from '../common';
 
+/**
+ * Convert a geojs rectangle annotation to the large_image
+ * annotation schema.
+ */
 function rectangle(annotation) {
     const element = common(annotation);
     const [p1, p2, p3, p4] = annotation.coordinates();

--- a/web_client/annotations/geometry/index.js
+++ b/web_client/annotations/geometry/index.js
@@ -1,7 +1,9 @@
 import rectangle from './rectangle';
 import polyline from './polyline';
+import point from './point';
 
 export {
     rectangle,
-    polyline
+    polyline,
+    point
 };

--- a/web_client/annotations/geometry/point.js
+++ b/web_client/annotations/geometry/point.js
@@ -1,0 +1,8 @@
+import _ from 'underscore';
+
+export default function point(json) {
+    return {
+        type: 'Point',
+        coordinates: _.first(json.center, 2)
+    };
+}

--- a/web_client/annotations/index.js
+++ b/web_client/annotations/index.js
@@ -3,11 +3,13 @@ import rotate from './rotate';
 import style from './style';
 import * as geometry from './geometry';
 import * as defaults from './defaults';
+import * as geojs from './geojs';
 
 export {
     convert,
     rotate,
     style,
     geometry,
-    defaults
+    defaults,
+    geojs
 };

--- a/web_client/annotations/style.js
+++ b/web_client/annotations/style.js
@@ -2,7 +2,6 @@ import _ from 'underscore';
 import tc from 'tinycolor2';
 
 const props = [
-    'lineWidth',
     'label'
 ];
 
@@ -33,5 +32,8 @@ export default function style(json) {
         style.strokeOpacity = color.alpha;
     }
 
+    if (json.lineWidth) {
+        style.strokeWidth = json.lineWidth;
+    }
     return style;
 }

--- a/web_client/collections/ElementCollection.js
+++ b/web_client/collections/ElementCollection.js
@@ -1,0 +1,7 @@
+import Backbone from 'backbone';
+
+import ElementModel from '../models/ElementModel';
+
+export default Backbone.Collection.extend({
+    model: ElementModel
+});

--- a/web_client/models/AnnotationModel.js
+++ b/web_client/models/AnnotationModel.js
@@ -17,7 +17,7 @@ export default Model.extend({
         );
         this._elements.annotation = this;
 
-        this.listenTo(this._elements, 'change add remove', () => {
+        this.listenTo(this._elements, 'change add remove reset', () => {
             // copy the object to ensure a change event is triggered
             var annotation = _.extend({}, this.get('annotation'));
 

--- a/web_client/models/AnnotationModel.js
+++ b/web_client/models/AnnotationModel.js
@@ -4,6 +4,18 @@ import Model from 'girder/models/Model';
 import ElementCollection from '../collections/ElementCollection';
 import convert from '../annotations/convert';
 
+/**
+ * Define a backbone model representing an annotation.
+ * An annotation contains zero or more "elements" or
+ * geometric primatives that are represented in the
+ * embedded "elements" attribute.  This attribute is
+ * an "ElementCollection" that triggers events when
+ * any of the "ElementModel"'s contained within change.
+ *
+ * This model listens to changes in the element collection
+ * and updates its own attribute in response.  Users
+ * should not modify the "elements" attribute directly.
+ */
 export default Model.extend({
     resourceName: 'annotation',
 

--- a/web_client/models/AnnotationModel.js
+++ b/web_client/models/AnnotationModel.js
@@ -1,9 +1,30 @@
+import _ from 'underscore';
 import Model from 'girder/models/Model';
 
+import ElementCollection from '../collections/ElementCollection';
 import convert from '../annotations/convert';
 
 export default Model.extend({
     resourceName: 'annotation',
+
+    defaults: {
+        'annotation': {}
+    },
+
+    initialize() {
+        this._elements = new ElementCollection(
+            this.get('annotation').elements || []
+        );
+        this._elements.annotation = this;
+
+        this.listenTo(this._elements, 'change add remove', () => {
+            // copy the object to ensure a change event is triggered
+            var annotation = _.extend({}, this.get('annotation'));
+
+            annotation.elements = this._elements.toJSON();
+            this.set('annotation', annotation);
+        });
+    },
 
     /**
      * Return the annotation as a geojson FeatureCollection.
@@ -15,5 +36,12 @@ export default Model.extend({
         const json = this.get('annotation') || {};
         const elements = json.elements || [];
         return convert(elements);
+    },
+
+    /**
+     * Return a backbone collection containing the annotation elements.
+     */
+    elements() {
+        return this._elements;
     }
 });

--- a/web_client/models/ElementModel.js
+++ b/web_client/models/ElementModel.js
@@ -1,0 +1,12 @@
+import Backbone from 'backbone';
+
+/**
+ * Define a "view model" representing an annotation element
+ * (an individual shape.  This model does not support REST
+ * calls such as save/fetch/sync/delete because annotation
+ * elements don't have endpoints.  Instead this model exists
+ * to support editing of the AnnotationModel on the client.
+ */
+export default Backbone.Model.extend({
+    idAttribute: 'id'
+});

--- a/web_client/views/imageViewerWidget/base.js
+++ b/web_client/views/imageViewerWidget/base.js
@@ -37,11 +37,52 @@ var ImageViewerWidget = View.extend({
         return url;
     },
 
-    drawAnnotation: function () {
+    /**
+     * Render an annotation model on the image.
+     *
+     * @param {AnnotationModel} annotation
+     */
+    drawAnnotation: function (/* annotation */) {
         throw new Error('Viewer does not support drawing annotations');
     },
 
-    removeAnnotation: function () {
+    /**
+     * Remove an annotation from the image.  This simply
+     * finds a layer with the given id and removes it because
+     * each annotation is contained in its own layer.  If
+     * the annotation is not drawn, this is a noop.
+     *
+     * @param {AnnotationModel} annotation
+     */
+    removeAnnotation: function (/* annotation */) {
+        throw new Error('Viewer does not support drawing annotations');
+    },
+
+    /**
+     * Set the image interaction mode to region drawing mode.  This
+     * method takes an optional `model` argument where the region will
+     * be stored when created by the user.  In any case, this method
+     * returns a promise that resolves to an array defining the region:
+     *   [ left, top, width, height ]
+     *
+     * @param {Backbone.Model} [model] A model to set the region to
+     * @returns {Promise}
+     */
+    drawRegion: function (/* model */) {
+        throw new Error('Viewer does not support drawing annotations');
+    },
+
+    /**
+     * Set the image interaction mode to draw the given type of annotation.
+     *
+     * @param {string} type An annotation type
+     * @param {object} [options]
+     * @param {boolean} [options.trigger=true]
+     *      Trigger a global event after creating each annotation element.
+     * @returns {Promise}
+     *      Resolves to an array of generated annotation elements.
+     */
+    startDrawMode: function (/* type, options */) {
         throw new Error('Viewer does not support drawing annotations');
     }
 });

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -181,6 +181,7 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
                     }
 
                     layer.removeAllAnnotations();
+                    layer.geoOff(window.geo.event.annotation.state);
                     resolve(elements, annotations);
                 }
             );

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -7,6 +7,9 @@ import events from 'girder/events';
 import ImageViewerWidget from './base';
 import convertAnnotation from '../../annotations/geojs/convert';
 
+/**
+ * Generate a new "random" element id (24 random 16 digits).
+ */
 function guid() {
     function s4() {
         return Math.floor((1 + Math.random()) * 0x10000)
@@ -100,6 +103,8 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
      * finds a layer with the given id and removes it because
      * each annotation is contained in its own layer.  If
      * the annotation is not drawn, this is a noop.
+     *
+     * @param {AnnotationModel} annotation
      */
     removeAnnotation: function (annotation) {
         var layer = this._layers[annotation.id];

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -9,6 +9,7 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
 
         this._layers = {};
         this.listenTo(events, 's:widgetDrawRegion', this.drawRegion);
+        this.listenTo(events, 'g:startDrawMode', this.startDrawMode);
 
         $.getScript(
             staticRoot + '/built/plugins/large_image/extra/geojs.js',
@@ -91,8 +92,22 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
             }
         );
         layer.mode('rectangle');
-    }
+    },
 
+    startDrawMode: function (type) {
+        if (!this.viewer) {
+            return;
+        }
+        var layer = this.viewer.createLayer('annotation');
+        layer.geoOn(
+            window.geo.event.annotation.state,
+            (evt) => {
+                console.log(evt);
+                window.setTimeout(() => this.viewer.deleteLayer(layer), 10);
+            }
+        );
+        layer.mode(type);
+    }
 });
 
 export default GeojsImageViewerWidget;

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -7,6 +7,16 @@ import events from 'girder/events';
 import ImageViewerWidget from './base';
 import convertAnnotation from '../../annotations/geojs/convert';
 
+function guid() {
+    function s4() {
+        return Math.floor((1 + Math.random()) * 0x10000)
+            .toString(16)
+            .substring(1);
+    }
+    return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
+        s4() + '-' + s4() + s4() + s4();
+}
+
 var GeojsImageViewerWidget = ImageViewerWidget.extend({
     initialize: function (settings) {
         ImageViewerWidget.prototype.initialize.call(this, settings);
@@ -151,6 +161,9 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
                 window.geo.event.annotation.state,
                 (evt) => {
                     element = convertAnnotation(evt.annotation);
+                    if (!element.id) {
+                        element.id = guid();
+                    }
                     elements.push(element);
                     annotations.push(evt.annotation);
 

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -104,6 +104,7 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
     removeAnnotation: function (annotation) {
         var layer = this._layers[annotation.id];
         if (layer) {
+            delete this._layers[annotation.id];
             this.viewer.deleteLayer(layer);
         }
     },

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -2,6 +2,7 @@ import { staticRoot } from 'girder/rest';
 import events from 'girder/events';
 
 import ImageViewerWidget from './base';
+import convertAnnotation from '../../annotations/geojs/convert';
 
 var GeojsImageViewerWidget = ImageViewerWidget.extend({
     initialize: function (settings) {
@@ -102,8 +103,8 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
         layer.geoOn(
             window.geo.event.annotation.state,
             (evt) => {
-                console.log(evt);
-                window.setTimeout(() => this.viewer.deleteLayer(layer), 10);
+                events.trigger('g:annotationCreated', convertAnnotation(evt.annotation));
+                this.viewer.deleteLayer(layer);
             }
         );
         layer.mode(type);

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -13,8 +13,7 @@ function guid() {
             .toString(16)
             .substring(1);
     }
-    return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
-        s4() + '-' + s4() + s4() + s4();
+    return s4() + s4() + s4() + s4() + s4() + s4();
 }
 
 var GeojsImageViewerWidget = ImageViewerWidget.extend({


### PR DESCRIPTION
This supports an upcoming PR in HistomicsTK to draw annotation on top of large_image viewers.  This adds a components:

1. New models and collections representing both "annotations" and "elements".  The annotation types are real models that can be sync'ed to the server, but elements are ephemeral objects for storing the individual primitive elements.
2. Modules in `web_client/annotations/geojs` that generate large_image annotations from native geojs annotation objects.
3. A couple of methods and events added to the viewer class itself to trigger "drawing mode".

The CI is current failing at `server_large_image.tiles`.  I assume the failure is also in master because I didn't make any relevant server side changes.