### PR TITLE
Add mouse events to geojs drawn annotations

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -175,15 +175,17 @@ describe('Annotations', function () {
 
     describe('convert', function () {
         it('rectangle', function () {
-            var obj = largeImage.annotations.convert([{
+            var element = {
                 type: 'rectangle',
                 id: 'a',
                 center: [10, 20, 0],
                 width: 5,
                 height: 10,
                 rotation: 0
-            }]);
+            };
+            var obj = largeImage.annotations.convert([element]);
             var features = obj.features;
+
             expect(obj.type).toBe('FeatureCollection');
             expect(features.length).toBe(1);
             expect(features[0].id).toBe('a');
@@ -194,18 +196,21 @@ describe('Annotations', function () {
             expect(properties.fillOpacity).toBe(0);
             expect(properties.strokeColor).toBe('#000000');
             expect(properties.strokeOpacity).toBe(1);
+            expect(properties.element).toEqual(element);
         });
 
         it('polyline', function () {
-            var obj = largeImage.annotations.convert([{
+            var element = {
                 type: 'polyline',
                 id: 'a',
                 points: [
                     [0, 1, 0],
                     [1, 0, 0]
                 ]
-            }]);
+            };
+            var obj = largeImage.annotations.convert([element]);
             var features = obj.features;
+
             expect(obj.type).toBe('FeatureCollection');
             expect(features.length).toBe(1);
             expect(features[0].id).toBe('a');
@@ -216,6 +221,7 @@ describe('Annotations', function () {
             expect(properties.fillOpacity).toBe(0);
             expect(properties.strokeColor).toBe('#000000');
             expect(properties.strokeOpacity).toBe(1);
+            expect(properties.element).toEqual(element);
         });
     });
 });

--- a/plugin_tests/client/geojsSpec.js
+++ b/plugin_tests/client/geojsSpec.js
@@ -230,6 +230,27 @@ $(function () {
             });
         });
 
+        it('mouse reset events', function () {
+            var mousereset, context = {};
+            runs(function () {
+                function onMouseReset(annotation) {
+                    expect(annotation.id).toBe(annotationId);
+                    mousereset = true;
+                }
+                viewer.on('g:mouseResetAnnotation', onMouseReset, context);
+                annotation.trigger('g:fetched');
+            });
+
+            waitsFor(function () {
+                return mousereset;
+            }, 'event to be fired');
+
+            runs(function () {
+                viewer.off(null, null, context);
+                viewer.viewer.zoom(1);
+            });
+        });
+
         it('removeAnnotation', function () {
             viewer.removeAnnotation(annotation);
             expect(viewer._layers).toEqual({});

--- a/plugin_tests/client/geojsSpec.js
+++ b/plugin_tests/client/geojsSpec.js
@@ -64,9 +64,9 @@ $(function () {
                         name: 'test annotation',
                         elements: [{
                             type: 'rectangle',
-                            center: [10, 10, 0],
-                            width: 2,
-                            height: 2,
+                            center: [200, 200, 0],
+                            width: 400,
+                            height: 400,
                             rotation: 0
                         }]
                     })
@@ -100,7 +100,8 @@ $(function () {
             viewer = new GeojsViewer({
                 el: $el,
                 itemId: itemId,
-                parentView: null
+                parentView: null,
+                hoverEvents: true
             });
             viewer.once('g:beforeFirstRender', function () {
                 window.geo.util.mockVGLRenderer();
@@ -135,13 +136,97 @@ $(function () {
             girderTest.waitForLoad();
             runs(function () {
                 expect(viewer._layers[annotationId]).toBeDefined();
-                // geojs makes to features for a polygon
+                // geojs makes two features for a polygon
                 expect(viewer._layers[annotationId].features().length >= 1).toBe(true);
 
                 layerSpy = sinon.spy(viewer._layers[annotationId], '_exit');
 
                 sinon.assert.called(annotation.setView);
                 viewer.viewer.zoom(1);
+            });
+        });
+
+        it('mouse over events', function () {
+            var mouseon, mouseover, context = {};
+            runs(function () {
+                function onMouseOn(element, annotation) {
+                    expect(annotation).toBe(annotationId);
+                    mouseon = true;
+                }
+                function onMouseOver(element, annotation) {
+                    expect(annotation).toBe(annotationId);
+                    mouseover = true;
+                }
+                viewer.on('g:mouseOnAnnotation', onMouseOn, context);
+                viewer.on('g:mouseOverAnnotation', onMouseOver, context);
+                interactor.simulateEvent('mousemove', {
+                    map: viewer.viewer.gcsToDisplay({x: 1000, y: 1000})
+                });
+                interactor.simulateEvent('mousemove', {
+                    map: viewer.viewer.gcsToDisplay({x: 100, y: 100})
+                });
+            });
+
+            waitsFor(function () {
+                return mouseon && mouseover;
+            }, 'events to be fired');
+
+            runs(function () {
+                viewer.off(null, null, context);
+            });
+        });
+
+        it('mouse out events', function () {
+            var mouseout, mouseoff, context = {};
+            runs(function () {
+                function onMouseOut(element, annotation) {
+                    expect(annotation).toBe(annotationId);
+                    mouseout = true;
+                }
+                function onMouseOff(element, annotation) {
+                    expect(annotation).toBe(annotationId);
+                    mouseoff = true;
+                }
+                viewer.on('g:mouseOutAnnotation', onMouseOut, context);
+                viewer.on('g:mouseOffAnnotation', onMouseOff, context);
+                interactor.simulateEvent('mousemove', {
+                    map: viewer.viewer.gcsToDisplay({x: 1000, y: 1000})
+                });
+            });
+
+            waitsFor(function () {
+                return mouseoff && mouseout;
+            }, 'events to be fired');
+
+            runs(function () {
+                viewer.off(null, null, context);
+            });
+        });
+
+        it('mouse click events', function () {
+            var mouseclick, context = {};
+            runs(function () {
+                function onMouseClick(element, annotation) {
+                    expect(annotation).toBe(annotationId);
+                    mouseclick = true;
+                }
+                viewer.on('g:mouseClickAnnotation', onMouseClick, context);
+                interactor.simulateEvent('mousedown', {
+                    button: 'left',
+                    map: viewer.viewer.gcsToDisplay({x: 100, y: 100})
+                });
+                interactor.simulateEvent('mouseup', {
+                    button: 'left',
+                    map: viewer.viewer.gcsToDisplay({x: 100, y: 100})
+                });
+            });
+
+            waitsFor(function () {
+                return mouseclick;
+            }, 'event to be fired');
+
+            runs(function () {
+                viewer.off(null, null, context);
             });
         });
 

--- a/web_client/annotations/convert.js
+++ b/web_client/annotations/convert.js
@@ -14,7 +14,7 @@ function convertOne(annotation) {
         type: 'Feature',
         id: annotation.id,
         geometry: geometry[type](annotation),
-        properties: style(annotation)
+        properties: _.extend({element: annotation}, style(annotation))
     };
 }
 

--- a/web_client/annotations/convert.js
+++ b/web_client/annotations/convert.js
@@ -4,23 +4,25 @@ import * as geometry from './geometry';
 import * as defaults from './defaults';
 import style from './style';
 
-function convertOne(annotation) {
-    const type = annotation.type;
-    _.defaults(annotation, defaults[type] || {});
-    if (!_.has(geometry, type)) {
-        return;
-    }
-    return {
-        type: 'Feature',
-        id: annotation.id,
-        geometry: geometry[type](annotation),
-        properties: _.extend({element: annotation}, style(annotation))
+function convertOne(properties) {
+    return function (annotation) {
+        const type = annotation.type;
+        _.defaults(annotation, defaults[type] || {});
+        if (!_.has(geometry, type)) {
+            return;
+        }
+        return {
+            type: 'Feature',
+            id: annotation.id,
+            geometry: geometry[type](annotation),
+            properties: _.extend({element: annotation}, properties, style(annotation))
+        };
     };
 }
 
-export default function convert(json) {
+export default function convert(json, properties = {}) {
     const features = _.chain(json)
-        .map(convertOne)
+        .map(convertOne(properties))
         .compact()
         .value();
 

--- a/web_client/models/AnnotationModel.js
+++ b/web_client/models/AnnotationModel.js
@@ -47,7 +47,7 @@ export default Model.extend({
     geojson() {
         const json = this.get('annotation') || {};
         const elements = json.elements || [];
-        return convert(elements);
+        return convert(elements, {annotation: this.id});
     },
 
     /**

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -127,6 +127,12 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
                 }
 
                 annotation.off('g:fetched', null, this).on('g:fetched', () => {
+                    // Trigger anevent indicating to the listener that
+                    // mouseover states should reset.
+                    this.trigger(
+                        'g:mouseResetAnnotation',
+                        annotation
+                    );
                     this.drawAnnotation(annotation);
                 }, this);
                 setBounds();

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -206,15 +206,30 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
     },
 
     _onMouseOverFeature: function (evt) {
-        this.trigger('g:mouseOverAnnotation', evt.data.properties.element);
+        var properties = evt.data.properties || {};
+        this.trigger(
+            'g:mouseOverAnnotation',
+            properties.element,
+            properties.annotation
+        );
     },
 
     _onMouseOutFeature: function (evt) {
-        this.trigger('g:mouseOutAnnotation', evt.data.properties.element);
+        var properties = evt.data.properties || {};
+        this.trigger(
+            'g:mouseOutAnnotation',
+            properties.element,
+            properties.annotation
+        );
     },
 
     _onMouseClickFeature: function (evt) {
-        this.trigger('g:mouseClickAnnotation', evt.data.properties.element);
+        var properties = evt.data.properties || {};
+        this.trigger(
+            'g:mouseClickAnnotation',
+            properties.element,
+            properties.annotation
+        );
     }
 });
 

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -206,15 +206,15 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
     },
 
     _onMouseOverFeature: function (evt) {
-        this.trigger('g:mouseOverAnnotation', evt.data);
+        this.trigger('g:mouseOverAnnotation', evt.data.properties.element);
     },
 
     _onMouseOutFeature: function (evt) {
-        this.trigger('g:mouseOutAnnotation', evt.data);
+        this.trigger('g:mouseOutAnnotation', evt.data.properties.element);
     },
 
     _onMouseClickFeature: function (evt) {
-        this.trigger('g:mouseClickAnnotation', evt.data);
+        this.trigger('g:mouseClickAnnotation', evt.data.properties.element);
     }
 });
 

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -207,29 +207,35 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
 
     _onMouseOverFeature: function (evt) {
         var properties = evt.data.properties || {};
-        this.trigger(
-            'g:mouseOverAnnotation',
-            properties.element,
-            properties.annotation
-        );
+        if (properties.element && properties.annotation) {
+            this.trigger(
+                'g:mouseOverAnnotation',
+                properties.element,
+                properties.annotation
+            );
+        }
     },
 
     _onMouseOutFeature: function (evt) {
         var properties = evt.data.properties || {};
-        this.trigger(
-            'g:mouseOutAnnotation',
-            properties.element,
-            properties.annotation
-        );
+        if (properties.element && properties.annotation) {
+            this.trigger(
+                'g:mouseOutAnnotation',
+                properties.element,
+                properties.annotation
+            );
+        }
     },
 
     _onMouseClickFeature: function (evt) {
         var properties = evt.data.properties || {};
-        this.trigger(
-            'g:mouseClickAnnotation',
-            properties.element,
-            properties.annotation
-        );
+        if (properties.element && properties.annotation) {
+            this.trigger(
+                'g:mouseClickAnnotation',
+                properties.element,
+                properties.annotation
+            );
+        }
     }
 });
 

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -127,7 +127,7 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
                 }
 
                 annotation.off('g:fetched', null, this).on('g:fetched', () => {
-                    // Trigger anevent indicating to the listener that
+                    // Trigger an event indicating to the listener that
                     // mouseover states should reset.
                     this.trigger(
                         'g:mouseResetAnnotation',
@@ -170,6 +170,12 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
      */
     removeAnnotation: function (annotation) {
         annotation.off('g:fetched', null, this);
+        // Trigger an event indicating to the listener that
+        // mouseover states should reset.
+        this.trigger(
+            'g:mouseResetAnnotation',
+            annotation
+        );
         var layer = this._layers[annotation.id];
         if (layer) {
             delete this._layers[annotation.id];


### PR DESCRIPTION
This propagates geojs mouse events to the large_image viewer widget as custom events
* `g:mouseOverAnnotation`
* `g:mouseOutAnnotation`
* `g:mouseClickAnnotation`

I also added the source annotation model id to the `ElementModel` to disambiguate between different annotations for listeners of the events.

This is missing tests because it coupling with geojs is too strong to permit reasonable mocking.  We need to add infrastructure for integration tests including mocking webgl to get them to run in phantomjs.  I think we should look into doing this in a separate PR.