### PR TITLE
Fix annotation image access.

### DIFF
--- a/plugin_tests/annotations_test.py
+++ b/plugin_tests/annotations_test.py
@@ -459,11 +459,10 @@ class LargeImageAnnotationRestTest(common.LargeImageCommonTest):
         def create_annotation(item, user):
             return str(annotModel.createAnnotation(item, user, sampleAnnotation)['_id'])
 
-        def upload(name, user=self.user):
+        def upload(name, user=self.user, private=False):
             file = self._uploadFile(os.path.join(
-                os.environ['LARGE_IMAGE_DATA'], 'sample_image.ptif'), name)
-            item = self.model('item').load(file['itemId'], level=AccessType.READ,
-                                           user=self.admin)
+                os.environ['LARGE_IMAGE_DATA'], 'sample_image.ptif'), name, private=private)
+            item = self.model('item').load(file['itemId'], level=AccessType.READ, user=self.admin)
 
             create_annotation(item, user)
             create_annotation(item, user)
@@ -474,6 +473,7 @@ class LargeImageAnnotationRestTest(common.LargeImageCommonTest):
         item1 = upload('image1.ptif', self.admin)
         item2 = upload('image2.ptif')
         item3 = upload('image3.ptif')
+        item4 = upload('image3.ptif', self.user, True)
 
         # test default search
         resp = self.request('/annotation/images', user=self.admin, params={
@@ -481,7 +481,7 @@ class LargeImageAnnotationRestTest(common.LargeImageCommonTest):
         })
         self.assertStatusOk(resp)
         ids = [image['_id'] for image in resp.json]
-        self.assertEqual(ids, [item3, item2, item1])
+        self.assertEqual(ids, [item4, item3, item2, item1])
 
         # test filtering by user
         resp = self.request('/annotation/images', user=self.admin, params={
@@ -490,7 +490,15 @@ class LargeImageAnnotationRestTest(common.LargeImageCommonTest):
         })
         self.assertStatusOk(resp)
         ids = [image['_id'] for image in resp.json]
-        self.assertEqual(ids, [item3, item2])
+        self.assertEqual(ids, [item4, item3, item2])
+
+        # test getting annotations without admin access
+        resp = self.request('/annotation/images', user=self.user, params={
+            'limit': 100
+        })
+        self.assertStatusOk(resp)
+        ids = [image['_id'] for image in resp.json]
+        self.assertEqual(ids, [item3, item2, item1])
 
         # test sort direction
         resp = self.request('/annotation/images', user=self.admin, params={
@@ -499,18 +507,18 @@ class LargeImageAnnotationRestTest(common.LargeImageCommonTest):
         })
         self.assertStatusOk(resp)
         ids = [image['_id'] for image in resp.json]
-        self.assertEqual(ids, [item1, item2, item3])
+        self.assertEqual(ids, [item1, item2, item3, item4])
 
         # test pagination
         resp = self.request('/annotation/images', user=self.admin, params={
             'limit': 1
         })
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json[0]['_id'], item3)
+        self.assertEqual(resp.json[0]['_id'], item4)
 
         resp = self.request('/annotation/images', user=self.admin, params={
             'limit': 1,
-            'offset': 2
+            'offset': 3
         })
         self.assertStatusOk(resp)
         self.assertEqual(resp.json[0]['_id'], item1)

--- a/plugin_tests/common.py
+++ b/plugin_tests/common.py
@@ -74,13 +74,14 @@ class LargeImageCommonTest(base.TestCase):
                     }])})
         self.assertStatusOk(resp)
 
-    def _uploadFile(self, path, name=None):
+    def _uploadFile(self, path, name=None, private=False):
         """
-        Upload the specified path to the admin user's public folder and return
-        the resulting item.
+        Upload the specified path to the admin user's public or private folder
+        and return the resulting item.
 
         :param path: path to upload.
         :param name: optional name for the file.
+        :param private: True to upload to the private folder, False for public.
         :returns: file: the created file.
         """
         if not name:
@@ -90,7 +91,7 @@ class LargeImageCommonTest(base.TestCase):
         resp = self.request(
             path='/file', method='POST', user=self.admin, params={
                 'parentType': 'folder',
-                'parentId': self.publicFolder['_id'],
+                'parentId': self.privateFolder['_id'] if private else self.publicFolder['_id'],
                 'name': name,
                 'size': len(data)
             })

--- a/server/rest/annotation.py
+++ b/server/rest/annotation.py
@@ -24,7 +24,7 @@ from girder.api import access
 from girder.api.describe import describeRoute, Description
 from girder.api.rest import Resource, loadmodel, filtermodel, RestException
 from girder.constants import AccessType, SortDir
-from girder.models.model_base import ValidationException
+from girder.models.model_base import AccessException, ValidationException
 from ..models.annotation import AnnotationSchema
 
 
@@ -242,10 +242,13 @@ class AnnotationResource(Resource):
             if annotation['itemId'] in imageIds:
                 continue
 
-            item = self.model('image_item', 'large_image').load(
-                annotation['itemId'], level=AccessType.READ,
-                user=user
-            )
+            try:
+                item = self.model('image_item', 'large_image').load(
+                    annotation['itemId'], level=AccessType.READ,
+                    user=user
+                )
+            except AccessException:
+                item = None
 
             # ignore if no such item exists
             if not item:


### PR DESCRIPTION
If a recent annotation is on an item that the current user doesn't have permission to read, an `AccessException` was thrown rather than just not including that item.  The ignore-exceptions flag for loading models only applies to `ValidationException`, not `AccessException`.