### PR TITLE
Add a better failure condition for libtiff.

### DIFF
--- a/plugin_tests/import_test.py
+++ b/plugin_tests/import_test.py
@@ -43,6 +43,9 @@ def tearDownModule():
 
 class LargeImageTilesTest(base.TestCase):
     def testImportErrors(self):
+        from libtiff import libtiff_ctypes
+        tiff_h_name = libtiff_ctypes.tiff_h_name
+
         # Temporarily remove third-party dependencies
         for key in ['openslide', 'PIL', 'libtiff']:
             sys.modules[key] = None
@@ -60,6 +63,19 @@ class LargeImageTilesTest(base.TestCase):
             self.assertIn('libtiff', exc.args[0])
         else:
             self.fail()
+
+        del sys.modules['libtiff']
+        del sys.modules['libtiff.libtiff_ctypes']
+        sys.modules['libtiff.' + tiff_h_name] = None
+        try:
+            reload_module(girder.plugins.large_image.tilesource.tiff_reader)
+        except ImportError as exc:
+            self.assertIn('libtiff', exc.args[0])
+        else:
+            self.fail()
+        del sys.modules['libtiff.' + tiff_h_name]
+        reload_module(girder.plugins.large_image.tilesource.tiff_reader)
+
         try:
             reload_module(girder.plugins.large_image.tilesource.svs)
         except ImportError as exc:

--- a/plugin_tests/import_test.py
+++ b/plugin_tests/import_test.py
@@ -64,6 +64,9 @@ class LargeImageTilesTest(base.TestCase):
         else:
             self.fail()
 
+        # Test that we handle a missing libtiff header module and file in a
+        # graceful manner.  This makes it appear that no such module is
+        # available, and checks that we get the expected ImportError.
         del sys.modules['libtiff']
         del sys.modules['libtiff.libtiff_ctypes']
         sys.modules['libtiff.' + tiff_h_name] = None

--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -69,7 +69,7 @@ class TiffFileTileSource(FileTileSource):
         # Query all know directories in the tif file.  Only keep track of
         # directories that contain tiled images.
         alldir = []
-        for directoryNum in itertools.count():
+        for directoryNum in itertools.count():  # pragma: no branch
             try:
                 td = TiledTiffDirectory(largeImagePath, directoryNum)
             except ValidationTiffException as exc:

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -34,6 +34,13 @@ except ImportError:
 try:
     from libtiff import libtiff_ctypes
 except ValueError as exc:
+    # If the python libtiff module doesn't contain a pregenerated module for
+    # the appropriate version of libtiff, it tries to generate a module from
+    # the libtiff header file.  If it can't find this file (possibly because it
+    # is in a virtual environment), it raises a ValueError instead of an
+    # ImportError.  We convert this to an ImportError, so that we will print a
+    # more lucid error message and just fail to load this one tile source
+    # instead of failing to load the whole plugin.
     logger.warn('Failed to import libtiff; try upgrading the python module (%s)' % exc)
     raise ImportError(str(exc))
 try:

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -34,8 +34,8 @@ except ImportError:
 try:
     from libtiff import libtiff_ctypes
 except ValueError as exc:
-    logger.warn('Failed to import libtiff; try upgrading the python module (%r)' % exc.message)
-    raise ImportError(exc.message)
+    logger.warn('Failed to import libtiff; try upgrading the python module (%s)' % exc)
+    raise ImportError(str(exc))
 try:
     import PIL.Image
 except ImportError:

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -22,7 +22,6 @@ import os
 import six
 
 from functools import partial
-from libtiff import libtiff_ctypes
 from xml.etree import cElementTree
 
 from ..cache_util import LRUCache, strhash, methodcache
@@ -32,6 +31,11 @@ try:
 except ImportError:
     import logging as logger
     logger.getLogger().setLevel(logger.INFO)
+try:
+    from libtiff import libtiff_ctypes
+except ValueError as exc:
+    logger.warn('Failed to import libtiff; try upgrading the python module (%r)' % exc.message)
+    raise ImportError(exc.message)
 try:
     import PIL.Image
 except ImportError:


### PR DESCRIPTION
When the version of libtiff doesn't match a known version in the python libtiff module and large_image is in a virtual environment, the tiff tile source throws a ValueError instead of an ImportError.  Switch to an ImportError and log a message to help resolve the problem.