### PR TITLE
Add support for TIFF output.

### DIFF
--- a/plugin_tests/common.py
+++ b/plugin_tests/common.py
@@ -32,6 +32,7 @@ from girder.constants import SortDir
 JFIFHeader = b'\xff\xd8\xff\xe0\x00\x10JFIF'
 JPEGHeader = b'\xff\xd8\xff'
 PNGHeader = b'\x89PNG'
+TIFFHeader = b'II\x2a\x00'
 
 
 class LargeImageCommonTest(base.TestCase):

--- a/plugin_tests/sources_test.py
+++ b/plugin_tests/sources_test.py
@@ -223,6 +223,16 @@ class LargeImageSourcesTest(common.LargeImageCommonTest):
             self.assertEqual(tile['tile'][:len(common.PNGHeader)],
                              common.PNGHeader)
         self.assertEqual(tileCount, 45)
+        # Ask for TIFFs
+        tileCount = 0
+        for tile in source.tileIterator(
+                scale={'magnification': 2.5},
+                format=tilesource.TILE_FORMAT_IMAGE,
+                encoding='TIFF'):
+            tileCount += 1
+            self.assertEqual(tile['tile'][:len(common.TIFFHeader)],
+                             common.TIFFHeader)
+        self.assertEqual(tileCount, 45)
         # Test some internal properties
         self.assertEqual(len(source._tiffDirectories), 9)
         info = source._tiffDirectories[-1]._tiffInfo

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -264,8 +264,8 @@ class ImageItem(Item):
         :param width: maximum width in pixels.
         :param height: maximum height in pixels.
         :param **kwargs: optional arguments.  Some options are encoding,
-            jpegQuality, and jpegSubsampling.  This is also passed to the
-            tile source.
+            jpegQuality, jpegSubsampling, and tiffCompression.  This is also
+            passed to the tile source.
         :returns: thumbData, thumbMime: the image data and the mime type OR
             a generator which will yield a file.
         """
@@ -350,8 +350,8 @@ class ImageItem(Item):
         :param item: the item with the tile source.
         :param **kwargs: optional arguments.  Some options are left, top,
             right, bottom, regionWidth, regionHeight, units, width, height,
-            encoding, jpegQuality, and jpegSubsampling.  This is also passed to
-            the tile source.
+            encoding, jpegQuality, jpegSubsampling, and tiffCompression.  This
+            is also passed to the tile source.
         :returns: regionData, regionMime: the image data and the mime type.
         """
         tileSource = self._loadTileSource(item, **kwargs)
@@ -384,7 +384,7 @@ class ImageItem(Item):
         :param item: the item with the tile source.
         :param imageKey: the key of the associated image to retreive.
         :param **kwargs: optional arguments.  Some options are width, height,
-            encoding, jpegQuality, and jpegSubsampling.
+            encoding, jpegQuality, jpegSubsampling, and tiffCompression.
         :returns: imageData, imageMime: the image data and the mime type, or
             None if the associated image doesn't exist.
         """

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -309,7 +309,7 @@ class TilesItemResource(Item):
         .param('height', 'The maximum height of the thumbnail in pixels.',
                required=False, dataType='int')
         .param('encoding', 'Thumbnail output encoding', required=False,
-               enum=['JPEG', 'PNG'], default='JPEG')
+               enum=['JPEG', 'PNG', 'TIFF'], default='JPEG')
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
@@ -323,6 +323,7 @@ class TilesItemResource(Item):
             ('height', int),
             ('jpegQuality', int),
             ('jpegSubsampling', int),
+            ('tiffCompression', str),
             ('encoding', str),
         ])
         try:
@@ -389,13 +390,16 @@ class TilesItemResource(Item):
                'must match an existing level of the image exactly.',
                required=False, dataType='boolean', default=False)
         .param('encoding', 'Output image encoding', required=False,
-               enum=['JPEG', 'PNG'], default='JPEG')
+               enum=['JPEG', 'PNG', 'TIFF'], default='JPEG')
         .param('jpegQuality', 'Quality used for generating JPEG images',
                required=False, dataType='int', default=95)
         .param('jpegSubsampling', 'Chroma subsampling used for generating '
                'JPEG images.  0, 1, and 2 are full, half, and quarter '
                'resolution chroma respectively.', required=False,
                enum=['0', '1', '2'], dataType='int', default='0')
+        .param('tiffCompression', 'Compression method when storing a TIFF '
+               'image', required=False,
+               enum=['raw', 'tiff_lzw', 'jpeg', 'tiff_adobe_deflate'])
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
         .errorResponse('Insufficient memory.')
@@ -422,6 +426,7 @@ class TilesItemResource(Item):
             ('encoding', str),
             ('jpegQuality', int),
             ('jpegSubsampling', int),
+            ('tiffCompression', str),
         ])
         try:
             regionData, regionMime = self.imageItemModel.getRegion(
@@ -459,7 +464,7 @@ class TilesItemResource(Item):
         .param('height', 'The maximum height of the image in pixels.',
                required=False, dataType='int')
         .param('encoding', 'Image output encoding', required=False,
-               enum=['JPEG', 'PNG'], default='JPEG')
+               enum=['JPEG', 'PNG', 'TIFF'], default='JPEG')
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
@@ -474,6 +479,7 @@ class TilesItemResource(Item):
             ('height', int),
             ('jpegQuality', int),
             ('jpegSubsampling', int),
+            ('tiffCompression', str),
             ('encoding', str),
         ])
         try:

--- a/server/tilesource/test.py
+++ b/server/tilesource/test.py
@@ -54,7 +54,7 @@ class TestTileSource(TileSource):
             maxLevel and tileHeight if None.
         :param fractal: if True, and the tile size is square and a power of
             two, draw a simple fractal on the tiles.
-        :param encoding: 'PNG' or 'JPEG'.
+        :param encoding: 'PNG', 'JPEG', or 'TIFF'.
         """
         if not kwargs.get('encoding'):
             kwargs = kwargs.copy()


### PR DESCRIPTION
For the endpoints that generate images (tiles, thumbnails, regions, associated images), we had supported JPEG and PNG.  This adds TIFF support (only small tiffs as encoded by PIL) and generalizes some of the encoding format testing.  TIFFs can have a compression set, which is one of PIL's string constants.