### PR TITLE
Add a method to delete an annotation without unbinding listeners

### DIFF
--- a/web_client/models/AnnotationModel.js
+++ b/web_client/models/AnnotationModel.js
@@ -157,17 +157,25 @@ export default Model.extend({
      * girder's base model either.
      */
     destroy(options) {
-        let xhr = false;
-
         this.stopListening();
         this.trigger('destroy', this, this.collection, options);
+        return this.delete(options);
+    },
 
+    /**
+     * Perform a DELETE request on the annotation model and reset the id
+     * attribute, but don't remove event listeners.
+     */
+    delete(options) {
+        this.trigger('g:delete', this, this.collection, options);
+        let xhr = false;
         if (!this.isNew()) {
             xhr = restRequest({
                 url: `annotation/${this.id}`,
                 method: 'DELETE'
             });
         }
+        this.unset('_id');
         return xhr;
     },
 


### PR DESCRIPTION
The backbone API for destroying models also removes all event listeners. To avoid regenerating an annotation model (and updating all views that listen to it), this adds a new public that performs the rest request but does not destroy the model object itself.  Very little code is changed here; it is mostly an additional test for the new public method.