### PR TITLE
Handle OSError exceptions on tile sources.

### DIFF
--- a/server/tilesource/__init__.py
+++ b/server/tilesource/__init__.py
@@ -71,7 +71,7 @@ for source in sourceList:
         # add it to our dictionary of available sources if it has a name
         if getattr(sourceClass, 'name', None):
             AvailableTileSources[sourceClass.name] = sourceClass
-    except ImportError:
+    except (ImportError, OSError):
         logprint.info('Notice: Could not import %s' % className)
 
 # Create a partial function that will work through the known functions to get a


### PR DESCRIPTION
When a tile source fails to import due to an OSError, treat it much like an ImportError.  This is the error we get when a library is missing but the python module is present.