### PR TITLE
Add an optional "group" tag to annotation elements

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -12,9 +12,9 @@ Partial annotations are shown below with some example values.  Note that the com
   "description": "This is a description",  # String.  Optional
   "attributes": {                          # Object.  Optional
     "key1": "value1",
-    "key2": ["any", {"value": "can"}, "go", "here"] 
+    "key2": ["any", {"value": "can"}, "go", "here"]
   },
-  "elements": []                           # A list.  Optional.  
+  "elements": []                           # A list.  Optional.
                                            # See below for valid elements.
 }
 ```
@@ -39,6 +39,7 @@ All shapes have the following properties.  If a property is not listed, it is no
     },
     "lineColor": "#000000",           # String.  See note about colors.  Optional
     "lineWidth": 1,                   # Number >= 0.  Optional
+    "group": "group name",            # String. Optional
     <shape specific properties>
 }
 ```
@@ -168,7 +169,7 @@ A sample that shows off a valid annotation:
   "description": "This is a description",
   "attributes": {
     "key1": "value1",
-    "key2": ["any", {"value": "can"}, "go", "here"] 
+    "key2": ["any", {"value": "can"}, "go", "here"]
   },
   "elements": [{
     "type": "point",

--- a/plugin_tests/annotations_test.py
+++ b/plugin_tests/annotations_test.py
@@ -334,6 +334,34 @@ class LargeImageAnnotationElementTest(common.LargeImageCommonTest):
         elemModel.removeElements(annot)
         self.assertEqual(len(annotModel.load(annot['_id'])['annotation']['elements']), 0)
 
+    def testAnnotationGroup(self):
+        annotModel = self.model('annotation', 'large_image')
+        file = self._uploadFile(os.path.join(
+            os.environ['LARGE_IMAGE_DATA'], 'sample_image.ptif'))
+        item = self.model('item').load(file['itemId'], level=AccessType.READ,
+                                       user=self.admin)
+
+        elements = [{
+            'type': 'rectangle',
+            'center': [20.0, 25.0, 0],
+            'width': 14.0,
+            'height': 15.0,
+            'group': 'a'
+        }, {
+            'type': 'rectangle',
+            'center': [40.0, 15.0, 0],
+            'width': 5.0,
+            'height': 5.0
+        }]
+        annotationWithGroup = {
+            'name': 'groups',
+            'elements': elements
+        }
+
+        annot = annotModel.createAnnotation(item, self.admin, annotationWithGroup)
+        result = annotModel.load(annot['_id'])
+        self.assertEqual(result['annotation']['elements'][0]['group'], 'a')
+
     #  Add tests for:
     # removeOldElements
     # updateElements

--- a/server/models/annotation.py
+++ b/server/models/annotation.py
@@ -93,7 +93,8 @@ class AnnotationSchema:
             'lineWidth': {
                 'type': 'number',
                 'minimum': 0
-            }
+            },
+            'group': {'type': 'string'}
         },
         'required': ['type'],
         'additionalProperties': True


### PR DESCRIPTION
The group tag is intended to be used for display as a method to perform bulk operations on a subset of related elements contained in an annotation.

Alternatively, this could be called a "layer".  I have a mild preference to group because I don't intend for it to have anything to do with display order, but I could be convinced otherwise.