### PR TITLE
Allow updating annotations without passing elements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -194,7 +194,9 @@ before_install:
 
 
 install:
-  - pip install --no-cache-dir -U -r $girder_path/requirements-dev.txt -e $girder_path
+  - pushd $girder_path
+  - pip install --no-cache-dir -U -r requirements-dev.txt -e .
+  - popd
   - girder-install plugin --symlink $large_image_path
   # Install all extras (since "girder-install plugin" does not provide a mechanism to specify them
   - pip install -e $large_image_path[memcached,openslide]

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -319,6 +319,23 @@ describe('Annotations', function () {
             }, 'annotation to save');
         });
 
+        it('update a paged annotation', function () {
+            var done;
+
+            annotation._pageElements = true;
+            annotation.save().done(function (resp) {
+                expect(resp.annotation).toBeDefined();
+                expect(resp.annotation.elements).not.toBeDefined();
+                done = true;
+            }).fail(function (resp) {
+                console.error(resp);
+            });
+
+            waitsFor(function () {
+                return done;
+            }, 'annotation to save');
+        });
+
         it('destroy an existing annotation', function () {
             var done, consoleError = console.error;
 
@@ -402,14 +419,6 @@ describe('Annotations', function () {
                 model.trigger('change');
                 expect(eventCalled).toBe(true);
             });
-        });
-
-        it('cannot save paged annotation', function () {
-            var model = new largeImage.models.AnnotationModel({_id: annotationId});
-            model._pageElements = true;
-            expect(function () {
-                model.save();
-            }).toThrow();
         });
 
         it('cannot create an annotation without an itemId', function () {

--- a/server/models/annotation.py
+++ b/server/models/annotation.py
@@ -17,6 +17,7 @@
 #  limitations under the License.
 ##############################################################################
 
+from bson import ObjectId
 import datetime
 import enum
 import jsonschema
@@ -631,6 +632,8 @@ class Annotation(Model):
             self.validatorAnnotation.validate(annot)
             lastValidatedElement = None
             for element in elements:
+                if isinstance(element.get('id'), ObjectId):
+                    element['id'] = str(element['id'])
                 if not self._similarElementStructure(element, lastValidatedElement):
                     self.validatorAnnotationElement.validate(element)
                     lastValidatedElement = element

--- a/web_client/models/AnnotationModel.js
+++ b/web_client/models/AnnotationModel.js
@@ -112,11 +112,6 @@ export default Model.extend({
         let url;
         let method;
 
-        // we don't want to override an annotation with a partial response
-        if (this._pageElements) {
-            throw new Error('Cannot save a paged annotation');
-        }
-
         if (this.isNew()) {
             if (!this.get('itemId')) {
                 throw new Error('itemId is required to save new annotations');
@@ -128,13 +123,22 @@ export default Model.extend({
             method = 'PUT';
         }
 
-        data.elements = _.map(data.elements, (element) => {
-            element = _.extend({}, element);
-            if (element.label && !element.label.value) {
-                delete element.label;
+        if (this._pageElements === false || this.isNew()) {
+            this._pageElements = false;
+            data.elements = _.map(data.elements, (element) => {
+                element = _.extend({}, element);
+                if (element.label && !element.label.value) {
+                    delete element.label;
+                }
+                return element;
+            });
+        } else {
+            delete data.elements;
+            // we don't want to override an annotation with a partial response
+            if (this._pageElements === true) {
+                console.warn('Cannot save elements of a paged annotation');
             }
-            return element;
-        });
+        }
 
         return restRequest({
             url,
@@ -202,7 +206,7 @@ export default Model.extend({
      * @param {number} maxZoom: the maximum zoom factor.
      */
     setView(bounds, zoom, maxZoom) {
-        if (this._pageElements === false || !this.get('_id')) {
+        if (this._pageElements === false || this.isNew()) {
             return;
         }
         var width = bounds.right - bounds.left,


### PR DESCRIPTION
For annotations with a large number of elements, it shouldn't be necessary to pass the elements just to change the annotation name or move it to another id.  This fixes the javascript model to allow updating the name of an annotation without requiring that all of the elements are loaded (also allowing changing the name of an annotation with paged elements).

Added tests for creating updating annotations.  Also, refactored the annotation tests to avoid uploading images in most cases; this speeds up the tests by 15 seconds or so on my local machine.