### PR TITLE
Add access control lists to the annotation model

### DIFF
--- a/plugin_tests/annotations_test.py
+++ b/plugin_tests/annotations_test.py
@@ -30,7 +30,7 @@ from six.moves import range
 
 from girder import config
 from girder.constants import AccessType
-from girder.exceptions import AccessException
+from girder.exceptions import AccessException, ValidationException
 from girder.models.item import Item
 
 from tests import base
@@ -679,6 +679,13 @@ class LargeImageAnnotationAccessMigrationTest(common.LargeImageCommonTest):
 
         self.assertEqual(annot['access'], self.publicFolder['access'])
         self.assertEqual(annot['public'], True)
+
+    def testLoadAnnotationWithCoreKWArgs(self):
+        from girder.plugins.large_image.models.annotation import Annotation
+
+        # try to load a non-existing annotation
+        with self.assertRaises(ValidationException):
+            Annotation().load(ObjectId(), user=self.admin, exc=True)
 
     def testMigrateAnnotationAccessControlNoItemError(self):
         from girder.plugins.large_image.models.annotation import Annotation

--- a/server/models/annotation.py
+++ b/server/models/annotation.py
@@ -30,7 +30,10 @@ from girder import events
 from girder import logger
 from girder.constants import AccessType
 from girder.exceptions import ValidationException
-from girder.models.model_base import Model
+from girder.models.folder import Folder
+from girder.models.item import Item
+from girder.models.model_base import AccessControlledModel
+from girder.models.user import User
 
 from .annotationelement import Annotationelement
 
@@ -355,7 +358,7 @@ class AnnotationSchema:
     }
 
 
-class Annotation(Model):
+class Annotation(AccessControlledModel):
     """
     This model is used to represent an annotation that is associated with an
     item.  The annotation can contain any number of annotationelements, which
@@ -385,6 +388,8 @@ class Annotation(Model):
         'created',
         'updated',
         'updatedId',
+        'public',
+        'publicFlags'
         # 'skill',
         # 'startTime'
         # 'stopTime'
@@ -399,7 +404,7 @@ class Annotation(Model):
         })
 
         self.exposeFields(AccessType.READ, (
-            'annotation', '_version', '_elementQuery',
+            'annotation', '_version', '_elementQuery'
         ) + self.baseFields)
         events.bind('model.item.remove', 'large_image', self._onItemRemove)
 
@@ -414,7 +419,45 @@ class Annotation(Model):
         for annotation in annotations:
             Annotation().remove(annotation)
 
-    def createAnnotation(self, item, creator, annotation):
+    def _migrateACL(self, annotation):
+        """
+        Add access control information to an annotation model.
+
+        Originally annotation models were not access controlled.  This function performs
+        the migration for annotations created before this change was made.  The access
+        object is copied from the folder containing the image the annotation is attached
+        to.   In addition, the creator is given admin access.
+        """
+        if 'access' in annotation:
+            return
+
+        item = Item().load(annotation['itemId'], force=True)
+        if item is None:
+            logger.warning(
+                'Could not generate annotation ACL due to missing item %s', annotation['_id'])
+            return
+
+        folder = Folder().load(item['folderId'], force=True)
+        if folder is None:
+            logger.warning(
+                'Could not generate annotation ACL due to missing folder %s', annotation['_id'])
+            return
+
+        user = User().load(annotation['creatorId'], force=True)
+        if user is None:
+            logger.warning(
+                'Could not generate annotation ACL %s due to missing user %s', annotation['_id'])
+            return
+
+        self.copyAccessPolicies(item, annotation, save=False)
+        self.setUserAccess(annotation, user, AccessType.ADMIN, force=True, save=False)
+        self.setPublic(annotation, folder.get('public'), save=False)
+
+        # call the super class save method to avoid messing with elements
+        super(Annotation, self).save(annotation)
+        logger.info('Generated annotation ACL for %s', annotation['_id'])
+
+    def createAnnotation(self, item, creator, annotation, public=None):
         now = datetime.datetime.utcnow()
         doc = {
             'itemId': item['_id'],
@@ -424,6 +467,18 @@ class Annotation(Model):
             'updated': now,
             'annotation': annotation,
         }
+
+        # copy access control from the folder containing the image
+        folder = Folder().load(item['folderId'], force=True)
+        self.copyAccessPolicies(src=folder, dest=doc, save=False)
+
+        if public is None:
+            public = folder.get('public', False)
+        self.setPublic(doc, public, save=False)
+
+        # give the current user admin access
+        self.setUserAccess(doc, user=creator, level=AccessType.ADMIN, save=False)
+
         return self.save(doc)
 
     def load(self, id, region=None, getElements=True, *args, **kwargs):
@@ -436,8 +491,21 @@ class Annotation(Model):
             annotation.
         :returns: the matching annotation or none.
         """
+        force = kwargs.pop('force', False)
+        kwargs['force'] = True
         annotation = super(Annotation, self).load(id, *args, **kwargs)
-        if annotation is not None and getElements:
+
+        if annotation is None:
+            return
+
+        self._migrateACL(annotation)
+
+        if not force:
+            self.requireAccess(
+                annotation, kwargs.get('user'), kwargs.get('level', AccessType.ADMIN)
+            )
+
+        if getElements:
             # It is possible that we are trying to read the elements of an
             # annotation as another thread is updating them.  In this case,
             # there is a chance, that between when we get the annotation and

--- a/server/models/annotation.py
+++ b/server/models/annotation.py
@@ -491,16 +491,14 @@ class Annotation(AccessControlledModel):
             annotation.
         :returns: the matching annotation or none.
         """
-        force = kwargs.pop('force', False)
-        kwargs['force'] = True
-        annotation = super(Annotation, self).load(id, *args, **kwargs)
+        annotation = super(Annotation, self).load(id, force=True)
 
         if annotation is None:
             return
 
         self._migrateACL(annotation)
 
-        if not force:
+        if not kwargs.get('force'):
             self.requireAccess(
                 annotation, kwargs.get('user'), kwargs.get('level', AccessType.ADMIN)
             )

--- a/server/rest/annotation.py
+++ b/server/rest/annotation.py
@@ -138,6 +138,8 @@ class AnnotationResource(Resource):
     def getAnnotation(self, id, params):
         user = self.getCurrentUser()
         annotation = Annotation().load(id, region=params, user=user, level=AccessType.READ)
+        if annotation is None:
+            raise RestException('Annotation not found', 404)
         # Ensure that we have read access to the parent item.  We could fail
         # faster when there are permissions issues if we didn't load the
         # annotation elements before checking the item access permissions.

--- a/server/rest/annotation.py
+++ b/server/rest/annotation.py
@@ -17,6 +17,8 @@
 #  limitations under the License.
 ##############################################################################
 
+import json
+
 import cherrypy
 
 from girder import logger
@@ -45,6 +47,8 @@ class AnnotationResource(Resource):
         self.route('POST', (':id', 'copy'), self.copyAnnotation)
         self.route('PUT', (':id',), self.updateAnnotation)
         self.route('DELETE', (':id',), self.deleteAnnotation)
+        self.route('GET', (':id', 'access'), self.getAnnotationAccess)
+        self.route('PUT', (':id', 'access'), self.updateAnnotationAccess)
 
     @describeRoute(
         Description('Search for annotations.')
@@ -79,10 +83,12 @@ class AnnotationResource(Resource):
             query['$text'] = {'$search': params['text']}
         if params.get('name'):
             query['annotation.name'] = params['name']
-        fields = list(('annotation.name', 'annotation.description') +
+        fields = list(('annotation.name', 'annotation.description', 'access') +
                       Annotation().baseFields)
-        return list(Annotation().find(
-            query, limit=limit, offset=offset, sort=sort, fields=fields))
+        return list(Annotation().filterResultsByPermission(
+            cursor=Annotation().find(query, sort=sort, fields=fields),
+            user=self.getCurrentUser(), level=AccessType.READ, limit=limit, offset=offset
+        ))
 
     @describeRoute(
         Description('Get the official Annotation schema')
@@ -130,13 +136,11 @@ class AnnotationResource(Resource):
     @access.public
     @filtermodel(model='annotation', plugin='large_image')
     def getAnnotation(self, id, params):
-        annotation = Annotation().load(id, region=params)
+        user = self.getCurrentUser()
+        annotation = Annotation().load(id, region=params, user=user, level=AccessType.READ)
         # Ensure that we have read access to the parent item.  We could fail
         # faster when there are permissions issues if we didn't load the
         # annotation elements before checking the item access permissions.
-        item = Item().load(annotation.get('itemId'), force=True)
-        Item().requireAccess(
-            item, user=self.getCurrentUser(), level=AccessType.READ)
         return annotation
 
     @describeRoute(
@@ -173,7 +177,7 @@ class AnnotationResource(Resource):
         .errorResponse('Write access was denied for the item.', 403)
     )
     @access.user
-    @loadmodel(model='annotation', plugin='large_image')
+    @loadmodel(model='annotation', plugin='large_image', level=AccessType.READ)
     @filtermodel(model='annotation', plugin='large_image')
     def copyAnnotation(self, annotation, params):
         itemId = params['itemId']
@@ -199,7 +203,7 @@ class AnnotationResource(Resource):
         .errorResponse('Validation Error: JSON doesn\'t follow schema.')
     )
     @access.user
-    @loadmodel(model='annotation', plugin='large_image')
+    @loadmodel(model='annotation', plugin='large_image', level=AccessType.WRITE)
     @filtermodel(model='annotation', plugin='large_image')
     def updateAnnotation(self, annotation, params):
         user = self.getCurrentUser()
@@ -241,7 +245,7 @@ class AnnotationResource(Resource):
     )
     @access.user
     # Load with a limit of 1 so that we don't bother getting most annotations
-    @loadmodel(model='annotation', plugin='large_image', getElements=False)
+    @loadmodel(model='annotation', plugin='large_image', getElements=False, level=AccessType.WRITE)
     def deleteAnnotation(self, annotation, params):
         # Ensure that we have write access to the parent item
         item = Item().load(annotation.get('itemId'), force=True)
@@ -295,3 +299,29 @@ class AnnotationResource(Resource):
                 break
 
         return response
+
+    @describeRoute(
+        Description('Get the access control list for an annotation.')
+        .param('id', 'The ID of the annotation.', paramType='path')
+        .errorResponse('ID was invalid.')
+        .errorResponse('Admin access was denied for the annotation.', 403)
+    )
+    @access.user
+    @loadmodel(model='annotation', plugin='large_image', level=AccessType.ADMIN)
+    def getAnnotationAccess(self, annotation, params):
+        return Annotation().getFullAccessList(annotation)
+
+    @describeRoute(
+        Description('Update the access control list for an annotation.')
+        .param('id', 'The ID of the annotation.', paramType='path')
+        .param('access', 'THe JSON-encoded access control list.')
+        .errorResponse('ID was invalid.')
+        .errorResponse('Admin access was denied for the annotation.', 403)
+    )
+    @access.user
+    @loadmodel(model='annotation', plugin='large_image', level=AccessType.ADMIN)
+    @filtermodel(model=Annotation, addFields={'access'})
+    def updateAnnotationAccess(self, annotation, params):
+        access = json.loads(params['access'])
+        return Annotation().setAccessList(
+            annotation, access, save=True, user=self.getCurrentUser())


### PR DESCRIPTION
This changes the super class of the annotation model from `Model` to `AccessControlledModel`.  It will allow us to use all of the access control functionality of Girder's permission model for annotations instead of coding ad hoc implementations as needed.  The main backwards incompatible change here is that the `load` method now does permission checking.

There is a schema migration that occurs on load.  It will generate an access control list identical to the folder containing the item the annotation is attached to plus it will give the annotation creator admin access.  I believe this will allow a smooth migration for annotations that currently exist (in HistomicsTK at least).