### PR TITLE
Support content disposition on some endpoints.

### DIFF
--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -85,6 +85,39 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
         image = self.getBody(resp, text=False)
         self.assertEqual(image[:len(common.PNGHeader)], common.PNGHeader)
 
+        # test content disposition
+        if not tileMetadata:
+            params['contentDisposition'] = 'inline'
+            resp = self.request(path=path % itemId, user=self.admin,
+                                isJson=False, params=params)
+            self.assertStatusOk(resp)
+            self.assertTrue(resp.headers['Content-Disposition'].startswith('inline'))
+            self.assertTrue(
+                resp.headers['Content-Disposition'].endswith('.png') or
+                'largeImageThumbnail' in resp.headers['Content-Disposition'])
+            params['contentDisposition'] = 'attachment'
+            resp = self.request(path=path % itemId, user=self.admin,
+                                isJson=False, params=params)
+            self.assertStatusOk(resp)
+            self.assertTrue(resp.headers['Content-Disposition'].startswith('attachment'))
+            self.assertTrue(
+                resp.headers['Content-Disposition'].endswith('.png') or
+                'largeImageThumbnail' in resp.headers['Content-Disposition'])
+            params['contentDisposition'] = 'other'
+            resp = self.request(path=path % itemId, user=self.admin,
+                                isJson=False, params=params)
+            self.assertStatusOk(resp)
+            self.assertTrue(
+                resp.headers.get('Content-Disposition') is None or
+                'largeImageThumbnail' in resp.headers['Content-Disposition'])
+            del params['contentDisposition']
+            resp = self.request(path=path % itemId, user=self.admin,
+                                isJson=False, params=params)
+            self.assertStatusOk(resp)
+            self.assertTrue(
+                resp.headers.get('Content-Disposition') is None or
+                'largeImageThumbnail' in resp.headers['Content-Disposition'])
+
         # Check that JPEG options are honored.
         # JPEG is the default encoding
         del params['encoding']

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -282,7 +282,10 @@ class ImageItem(Item):
         })
         if existing:
             return self.model('file').download(
-                existing, contentDisposition='inline')
+                existing,
+                contentDisposition='inline'
+                if kwargs.get('contentDisposition') != 'attachment'
+                else kwargs['contentDisposition'])
         tileSource = self._loadTileSource(item, **kwargs)
         thumbData, thumbMime = tileSource.getThumbnail(
             width, height, **kwargs)

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -281,11 +281,12 @@ class ImageItem(Item):
             'thumbnailKey': key
         })
         if existing:
+            if kwargs.get('contentDisposition') != 'attachment':
+                contentDisposition = 'inline'
+            else:
+                contentDisposition = kwargs['contentDisposition']
             return self.model('file').download(
-                existing,
-                contentDisposition='inline'
-                if kwargs.get('contentDisposition') != 'attachment'
-                else kwargs['contentDisposition'])
+                existing, contentDisposition=contentDisposition)
         tileSource = self._loadTileSource(item, **kwargs)
         thumbData, thumbMime = tileSource.getThumbnail(
             width, height, **kwargs)

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -195,7 +195,7 @@ class TilesItemResource(Item):
         except TileGeneralException as e:
             raise RestException(e.message, code=400)
 
-    def _setContentDisposition(self, item, contentDisposition, mime, subname, params):
+    def _setContentDisposition(self, item, contentDisposition, mime, subname):
         """
         If requested, set the content disposition and a suggested file name.
 
@@ -205,8 +205,6 @@ class TilesItemResource(Item):
         :param mime: the mimetype of the output image.  Used for the filename
             suffix.
         :param subname: a subname to append to the item name.
-        :param params: a dictionary of parameters.  Some of these can be used
-            to suggest a filename.
         """
         if (not item or not item.get('name') or
                 mime not in MimeTypeExtensions or
@@ -379,8 +377,7 @@ class TilesItemResource(Item):
             return result
         thumbData, thumbMime = result
         self._setContentDisposition(
-            item, params.get('contentDisposition'), thumbMime, 'thumbnail',
-            params)
+            item, params.get('contentDisposition'), thumbMime, 'thumbnail')
         setResponseHeader('Content-Type', thumbMime)
         setRawResponse()
         return thumbData
@@ -486,8 +483,7 @@ class TilesItemResource(Item):
         except ValueError as e:
             raise RestException('Value Error: %s' % e.message)
         self._setContentDisposition(
-            item, params.get('contentDisposition'), regionMime, 'region',
-            params)
+            item, params.get('contentDisposition'), regionMime, 'region')
         setResponseHeader('Content-Type', regionMime)
         setRawResponse()
         return regionData
@@ -547,7 +543,7 @@ class TilesItemResource(Item):
             return result
         imageData, imageMime = result
         self._setContentDisposition(
-            item, params.get('contentDisposition'), imageMime, image, params)
+            item, params.get('contentDisposition'), imageMime, image)
         setResponseHeader('Content-Type', imageMime)
         setRawResponse()
         return imageData

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -18,7 +18,9 @@
 #############################################################################
 
 import cherrypy
+import os
 import re
+import six
 
 from girder.api import access, filter_logging
 from girder.api.v1.item import Item
@@ -30,6 +32,13 @@ from girder.models.model_base import AccessType
 from ..models import TileGeneralException
 
 from .. import loadmodelcache
+
+
+MimeTypeExtensions = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/tiff': 'tiff',
+}
 
 
 def _adjustParams(params):
@@ -186,6 +195,36 @@ class TilesItemResource(Item):
         except TileGeneralException as e:
             raise RestException(e.message, code=400)
 
+    def _setContentDisposition(self, item, contentDisposition, mime, subname, params):
+        """
+        If requested, set the content disposition and a suggested file name.
+
+        :param item: an item that includes a name.
+        :param contentDisposition: either 'inline' or 'attachemnt', otherwise
+            no header is added.
+        :param mime: the mimetype of the output image.  Used for the filename
+            suffix.
+        :param subname: a subname to append to the item name.
+        :param params: a dictionary of parameters.  Some of these can be used
+            to suggest a filename.
+        """
+        if (not item or not item.get('name') or
+                mime not in MimeTypeExtensions or
+                contentDisposition not in ('inline', 'attachment')):
+            return
+        filename = os.path.splitext(item['name'])[0]
+        if subname:
+            filename += '-' + subname
+        filename += '.' + MimeTypeExtensions[mime]
+        if not isinstance(filename, six.text_type):
+            filename = filename.decode('utf8', 'ignore')
+        safeFilename = filename.encode('ascii', 'ignore').replace('"', '')
+        encodedFilename = six.moves.urllib.parse.quote(filename.encode('utf8', 'ignore'))
+        setResponseHeader(
+            'Content-Disposition',
+            '%s; filename="%s"; filename*=UTF-8\'\'%s' % (
+                contentDisposition, safeFilename, encodedFilename))
+
     @describeRoute(
         Description('Get large image metadata.')
         .param('itemId', 'The ID of the item.', paramType='path')
@@ -310,6 +349,9 @@ class TilesItemResource(Item):
                required=False, dataType='int')
         .param('encoding', 'Thumbnail output encoding', required=False,
                enum=['JPEG', 'PNG', 'TIFF'], default='JPEG')
+        .param('contentDisposition', 'Specify the Content-Disposition response '
+               'header disposition-type value.', required=False,
+               enum=['inline', 'attachment'])
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
@@ -325,6 +367,7 @@ class TilesItemResource(Item):
             ('jpegSubsampling', int),
             ('tiffCompression', str),
             ('encoding', str),
+            ('contentDisposition', str),
         ])
         try:
             result = self.imageItemModel.getThumbnail(item, **params)
@@ -335,6 +378,9 @@ class TilesItemResource(Item):
         if not isinstance(result, tuple):
             return result
         thumbData, thumbMime = result
+        self._setContentDisposition(
+            item, params.get('contentDisposition'), thumbMime, 'thumbnail',
+            params)
         setResponseHeader('Content-Type', thumbMime)
         setRawResponse()
         return thumbData
@@ -400,6 +446,9 @@ class TilesItemResource(Item):
         .param('tiffCompression', 'Compression method when storing a TIFF '
                'image', required=False,
                enum=['raw', 'tiff_lzw', 'jpeg', 'tiff_adobe_deflate'])
+        .param('contentDisposition', 'Specify the Content-Disposition response '
+               'header disposition-type value.', required=False,
+               enum=['inline', 'attachment'])
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
         .errorResponse('Insufficient memory.')
@@ -427,6 +476,7 @@ class TilesItemResource(Item):
             ('jpegQuality', int),
             ('jpegSubsampling', int),
             ('tiffCompression', str),
+            ('contentDisposition', str),
         ])
         try:
             regionData, regionMime = self.imageItemModel.getRegion(
@@ -435,6 +485,9 @@ class TilesItemResource(Item):
             raise RestException(e.message)
         except ValueError as e:
             raise RestException('Value Error: %s' % e.message)
+        self._setContentDisposition(
+            item, params.get('contentDisposition'), regionMime, 'region',
+            params)
         setResponseHeader('Content-Type', regionMime)
         setRawResponse()
         return regionData
@@ -465,6 +518,9 @@ class TilesItemResource(Item):
                required=False, dataType='int')
         .param('encoding', 'Image output encoding', required=False,
                enum=['JPEG', 'PNG', 'TIFF'], default='JPEG')
+        .param('contentDisposition', 'Specify the Content-Disposition response '
+               'header disposition-type value.', required=False,
+               enum=['inline', 'attachment'])
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
@@ -481,6 +537,7 @@ class TilesItemResource(Item):
             ('jpegSubsampling', int),
             ('tiffCompression', str),
             ('encoding', str),
+            ('contentDisposition', str),
         ])
         try:
             result = self.imageItemModel.getAssociatedImage(item, image, **params)
@@ -489,6 +546,8 @@ class TilesItemResource(Item):
         if not isinstance(result, tuple):
             return result
         imageData, imageMime = result
+        self._setContentDisposition(
+            item, params.get('contentDisposition'), imageMime, image, params)
         setResponseHeader('Content-Type', imageMime)
         setRawResponse()
         return imageData


### PR DESCRIPTION
On the region, associated image, and thumbnail endpoints, support requesting a content disposition.  The contentDisposition query parameter can be left blank for the existing behavior, or set to 'inline' or 'attachment'.  The filename is absed on the item name with the word 'region', 'thumbnail', or the associated image label appended to it and the appropriate suffix for the mimetype, except that cached thumbnails yield a generate '_largeImageThumbnail' filename.  The filename is encoded in a safe ASCII manner and a UTF-8 manner such that it should work on most clients.

This is based on the small-tif-output branch to leverage some of the testing infrastructure there.