### PR TITLE
Unpin geojs verison.

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -9,7 +9,7 @@
     "npm": {
         "dependencies": {
             "hammerjs": "^2.0.8",
-            "geojs": "0.12.3",
+            "geojs": "^0.12.4",
             "slideatlas-viewer": "4.0.3",
             "sinon": "^2.1.0",
             "tinycolor2": "^1.4.1"


### PR DESCRIPTION
This allows the large_image plugin to work better with other Girder plugins that use geojs.