### PR TITLE
Fix annotation model save resetting elements

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -251,13 +251,24 @@ describe('Annotations', function () {
             }, 'Get an item id');
         });
 
-        it('create a new empty annotation', function () {
+        it('create a new annotation', function () {
             var model = new largeImage.models.AnnotationModel({itemId: item._id});
             var done;
 
-            model.save().done(function () {
+            model.elements().add({
+                center: [5, 5, 0],
+                height: 1,
+                rotation: 0,
+                type: 'rectangle',
+                width: 1
+            });
+
+            model.save().done(function (resp) {
                 expect(model.id).toBeDefined();
                 annotationId = model.id;
+                expect(resp.annotation).toBeDefined();
+                expect(resp.annotation.elements).toBeDefined();
+                expect(resp.annotation.elements.length).toBe(1);
                 done = true;
             }).fail(function (resp) {
                 console.error(resp);
@@ -297,7 +308,7 @@ describe('Annotations', function () {
             annotation.save().done(function (resp) {
                 expect(resp.annotation).toBeDefined();
                 expect(resp.annotation.elements).toBeDefined();
-                expect(resp.annotation.elements.length).toBe(1);
+                expect(resp.annotation.elements.length).toBe(2);
                 done = true;
             }).fail(function (resp) {
                 console.error(resp);

--- a/web_client/models/AnnotationModel.js
+++ b/web_client/models/AnnotationModel.js
@@ -88,7 +88,7 @@ export default Model.extend({
                 this.trigger('g:fetched');
             }
 
-            this._elements.reset(elements);
+            this._elements.reset(elements, _.extend({sync: true}, opts));
         }).fail((err) => {
             this.trigger('g:error', err);
         }).always(() => {

--- a/web_client/models/AnnotationModel.js
+++ b/web_client/models/AnnotationModel.js
@@ -143,6 +143,8 @@ export default Model.extend({
             processData: false,
             data: JSON.stringify(data)
         }).done((annotation) => {
+            // the elements array does not come back with this request
+            annotation.elements = (this.get('annotation') || {}).elements || [];
             this.set(annotation);
             this.trigger('sync', this, annotation, options);
         });


### PR DESCRIPTION
The annotation REST calls don't return the elements of the annotation, so the elements collection was being reset on every save.  This sets the elements property in the response before updating the model.