### PR TITLE
Fix JPEG color-space issues in Safari

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,6 +183,8 @@ install:
   - cd $girder_path
   - pip install --no-cache-dir -U -r requirements.txt -r requirements-dev.txt -e .
   - pip install -r $main_path/requirements.txt -e .
+  # Make sure we have a prefered version of celery for Girder Worker
+  - pip install -U 'celery>=4'
   - python -c "import openslide;print openslide.__version__"
   # This was
   # - npm install

--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -115,6 +115,26 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
         image = self.getBody(resp, text=False)
         self.assertEqual(image[:len(common.JFIFHeader)], common.JFIFHeader)
 
+        resp = self.request(
+            path='/item/%s/tiles/zxy/0/0/0' % itemId, user=self.admin,
+            isJson=False, additionalHeaders=[(
+                'User-Agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X '
+                '10_12_3) AppleWebKit/602.4.8 (KHTML, like Gecko) '
+                'Version/10.0.3 Safari/602.4.8')])
+        self.assertStatusOk(resp)
+        image = self.getBody(resp, text=False)
+        self.assertEqual(image[:len(common.JFIFHeader)], common.JFIFHeader)
+
+        resp = self.request(
+            path='/item/%s/tiles/zxy/0/0/0' % itemId, user=self.admin,
+            isJson=False, additionalHeaders=[(
+                'User-Agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
+                'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 '
+                'Safari/537.36')])
+        self.assertStatusOk(resp)
+        image = self.getBody(resp, text=False)
+        self.assertNotEqual(image[:len(common.JFIFHeader)], common.JFIFHeader)
+
         # Ask to make this a tile-based item again
         resp = self.request(path='/item/%s/tiles' % itemId, method='POST',
                             user=self.admin, params={'fileId': fileId})

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -18,6 +18,7 @@
 #############################################################################
 
 import cherrypy
+import re
 
 from girder.api import access, filter_logging
 from girder.api.v1.item import Item
@@ -49,8 +50,8 @@ def _adjustParams(params):
     except Exception:
         pass
     if params.get('encoding', 'JPEG') == 'JPEG':
-        if ('ipad' in userAgent or 'ipod' in userAgent or
-                'iphone' in userAgent):
+        if ('ipad' in userAgent or 'ipod' in userAgent or 'iphone' in userAgent or
+                re.match('((?!chrome|android).)*safari', userAgent, re.IGNORECASE)):
             params['encoding'] = 'JFIF'
 
 


### PR DESCRIPTION
The JPEG color-space issue in Mobile Safari now is also present in Safari.  We having nothing better than user-agent scraping to determine if we need to convert to a limited set of color spaces with JFIF headers.  Test against recent Safari and Chrome user agent strings.