### PR TITLE
Use python as the default cache when girder isn't available.

### DIFF
--- a/examples/average_color.py
+++ b/examples/average_color.py
@@ -6,6 +6,7 @@ import numpy
 
 import large_image
 
+# Explicitly set the caching method before we request any data
 large_image.cache_util.setConfig('cache_backend', 'python')
 
 

--- a/server/cache_util/cachefactory.py
+++ b/server/cache_util/cachefactory.py
@@ -114,7 +114,7 @@ class CacheFactory():
     def getCache(self, numItems=None):
         curConfig = getConfig()
         # memcached is the fallback default, if available.
-        cacheBackend = curConfig.get('cache_backend', 'memcached')
+        cacheBackend = curConfig.get('cache_backend', 'memcached' if config else 'python')
         if cacheBackend:
             cacheBackend = str(cacheBackend).lower()
         cache = None


### PR DESCRIPTION
By default, we had been using memcached.  When Girder isn't available, we are likely running in Dask or another environment where memcached is probably not configured properly.  As such, use the python caching backend as the default in those circumstances.  This can always be overridden.

Added a comment on the example showing how to specify the caching method explicitly.