### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -187,7 +187,8 @@ before_install:
 
   - pip install --no-cache-dir numpy==1.11.3  # needed because libtiff doesn't install correctly without it.  This ensures we have the same version for libtiff as for the project.
 
-  - if [ ${LIBTIFF_VERSION} == "4.0.6" ]; then pip install "git+https://github.com/pearu/pylibtiff@33735eb7197eb33ed1a50bbc4bc5a47ce4305e92" --force-reinstall --ignore-installed --upgrade --no-cache-dir; fi
+  # Make sure we are using an appropriate pylibtiff.
+  - pip install "git+https://github.com/pearu/pylibtiff@33735eb7197eb33ed1a50bbc4bc5a47ce4305e92" --force-reinstall --ignore-installed --upgrade --no-cache-dir
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,16 @@ language: python
 
 python:
   - "2.7"
+  - "3.5"
 
 env:
   - LIBTIFF_VERSION=4.0.3 LIBTIFF_DIR=/old OPENJPEG_VERSION=2.1   OPENJPEG_FILE=version.2.1.tar.gz OPENJPEG_DIR="openjpeg-version.2.1" 
   - LIBTIFF_VERSION=4.0.6 LIBTIFF_DIR=     OPENJPEG_VERSION=2.1.2 OPENJPEG_FILE=v2.1.2.tar.gz      OPENJPEG_DIR="openjpeg-2.1.2" BUILD_VIPS="yes"
+
+matrix:
+  exclude:
+  - python: "3.5"
+    env: LIBTIFF_VERSION=4.0.3 LIBTIFF_DIR=/old OPENJPEG_VERSION=2.1   OPENJPEG_FILE=version.2.1.tar.gz OPENJPEG_DIR="openjpeg-version.2.1" 
 
 cache:
   directories:
@@ -162,8 +168,9 @@ before_install:
   - girder_worker_path=$build_path/girder_worker
   - git clone https://github.com/girder/girder_worker.git $girder_worker_path && git -C $girder_worker_path checkout $GIRDER_WORKER_VERSION
   - cp $PWD/plugin_tests/test_files/girder_worker.cfg $girder_worker_path/girder_worker/worker.local.cfg
-  - python $girder_worker_path/scripts/install_requirements.py # --mode=dev
-  - pip install --no-cache-dir -U -e $girder_worker_path'[girder_io]'
+  # - python $girder_worker_path/scripts/install_requirements.py # --mode=dev
+  # - pip install --no-cache-dir -U -e $girder_worker_path'[girder_io]'
+  - pip2 install --no-cache-dir -U $girder_worker_path'[girder_io]'
 
   - export MONGO_VERSION=3.0.7
   - export PY_COVG="ON"
@@ -178,9 +185,9 @@ before_install:
 
   - pip install --no-cache-dir -U pip virtualenv
 
-  - pip install --no-cache-dir numpy==1.10.2  # needed because libtiff doesn't install correctly without it.  This ensures we have the same version for libtiff as for the project.
+  - pip install --no-cache-dir numpy==1.11.3  # needed because libtiff doesn't install correctly without it.  This ensures we have the same version for libtiff as for the project.
 
-  - if [ ${LIBTIFF_VERSION} == "4.0.6" ]; then pip install "git+https://github.com/pearu/pylibtiff@33735eb7197eb33ed1a50bbc4bc5a47ce4305e92" --force-reinstall --ignore-installed --upgrade; fi
+  - if [ ${LIBTIFF_VERSION} == "4.0.6" ]; then pip install "git+https://github.com/pearu/pylibtiff@33735eb7197eb33ed1a50bbc4bc5a47ce4305e92" --force-reinstall --ignore-installed --upgrade --no-cache-dir; fi
 
 
 install:
@@ -189,9 +196,9 @@ install:
   - pip install -r $main_path/requirements.txt -e .
   # Make sure we have a prefered version of celery for Girder Worker
   - pip install -U 'celery>=4'
-  # Make sure we have a prefered version of cryptography for Girder Worker
-  - pip install -U 'cryptography>=1.7'
-  - python -c "import openslide;print openslide.__version__"
+  # # Make sure we have a prefered version of cryptography for Girder Worker
+  # - pip install -U 'cryptography>=1.7'
+  - python -c "import openslide;print(openslide.__version__)"
   # This was
   # - npm install
   # but since there are often connection failures, use the retry package.
@@ -200,8 +207,7 @@ install:
 
 script:
   - cd $girder_worker_path
-  - python -m girder_worker >/tmp/worker.out 2>&1 &
-  # - python -m girder_worker 2>&1 | tee /tmp/worker.out &
+  - python2 -m girder_worker >/tmp/worker.out 2>&1 &
   - mkdir -p $build_path/girder_testing_build
   - cd $build_path/girder_testing_build
   - cmake -DPYTHON_COVERAGE:BOOL=${PY_COVG} -DPYTHON_VERSION:STRING=${TRAVIS_PYTHON_VERSION} -DCOVERAGE_MINIMUM_PASS=80 -DJS_COVERAGE_MINIMUM_PASS=9 -DRUN_CORE_TESTS:BOOL="OFF" -DTEST_PLUGINS:STRING="large_image" $girder_path

--- a/plugin_tests/client/geojsSpec.js
+++ b/plugin_tests/client/geojsSpec.js
@@ -75,7 +75,9 @@ $(function () {
                     return null;
                 });
             });
-
+            waitsFor(function () {
+                return annotationId !== undefined;
+            });
             girderTest.waitForLoad();
             runs(function () {
                 expect(annotationId).toBeDefined();

--- a/plugin_tests/common.py
+++ b/plugin_tests/common.py
@@ -167,7 +167,7 @@ class LargeImageCommonTest(base.TestCase):
                 resp = self.request(path='/item/%s/tiles/zxy/%d/%d/%d' % (
                     itemId, z, x, y), params=tileParams, isJson=False,
                     **kwargs)
-                if (resp.output_status[:3] != '200' and
+                if (resp.output_status[:3] != b'200' and
                         metadata.get('sparse') and z > metadata['sparse']):
                     self.assertStatus(resp, 404)
                     continue

--- a/plugin_tests/import_test.py
+++ b/plugin_tests/import_test.py
@@ -51,19 +51,19 @@ class LargeImageTilesTest(base.TestCase):
         try:
             reload_module(girder.plugins.large_image.tilesource.test)
         except ImportError as exc:
-            self.assertIn('No module named PIL', exc.args[0])
+            self.assertIn('PIL', exc.args[0])
         else:
             self.fail()
         try:
             reload_module(girder.plugins.large_image.tilesource.tiff_reader)
         except ImportError as exc:
-            self.assertIn('No module named libtiff', exc.args[0])
+            self.assertIn('libtiff', exc.args[0])
         else:
             self.fail()
         try:
             reload_module(girder.plugins.large_image.tilesource.svs)
         except ImportError as exc:
-            self.assertIn('No module named openslide', exc.args[0])
+            self.assertIn('openslide', exc.args[0])
         else:
             self.fail()
 

--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -1028,8 +1028,8 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
         tileMetadata = resp.json
         tileMetadata['sparse'] = 5
         self._testTilesZXY(itemId, tileMetadata, token=token)
-        self.assertGreater(loadmodelcache.LoadModelCache[
-            loadmodelcache.LoadModelCache.keys()[0]]['hits'], 70)
+        self.assertGreater(six.next(six.itervalues(
+            loadmodelcache.LoadModelCache))['hits'], 70)
 
     def testTilesAutoSetOption(self):
         from girder.plugins.large_image import constants

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cachetools>=1.1.6,<2.0.0
+cachetools>=2.0.0
 enum34>=1.1.6
 jsonschema>=2.5.1
 psutil>=4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,10 @@ Pillow>=3.2.0
 # https://github.com/girder/large_image/issues/30
 numpy>=1.10.2
 
-libtiff>=0.4.0
-# If you have OpenJPEG 2.1.1 or later or need libtiff 4.0.6 support, instead use
-# -e git+https://github.com/pearu/pylibtiff@33735eb7197eb33ed1a50bbc4bc5a47ce4305e92
+# If you are using OpenJPEG < 2.1.1, libtiff <= 4.0.3, and Python 2.x, you can
+# use the packaged version of libtiff
+#   libtiff>=0.4.0
+# otherwise, we need a newer version:
+-e git+https://github.com/pearu/pylibtiff@33735eb7197eb33ed1a50bbc4bc5a47ce4305e92#egg=libtiff-0.4.1.dev0
 
 openslide-python>=1.1.0

--- a/scripts/tile_benchmark/benchmark.py
+++ b/scripts/tile_benchmark/benchmark.py
@@ -46,7 +46,7 @@ def main(file_name):
     with open(file_name, 'r') as params:
         for line in params:
             if '#' not in line:
-                print line
+                print(line)
                 args = line.split()
                 # second item in source/config file is the server name
                 run_params[args[1]] = args
@@ -61,7 +61,7 @@ def main(file_name):
                 int(run_params[server_name][2]),
                 int(run_params[server_name][3]))
         elif host == 'iip':
-            print ('Getting images from iip')
+            print('Getting images from iip')
             elapsed_time = get_data(
                 host,
                 int(run_params[server_name][2]),
@@ -223,8 +223,8 @@ def girder_init(host, image_id):
                   'request \n %s' % (image_summary_url))
             sys.exit()
     else:
-        print'Could not receive meta data using the following request\n %s' \
-             % (image_summary_url)
+        print('Could not receive meta data using the following request\n %s' %
+              image_summary_url)
         sys.exit()
 
     return data
@@ -248,13 +248,13 @@ def girder_request(data, z, x, y):
         return elapsed_time
 
     elif tile_req.status_code == 404:
-        print ' 404 error to get tile from layer %d x %d y %d error code %d' \
-              % (z, x, y, tile_req.status_code)
+        print('404 error to get tile from layer %d x %d y %d error code %d' % (
+              z, x, y, tile_req.status_code))
         return -1
 
     elif tile_req.status_code != 404:
-        print ' error to get tile from layer %d x %d y %d error code %d' \
-              % (z, x, y, tile_req.status_code)
+        print('error to get tile from layer %d x %d y %d error code %d' % (
+              z, x, y, tile_req.status_code))
         return -1
 
 
@@ -271,8 +271,8 @@ def atlas_request(data, z, x, y):
         return -1
 
     elif tile_req.status_code != 404:
-        print ' error to get tile from layer %d x %d y %d error code %d' \
-              % (z, x, y, tile_req.status_code)
+        print('error to get tile from layer %d x %d y %d error code %d' % (
+              z, x, y, tile_req.status_code))
         return -1
 
 

--- a/scripts/tile_benchmark/plot_time.py
+++ b/scripts/tile_benchmark/plot_time.py
@@ -28,7 +28,7 @@ import mpl_toolkits.mplot3d.axes3d  # noqa
 
 
 def main(file_list, units):
-    print file_list, units
+    print(file_list, units)
     data = {}
     for file in file_list:
         elapsed_time = np.loadtxt(file)
@@ -60,8 +60,8 @@ def plot_data(data):
         elapsed_time = data[server_name]
         max_val = np.amax(elapsed_time)
         mean_val = np.mean(elapsed_time)
-        print 'server %s  data has a mean value of %f milliseconds and a max ' \
-              'value of %f milliseconds' % (server_name, mean_val, max_val)
+        print('server %s  data has a mean value of %f milliseconds and a max '
+              'value of %f milliseconds' % (server_name, mean_val, max_val))
         num, bins, patch = ax.hist(
             elapsed_time,
             interval,

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -24,7 +24,7 @@ except ImportError as exc:
     # unavailable, log it and start anyway (we may be running in a girder-less
     # environment).  Otherwise, reraise the exception -- something else went
     # wrong.
-    if 'plugins' not in exc.message and 'girder' not in exc.message:
+    if 'plugins' not in repr(exc.args) and 'girder' not in repr(exc.args):
         raise
     import logging as logger
     logger.getLogger().setLevel(logger.INFO)

--- a/server/cache_util/memcache.py
+++ b/server/cache_util/memcache.py
@@ -141,6 +141,6 @@ class MemCache(cachetools.Cache):
         except pylibmc.Error as exc:
             # memcached won't cache items larger than 1 Mb, but this returns a
             # 'SUCCESS' error.  Raise other errors.
-            if 'SUCCESS' not in exc.message:
+            if 'SUCCESS' not in repr(exc.args):
                 self.logError(pylibmc.Error, logprint.exception,
                               'pylibmc exception')

--- a/server/rest/annotation.py
+++ b/server/rest/annotation.py
@@ -155,8 +155,8 @@ class AnnotationResource(Resource):
         except ValidationException as exc:
             logger.exception('Failed to validate annotation')
             raise RestException(
-                'Validation Error: JSON doesn\'t follow schema (%s).' % (
-                    exc.message, ))
+                'Validation Error: JSON doesn\'t follow schema (%r).' % (
+                    exc.args, ))
 
     @describeRoute(
         Description('Update an annotation or move it to a different item.')
@@ -192,8 +192,8 @@ class AnnotationResource(Resource):
         except ValidationException as exc:
             logger.exception('Failed to validate annotation')
             raise RestException(
-                'Validation Error: JSON doesn\'t follow schema (%s).' % (
-                    exc.message, ))
+                'Validation Error: JSON doesn\'t follow schema (%r).' % (
+                    exc.args, ))
         return annotation
 
     @describeRoute(

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -125,7 +125,7 @@ class TilesItemResource(Item):
                 item, largeImageFile, user, token,
                 notify=self.boolParam('notify', params, default=True))
         except TileGeneralException as e:
-            raise RestException(e.message)
+            raise RestException(e.args[0])
 
     @classmethod
     def _parseTestParams(cls, params):
@@ -193,7 +193,7 @@ class TilesItemResource(Item):
         try:
             return self.imageItemModel.getMetadata(item, **imageArgs)
         except TileGeneralException as e:
-            raise RestException(e.message, code=400)
+            raise RestException(e.args[0], code=400)
 
     def _setContentDisposition(self, item, contentDisposition, mime, subname):
         """
@@ -216,7 +216,7 @@ class TilesItemResource(Item):
         filename += '.' + MimeTypeExtensions[mime]
         if not isinstance(filename, six.text_type):
             filename = filename.decode('utf8', 'ignore')
-        safeFilename = filename.encode('ascii', 'ignore').replace('"', '')
+        safeFilename = filename.encode('ascii', 'ignore').replace(b'"', b'')
         encodedFilename = six.moves.urllib.parse.quote(filename.encode('utf8', 'ignore'))
         setResponseHeader(
             'Content-Disposition',
@@ -266,7 +266,7 @@ class TilesItemResource(Item):
             tileData, tileMime = self.imageItemModel.getTile(
                 item, x, y, z, **imageArgs)
         except TileGeneralException as e:
-            raise RestException(e.message, code=404)
+            raise RestException(e.args[0], code=404)
         setResponseHeader('Content-Type', tileMime)
         setRawResponse()
         return tileData
@@ -370,9 +370,9 @@ class TilesItemResource(Item):
         try:
             result = self.imageItemModel.getThumbnail(item, **params)
         except TileGeneralException as e:
-            raise RestException(e.message)
+            raise RestException(e.args[0])
         except ValueError as e:
-            raise RestException('Value Error: %s' % e.message)
+            raise RestException('Value Error: %s' % e.args[0])
         if not isinstance(result, tuple):
             return result
         thumbData, thumbMime = result
@@ -479,9 +479,9 @@ class TilesItemResource(Item):
             regionData, regionMime = self.imageItemModel.getRegion(
                 item, **params)
         except TileGeneralException as e:
-            raise RestException(e.message)
+            raise RestException(e.args[0])
         except ValueError as e:
-            raise RestException('Value Error: %s' % e.message)
+            raise RestException('Value Error: %s' % e.args[0])
         self._setContentDisposition(
             item, params.get('contentDisposition'), regionMime, 'region')
         setResponseHeader('Content-Type', regionMime)
@@ -500,7 +500,7 @@ class TilesItemResource(Item):
         try:
             return self.imageItemModel.getAssociatedImagesList(item)
         except TileGeneralException as e:
-            raise RestException(e.message, code=400)
+            raise RestException(e.args[0], code=400)
 
     @describeRoute(
         Description('Get an image associated with a large image.')
@@ -538,7 +538,7 @@ class TilesItemResource(Item):
         try:
             result = self.imageItemModel.getAssociatedImage(item, image, **params)
         except TileGeneralException as e:
-            raise RestException(e.message, code=400)
+            raise RestException(e.args[0], code=400)
         if not isinstance(result, tuple):
             return result
         imageData, imageMime = result

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -1603,7 +1603,7 @@ if girder:
                 raise
             except (KeyError, ValidationException, TileSourceException) as e:
                 raise TileSourceException(
-                    'No large image file in this item: %s' % e.message)
+                    'No large image file in this item: %s' % e.args[0])
 
 
 def getTileSourceFromDict(availableSources, pathOrUri, user=None, *args,

--- a/server/tilesource/test.py
+++ b/server/tilesource/test.py
@@ -82,8 +82,8 @@ class TestTileSource(TileSource):
         y *= self.tileHeight
         sq = widthCount * self.tileWidth
         while sq >= 4:
-            sq1 = sq / 4
-            sq2 = sq1 + sq / 2
+            sq1 = sq // 4
+            sq2 = sq1 + sq // 2
             for t in range(-(y % sq), self.tileWidth, sq):
                 if t + sq1 < self.tileWidth and t + sq2 >= 0:
                     for l in range(-(x % sq), self.tileWidth, sq):
@@ -93,7 +93,7 @@ class TestTileSource(TileSource):
                                 min(self.tileWidth, l + sq2 - 1),
                                 min(self.tileWidth, t + sq2 - 1),
                             ], color, None)
-            sq /= 2
+            sq //= 2
 
     @methodcache()
     def getTile(self, x, y, z, *args, **kwargs):

--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -65,7 +65,8 @@ class TiffFileTileSource(FileTileSource):
         for directoryNum in itertools.count():
             try:
                 td = TiledTiffDirectory(largeImagePath, directoryNum)
-            except ValidationTiffException as lastException:
+            except ValidationTiffException as exc:
+                lastException = exc
                 continue
             except TiffException as exc:
                 if not lastException:
@@ -149,7 +150,7 @@ class TiffFileTileSource(FileTileSource):
         except IndexError:
             raise TileSourceException('z layer does not exist')
         except InvalidOperationTiffException as e:
-            raise TileSourceException(e.message)
+            raise TileSourceException(e.args[0])
         except IOTiffException as e:
             if sparseFallback and z and PIL:
                 image = self.getTile(x / 2, y / 2, z - 1, pilImageAllowed=True,
@@ -164,7 +165,7 @@ class TiffFileTileSource(FileTileSource):
                 image = image.resize((self.tileWidth, self.tileHeight))
                 return self._outputTile(image, 'PIL', x, y, z, pilImageAllowed,
                                         **kwargs)
-            raise TileSourceException('Internal I/O failure: %s' % e.message)
+            raise TileSourceException('Internal I/O failure: %s' % e.args[0])
 
     def getTileFromEmptyDirectory(self, x, y, z):
         """

--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -135,6 +135,8 @@ class TiffFileTileSource(FileTileSource):
             associated = TiledTiffDirectory(largeImagePath, directoryNum, False)
             id = associated._tiffInfo.get(
                 'imagedescription').strip().split(None, 1)[0].lower()
+            if not isinstance(id, six.text_type):
+                id = id.decode('utf8')
             # Only use this as an associated image if the parsed id is
             # a reasonable length, alphanumeric characters, and the
             # image isn't too large.

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -314,8 +314,8 @@ class TiledTiffDirectory(object):
         :raises: InvalidOperationTiffException
         """
         # TIFFCheckTile and TIFFComputeTile require pixel coordinates
-        pixelX = x * self._tileWidth
-        pixelY = y * self._tileHeight
+        pixelX = int(x * self._tileWidth)
+        pixelY = int(y * self._tileHeight)
 
         if pixelX >= self._imageWidth or pixelY >= self._imageHeight:
             raise InvalidOperationTiffException(
@@ -527,6 +527,8 @@ class TiledTiffDirectory(object):
 
         if not meta:
             return
+        if not isinstance(meta, six.string_types):
+            meta = meta.decode('utf8', 'ignore')
         try:
             xml = cElementTree.fromstring(meta)
         except Exception:


### PR DESCRIPTION
Make changes necessary to be Python 3 compatible and test on Python 3.

Simplistically, changes are to (a) how some exceptions are handled, (b) to some utility scripts that may not be used, (c) to the test tile source, (d) to some tests.  Prior to this, the plugin was manually tested with Python 3 where it worked in common use cases.  Since this adds CI testing, it is more certain to stay working.

