### PR TITLE
Add save and destroy methods to AnnotationModel

### DIFF
--- a/plugin_tests/client/annotationSpec.yml
+++ b/plugin_tests/client/annotationSpec.yml
@@ -1,0 +1,11 @@
+users:
+  - login: 'admin'
+    email: 'admin@email.com'
+    firstName: 'Admin'
+    lastName: 'Admin'
+    password: 'adminpassword!'
+    folders:
+      - name: 'Public'
+        public: true
+        items:
+          - name: 'Empty'


### PR DESCRIPTION
This will be used to simplify some of the logic in HistomicsTK related to managing annotations connected to images.