### PR TITLE
Adjust file references when copying a large image.

### DIFF
--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -1300,3 +1300,16 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
                             user=self.admin)
         self.assertStatusOk(resp)
         self.assertEqual(resp.json, None)
+
+    def testTilesAfterCopyItem(self):
+        file = self._uploadFile(os.path.join(
+            os.path.dirname(__file__), 'test_files', 'yb10kx5k.png'))
+        itemId = str(file['itemId'])
+        fileId = str(file['_id'])
+        tileMetadata = self._postTileViaHttp(itemId, fileId)
+        self._testTilesZXY(itemId, tileMetadata)
+        item = Item().load(itemId, force=True)
+        newItem = Item().copyItem(item, self.admin)
+        self.assertNotEqual(item['largeImage']['fileId'], newItem['largeImage']['fileId'])
+        Item().remove(item)
+        self._testTilesZXY(str(newItem['_id']), tileMetadata)

--- a/server/base.py
+++ b/server/base.py
@@ -145,6 +145,37 @@ def removeThumbnails(event):
     ImageItem().removeThumbnailFiles(event.info)
 
 
+def prepareCopyItem(event):
+    """
+    When copying an item, adjust the largeImage fileId reference so it can be
+    matched to the to-be-copied file.
+    """
+    srcItem, newItem = event.info
+    if 'largeImage' in newItem:
+        li = newItem['largeImage']
+        for pos, file in enumerate(Item().childFiles(item=srcItem)):
+            for key in ('fileId', 'originalId'):
+                if li[key] == file['_id']:
+                    li['_index_' + key] = pos
+        Item().save(newItem, triggerEvents=False)
+
+
+def handleCopyItem(event):
+    """
+    When copying an item, finish adjusting the largeImage fileId reference to
+    the copied file.
+    """
+    newItem = event.info
+    if 'largeImage' in newItem:
+        li = newItem['largeImage']
+        files = list(Item().childFiles(item=newItem))
+        for key in ('fileId', 'originalId'):
+            pos = li.pop('_index_' + key, None)
+            if pos is not None and 0 <= pos < len(files):
+                li[key] = files[pos]['_id']
+        Item().save(newItem, triggerEvents=False)
+
+
 # Validators
 
 @setting_utilities.validator({
@@ -243,6 +274,8 @@ def load(info):
     events.bind('model.group.save.after', 'large_image',
                 invalidateLoadModelCache)
     events.bind('model.item.remove', 'large_image', invalidateLoadModelCache)
+    events.bind('model.item.copy.prepare', 'large_image', prepareCopyItem)
+    events.bind('model.item.copy.after', 'large_image', handleCopyItem)
     events.bind('model.item.save.after', 'large_image',
                 invalidateLoadModelCache)
     events.bind('model.file.save.after', 'large_image',

--- a/server/base.py
+++ b/server/base.py
@@ -155,7 +155,7 @@ def prepareCopyItem(event):
         li = newItem['largeImage']
         for pos, file in enumerate(Item().childFiles(item=srcItem)):
             for key in ('fileId', 'originalId'):
-                if li[key] == file['_id']:
+                if li.get(key) == file['_id']:
                     li['_index_' + key] = pos
         Item().save(newItem, triggerEvents=False)
 


### PR DESCRIPTION
When an item is copied, the `item['largeImage']['fileId']` reference still referred to the file in the original item.

Fixes #245.