### PR TITLE
Log a less-severe message if optional tilesources cannot be imported

### DIFF
--- a/server/tilesource/__init__.py
+++ b/server/tilesource/__init__.py
@@ -72,7 +72,7 @@ for source in sourceList:
         if getattr(sourceClass, 'name', None):
             AvailableTileSources[sourceClass.name] = sourceClass
     except ImportError:
-        logprint.exception('Error: Could not import %s' % className)
+        logprint.info('Notice: Could not import %s' % className)
 
 # Create a partial function that will work through the known functions to get a
 # tile source.


### PR DESCRIPTION
This prevents an unnecessary stack trace from being included in the log message, and keeps stdout cleaner when loading the plugin.