### PR TITLE
Add fill option for thumbnails and regions.

### DIFF
--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -799,6 +799,42 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
         self.assertEqual(width, 180)
         self.assertEqual(height, int(width * origHeight / origWidth))
 
+        # Test asking for fill values
+        resp = self.request(path='/item/%s/tiles/thumbnail' % itemId,
+                            user=self.admin, isJson=False,
+                            params={'encoding': 'PNG',
+                                    'width': 180, 'height': 180,
+                                    'fill': 'none'})
+        self.assertStatusOk(resp)
+        image = self.getBody(resp, text=False)
+        self.assertEqual(image[:len(common.PNGHeader)], common.PNGHeader)
+        (width, height) = struct.unpack('!LL', image[16:24])
+        self.assertEqual(width, 180)
+        self.assertEqual(height, int(width * origHeight / origWidth))
+        resp = self.request(path='/item/%s/tiles/thumbnail' % itemId,
+                            user=self.admin, isJson=False,
+                            params={'encoding': 'PNG',
+                                    'width': 180, 'height': 180,
+                                    'fill': 'pink'})
+        self.assertStatusOk(resp)
+        image = self.getBody(resp, text=False)
+        self.assertEqual(image[:len(common.PNGHeader)], common.PNGHeader)
+        (width, height) = struct.unpack('!LL', image[16:24])
+        self.assertEqual(width, 180)
+        self.assertEqual(height, 180)
+        resp = self.request(path='/item/%s/tiles/thumbnail' % itemId,
+                            user=self.admin, isJson=False,
+                            params={'encoding': 'PNG',
+                                    'width': 180, 'height': 180,
+                                    'fill': '#ffff00'})
+        self.assertStatusOk(resp)
+        nextimage = self.getBody(resp, text=False)
+        self.assertEqual(nextimage[:len(common.PNGHeader)], common.PNGHeader)
+        (width, height) = struct.unpack('!LL', nextimage[16:24])
+        self.assertEqual(width, 180)
+        self.assertEqual(height, 180)
+        self.assertNotEqual(image, nextimage)
+
         # Test bad parameters
         badParams = [
             ({'encoding': 'invalid'}, 400, 'Invalid encoding'),
@@ -810,6 +846,7 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
             ({'height': -5}, 400, 'Invalid width or height'),
             ({'jpegQuality': 'invalid'}, 400, 'incorrect type'),
             ({'jpegSubsampling': 'invalid'}, 400, 'incorrect type'),
+            ({'fill': 'not a color'}, 400, 'unknown color'),
         ]
         for entry in badParams:
             resp = self.request(path='/item/%s/tiles/thumbnail' % itemId,
@@ -826,7 +863,7 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
         self.assertEqual(image[:len(common.JPEGHeader)], common.JPEGHeader)
         self.assertEqual(len(image), defaultLength)
 
-        # We should report one thumbnail
+        # We should report some thumbnails
         item = self.model('item').load(itemId, user=self.admin)
         present, removed = self.model(
             'image_item', 'large_image').removeThumbnailFiles(item, keep=10)
@@ -946,6 +983,36 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
         self.assertEqual(width, 500)
         self.assertEqual(height, 375)
 
+        # Test fill
+        params['fill'] = 'none'
+        resp = self.request(path='/item/%s/tiles/region' % itemId,
+                            user=self.admin, isJson=False, params=params)
+        self.assertStatusOk(resp)
+        image = self.getBody(resp, text=False)
+        self.assertEqual(image[:len(common.PNGHeader)], common.PNGHeader)
+        (width, height) = struct.unpack('!LL', image[16:24])
+        self.assertEqual(width, 500)
+        self.assertEqual(height, 375)
+        params['fill'] = '#ff00ff'
+        resp = self.request(path='/item/%s/tiles/region' % itemId,
+                            user=self.admin, isJson=False, params=params)
+        self.assertStatusOk(resp)
+        image = self.getBody(resp, text=False)
+        self.assertEqual(image[:len(common.PNGHeader)], common.PNGHeader)
+        (width, height) = struct.unpack('!LL', image[16:24])
+        self.assertEqual(width, 500)
+        self.assertEqual(height, 500)
+        params['regionWidth'] = 1500
+        resp = self.request(path='/item/%s/tiles/region' % itemId,
+                            user=self.admin, isJson=False, params=params)
+        self.assertStatusOk(resp)
+        nextimage = self.getBody(resp, text=False)
+        self.assertEqual(nextimage[:len(common.PNGHeader)], common.PNGHeader)
+        (width, height) = struct.unpack('!LL', image[16:24])
+        self.assertEqual(width, 500)
+        self.assertEqual(height, 500)
+        self.assertNotEqual(image, nextimage)
+
         # test svs image
         file = self._uploadFile(os.path.join(
             os.environ['LARGE_IMAGE_DATA'], 'sample_svs_image.TCGA-DU-6399-'
@@ -1013,6 +1080,14 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
             user=self.admin, encoding='PNG')
         image, mime = source.getThumbnail(encoding='JPEG', width=200)
         self.assertEqual(image[:len(common.JPEGHeader)], common.JPEGHeader)
+
+        # Test the level0 thumbnail code path
+        image, mime = source.getThumbnail(
+            encoding='PNG', width=200, height=100, levelZero=True, fill='blue')
+        self.assertEqual(image[:len(common.PNGHeader)], common.PNGHeader)
+        (width, height) = struct.unpack('!LL', image[16:24])
+        self.assertEqual(width, 200)
+        self.assertEqual(height, 100)
 
     def testTilesLoadModelCache(self):
         from girder.plugins.large_image import loadmodelcache

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -264,13 +264,15 @@ class ImageItem(Item):
         :param width: maximum width in pixels.
         :param height: maximum height in pixels.
         :param **kwargs: optional arguments.  Some options are encoding,
-            jpegQuality, jpegSubsampling, and tiffCompression.  This is also
+            jpegQuality, jpegSubsampling, tiffCompression, fill.  This is also
             passed to the tile source.
         :returns: thumbData, thumbMime: the image data and the mime type OR
             a generator which will yield a file.
         """
         # check if a thumbnail file exists with a particular key
         keydict = dict(kwargs, width=width, height=height)
+        if 'fill' in keydict and (keydict['fill']).lower() == 'none':
+            del keydict['fill']
         keydict = {k: v for k, v in six.viewitems(keydict) if v is not None}
         key = json.dumps(keydict, sort_keys=True, separators=(',', ':'))
         fileModel = self.model('file')

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -345,6 +345,11 @@ class TilesItemResource(Item):
                required=False, dataType='int')
         .param('height', 'The maximum height of the thumbnail in pixels.',
                required=False, dataType='int')
+        .param('fill', 'A fill color.  If width and height are both specified '
+               'and fill is specified and not "none", the output image is '
+               'padded on either the sides or the top and bottom to the '
+               'requested output size.  Most css colors are accepted.',
+               required=False)
         .param('encoding', 'Thumbnail output encoding', required=False,
                enum=['JPEG', 'PNG', 'TIFF'], default='JPEG')
         .param('contentDisposition', 'Specify the Content-Disposition response '
@@ -361,6 +366,7 @@ class TilesItemResource(Item):
         params = self._parseParams(params, True, [
             ('width', int),
             ('height', int),
+            ('fill', str),
             ('jpegQuality', int),
             ('jpegSubsampling', int),
             ('tiffCompression', str),
@@ -421,6 +427,10 @@ class TilesItemResource(Item):
                required=False, dataType='int')
         .param('height', 'The maximum height of the output image in pixels.',
                required=False, dataType='int')
+        .param('fill', 'A fill color.  If output dimensions are specified and '
+               'fill is specified and not "none", the output image is padded '
+               'on either the sides or the top and bottom to the requested '
+               'output size.  Most css colors are accepted.', required=False)
         .param('magnification', 'Magnification of the output image.  If '
                'neither width for height is specified, the magnification, '
                'mm_x, and mm_y parameters are used to select the output size.',
@@ -465,6 +475,7 @@ class TilesItemResource(Item):
             ('units', str, 'region', 'units'),
             ('width', int, 'output', 'maxWidth'),
             ('height', int, 'output', 'maxHeight'),
+            ('fill', str),
             ('magnification', float, 'scale', 'magnification'),
             ('mm_x', float, 'scale', 'mm_x'),
             ('mm_y', float, 'scale', 'mm_y'),

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -148,6 +148,28 @@ def _encodeImage(image, encoding='JPEG', jpegQuality=95, jpegSubsampling=0,
     return imageData, imageFormatOrMimeType
 
 
+def _letterboxImage(image, width, height, fill):
+    """
+    Given a PIL image, width, height, and fill color, letterbox or pillarbox
+    the image to make it the specified dimensions.  The image is never
+    cropped.  The original image will be returned if no action is needed.
+
+    :param image: the source image.
+    :param width: the desired width in pixels.
+    :param height: the desired height in pixels.
+    :param fill: a fill color.
+    """
+    if ((image.width >= width and image.height >= height) or
+            not fill or str(fill).lower() == 'none'):
+        return image
+    color = PIL.ImageColor.getcolor(fill, image.mode)
+    width = max(width, image.width)
+    height = max(height, image.height)
+    result = PIL.Image.new(image.mode, (width, height), color)
+    result.paste(image, (int((width - image.width) / 2), int((height - image.height) / 2)))
+    return result
+
+
 class LazyTileDict(dict):
     """
     Tiles returned from the tile iterator and dictioaries of information with
@@ -1023,12 +1045,15 @@ class TileSource(object):
         image = image.crop((0, 0, imageWidth, imageHeight))
 
         if width or height:
+            maxWidth, maxHeight = width, height
             width, height, calcScale = self._calculateWidthHeight(
                 width, height, imageWidth, imageHeight)
 
             image = image.resize(
                 (width, height),
                 PIL.Image.BICUBIC if width > imageWidth else PIL.Image.LANCZOS)
+            if kwargs.get('fill') and maxWidth and maxHeight:
+                image = _letterboxImage(image, maxWidth, maxHeight, kwargs['fill'])
         return _encodeImage(image, **kwargs)
 
     def getPreferredLevel(self, level):
@@ -1157,7 +1182,7 @@ class TileSource(object):
             TILE_FORMAT_IMAGE).  If TILE_FORMAT_IMAGE, encoding may be
             specified.
         :param **kwargs: optional arguments.  Some options are region, output,
-            encoding, jpegQuality, jpegSubsampling, tiffCompression.  See
+            encoding, jpegQuality, jpegSubsampling, tiffCompression, fill.  See
             tileIterator.
         :returns: regionData, formatOrRegionMime: the image data and either the
             mime type, if the format is TILE_FORMAT_IMAGE, or the format.
@@ -1209,6 +1234,10 @@ class TileSource(object):
                 (outWidth, outHeight),
                 PIL.Image.BICUBIC if outWidth > regionWidth else
                 PIL.Image.LANCZOS)
+        maxWidth = kwargs.get('output', {}).get('maxWidth')
+        maxHeight = kwargs.get('output', {}).get('maxHeight')
+        if kwargs.get('fill') and maxWidth and maxHeight:
+            image = _letterboxImage(image, maxWidth, maxHeight, kwargs['fill'])
         return _encodeImage(image, format=format, **kwargs)
 
     def getRegionAtAnotherScale(self, sourceRegion, sourceScale=None,


### PR DESCRIPTION
If this option is set and a width and height is specified, then the output image is padded on either the left and right or the top and bottom to make it the specified width and height.  The letterbox or pillarbox color is specified in the fill parameter.