### PR TITLE
Fix direct access of ptif files with non-ASCII filenames.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -176,7 +176,7 @@ before_install:
 
   - pip install --no-cache-dir numpy==1.10.2  # needed because libtiff doesn't install correctly without it.  This ensures we have the same version for libtiff as for the project.
 
-  - if [ ${LIBTIFF_VERSION} == "4.0.6" ]; then pip install "git+https://github.com/pearu/pylibtiff@848785a6a9a4e2c6eb6f56ca9f7e8f6b32e523d5" --force-reinstall --ignore-installed --upgrade; fi
+  - if [ ${LIBTIFF_VERSION} == "4.0.6" ]; then pip install "git+https://github.com/pearu/pylibtiff@33735eb7197eb33ed1a50bbc4bc5a47ce4305e92" --force-reinstall --ignore-installed --upgrade; fi
 
 
 install:
@@ -192,7 +192,7 @@ install:
   # - npm install
   # but since there are often connection failures, use the retry package.
   - npm-install-retry
-  - BABEL_ENV=cover NYC_CWD=$main_path girder-install web --plugins=large_image,worker,jobs --dev
+  - BABEL_ENV=cover NYC_CWD=$main_path girder-install web --plugins=jobs,worker,large_image --dev
 
 script:
   - cd $girder_worker_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ numpy>=1.10.2
 
 libtiff>=0.4.0
 # If you have OpenJPEG 2.1.1 or later or need libtiff 4.0.6 support, instead use
-# -e git+https://github.com/pearu/pylibtiff@848785a6a9a4e2c6eb6f56ca9f7e8f6b32e523d5
+# -e git+https://github.com/pearu/pylibtiff@33735eb7197eb33ed1a50bbc4bc5a47ce4305e92
 
 openslide-python>=1.1.0

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -268,9 +268,10 @@ class TiledTiffDirectory(object):
         tableSize = ctypes.c_uint32()
         tableBuffer = ctypes.c_voidp()
 
-        libtiff_ctypes.libtiff.TIFFGetField.argtypes = \
-            libtiff_ctypes.libtiff.TIFFGetField.argtypes[:2] + \
-            [ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_void_p)]
+        if libtiff_ctypes.libtiff.TIFFGetField.argtypes:
+            libtiff_ctypes.libtiff.TIFFGetField.argtypes = \
+                libtiff_ctypes.libtiff.TIFFGetField.argtypes[:2] + \
+                [ctypes.POINTER(ctypes.c_uint32), ctypes.POINTER(ctypes.c_void_p)]
         if libtiff_ctypes.libtiff.TIFFGetField(
                 self._tiffFile,
                 libtiff_ctypes.TIFFTAG_JPEGTABLES,
@@ -373,9 +374,10 @@ class TiledTiffDirectory(object):
         rawTileSizesType = self._getTileByteCountsType()
         rawTileSizes = ctypes.POINTER(rawTileSizesType)()
 
-        libtiff_ctypes.libtiff.TIFFGetField.argtypes = \
-            libtiff_ctypes.libtiff.TIFFGetField.argtypes[:2] + \
-            [ctypes.POINTER(ctypes.POINTER(rawTileSizesType))]
+        if libtiff_ctypes.libtiff.TIFFGetField.argtypes:
+            libtiff_ctypes.libtiff.TIFFGetField.argtypes = \
+                libtiff_ctypes.libtiff.TIFFGetField.argtypes[:2] + \
+                [ctypes.POINTER(ctypes.POINTER(rawTileSizesType))]
         if libtiff_ctypes.libtiff.TIFFGetField(
                 self._tiffFile,
                 libtiff_ctypes.TIFFTAG_TILEBYTECOUNTS,


### PR DESCRIPTION
This was fixed in the pylibtiff module, but changes to that required some additional changed to our code.