### PR TITLE
Fix style involving __all__.

### DIFF
--- a/server/tilesource/__init__.py
+++ b/server/tilesource/__init__.py
@@ -32,10 +32,15 @@ except ImportError:
 
 
 AvailableTileSources = collections.OrderedDict()
+# Create a partial function that will work through the known functions to get a
+# tile source.
+getTileSource = functools.partial(getTileSourceFromDict,
+                                  AvailableTileSources)
+
 __all__ = [
     'TileSource', 'TileSourceException', 'TileSourceAssetstoreException',
     'AvailableTileSources', 'TileOutputMimeTypes', 'TILE_FORMAT_IMAGE',
-    'TILE_FORMAT_PIL', 'TILE_FORMAT_NUMPY']  # noqa
+    'TILE_FORMAT_PIL', 'TILE_FORMAT_NUMPY', 'getTileSource']
 
 if girder:
     __all__.append('GirderTileSource')
@@ -51,6 +56,7 @@ sourceList = [
     {'moduleName': '.test', 'className': 'TestTileSource'},
     {'moduleName': '.dummy', 'className': 'DummyTileSource'},
 ]
+
 for source in sourceList:
     try:
         # Don't try to load girder sources if we couldn't import girder
@@ -73,9 +79,3 @@ for source in sourceList:
             AvailableTileSources[sourceClass.name] = sourceClass
     except (ImportError, OSError):
         logprint.info('Notice: Could not import %s' % className)
-
-# Create a partial function that will work through the known functions to get a
-# tile source.
-getTileSource = functools.partial(getTileSourceFromDict,
-                                  AvailableTileSources)
-__all__.append('getTileSource')


### PR DESCRIPTION
With updates to flake8, the dynamically generated `__all__` reference can pass style tests if it is restructured so that the partial function is defined before `__all__`.