### PR TITLE
Allow the annotation download endpoint to use cookie authentication.

### DIFF
--- a/server/rest/annotation.py
+++ b/server/rest/annotation.py
@@ -122,6 +122,7 @@ class AnnotationResource(Resource):
         .errorResponse('Read access was denied for the annotation.', 403)
         .notes('Use "size" or "details" as possible sort keys.')
     )
+    @access.cookie
     @access.public
     @filtermodel(model='annotation', plugin='large_image')
     def getAnnotation(self, id, params):


### PR DESCRIPTION
If an annotation is on an item in a private folder, then browsers fail at downloading the annotation, since the download doesn't pass the authentication token.  If cookies are allowed, the authentication can be gleaned from the cookie and therefore works.