### PR TITLE
Guard against LRU cache issues.

### DIFF
--- a/server/cache_util/cache.py
+++ b/server/cache_util/cache.py
@@ -109,6 +109,10 @@ def methodcache(key=None):
                     self.cache[k] = v
             except ValueError:
                 pass  # value too large
+            except KeyError:
+                # the key was refused for some reason
+                logger.debug('Had a cache KeyError while trying to store a '
+                             'value to key %r' % k)
             return v
         return wrapper
     return decorator

--- a/server/cache_util/cachefactory.py
+++ b/server/cache_util/cachefactory.py
@@ -142,7 +142,7 @@ class CacheFactory():
         if cache is None:  # fallback backend
             cacheBackend = 'python'
             cache = LRUCache(self.getCacheSize(numItems))
-            cacheLock = None
+            cacheLock = threading.Lock()
         if numItems is None and not CacheFactory.logged:
             logprint.info('Using %s for large_image caching' % cacheBackend)
             CacheFactory.logged = True


### PR DESCRIPTION
cachetools LRU cache is not thread safe.  If two threads each cause an eviction, it would throw a KeyError and never recover.  Our cache would then fail, functionally breaking large_image until the server was restarted.

This does two things: (1) use a threading lock for the LRU cache, just as we do for memcached.  This should prevent the problem from ever occuring, and (2) guard against such a KeyError, and, if it occurs, return the cache miss value in any case.  If the LRU cache is used in a multithreaded environment without a lock, this guards against the catastrophic failure.

Tests have been added to ensure that multithreaded use works both with and without a cache lock.