### PR TITLE
Add annotation history.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ before_install:
   - sudo rm -f /etc/boto.cfg
 
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then export PY3="true"; else export PY2="true"; fi
-  - if [ -n "${PY3}" ]; then export MONGO_VERSION=3.6.1; export PY_COVG="OFF"; else export MONGO_VERSION=3.2.18; export PY_COVG="ON"; export DEPLOY=true; fi
+  - if [ -n "${PY3}" ]; then export MONGO_VERSION=3.6.2; export PY_COVG="OFF"; else export MONGO_VERSION=3.4.10; export PY_COVG="ON"; export DEPLOY=true; fi
   - GIRDER_VERSION=2.x-maintenance
   - GIRDER_WORKER_VERSION=master
 
@@ -195,7 +195,6 @@ before_install:
     pip install --no-cache-dir -U $girder_worker_path'[girder_io]' ;
     fi
 
-  - export MONGO_VERSION=3.0.7
   - export PY_COVG="ON"
   - CACHE=$HOME/.cache source $girder_path/scripts/install_mongo.sh
   - mkdir /tmp/db

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,9 @@ A Girder plugin to create, serve, and display large multiresolution images.
 Upload image files to Girder. If they are not already in a tiled-format, they can be converted to
 tiled images. The plugin has a variety of viewers to examine the images.
 
+Note that some features will not be available unless MongoDB version 3.4 or 
+later is used for Girder's database.
+
 
 As a stand-alone Python module
 ------------------------------

--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -337,7 +337,7 @@ describe('Annotations', function () {
         });
 
         it('destroy an existing annotation', function () {
-            var done, consoleError = console.error;
+            var done;
 
             annotation.destroy().done(function () {
                 done = true;
@@ -350,27 +350,24 @@ describe('Annotations', function () {
 
             runs(function () {
                 // silence rest request error message
-                console.error = function () {};
-
                 done = false;
                 annotation = new largeImage.models.AnnotationModel({_id: annotationId});
                 annotation.fetch().done(function () {
-                    console.error = consoleError;
-                    console.error('Expected fetch on deleted annotation to fail');
-                }).fail(function () {
-                    console.error = consoleError;
+                    expect(annotation.get('_active')).toBe(false);
                     done = true;
+                }).fail(function (resp) {
+                    console.error(resp);
                 });
             });
             waitsFor(function () {
                 return done;
-            }, 'fetch to fail');
+            }, 'fetch to get an inactive annotation');
         });
 
         it('delete an annotation without unbinding events', function () {
             var model = new largeImage.models.AnnotationModel({itemId: item._id});
             var id;
-            var done, consoleError = console.error;
+            var done;
             var eventCalled;
 
             model.listenTo(model, 'change', function () { eventCalled = true; });
@@ -397,23 +394,19 @@ describe('Annotations', function () {
             runs(function () {
                 var model2;
 
-                // silence rest request error message
-                console.error = function () {};
-
                 done = false;
                 model2 = new largeImage.models.AnnotationModel({_id: id});
                 model2.fetch().done(function () {
-                    console.error = consoleError;
-                    console.error('Expected fetch on deleted annotation to fail');
-                }).fail(function () {
-                    console.error = consoleError;
+                    expect(annotation.get('_active')).toBe(false);
                     done = true;
+                }).fail(function (resp) {
+                    console.error(resp);
                 });
             });
 
             waitsFor(function () {
                 return done;
-            }, 'fetch to fail');
+            }, 'fetch to return an inactive annotation');
             runs(function () {
                 eventCalled = false;
                 model.trigger('change');

--- a/server/base.py
+++ b/server/base.py
@@ -151,6 +151,7 @@ def removeThumbnails(event):
     constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
     constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
     constants.PluginSettings.LARGE_IMAGE_AUTO_SET,
+    constants.PluginSettings.LARGE_IMAGE_ANNOTATION_HISTORY,
 })
 def validateBoolean(doc):
     val = doc['value']
@@ -212,6 +213,7 @@ SettingDefault.defaults.update({
     constants.PluginSettings.LARGE_IMAGE_AUTO_SET: True,
     constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES: 10,
     constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE: 4096,
+    constants.PluginSettings.LARGE_IMAGE_ANNOTATION_HISTORY: True,
 })
 
 
@@ -231,7 +233,7 @@ def load(info):
     info['apiRoot'].annotation = AnnotationResource()
 
     Item().exposeFields(level=AccessType.READ, fields='largeImage')
-    # Ask for the annotation model to make sure it is initialized.
+    # Ask for some models to make sure their singletons are initialized.
     Annotation()
 
     events.bind('data.process', 'large_image', _postUpload)

--- a/server/constants.py
+++ b/server/constants.py
@@ -28,3 +28,4 @@ class PluginSettings:
     LARGE_IMAGE_AUTO_SET = 'large_image.auto_set'
     LARGE_IMAGE_MAX_THUMBNAIL_FILES = 'large_image.max_thumbnail_files'
     LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE = 'large_image.max_small_image_size'
+    LARGE_IMAGE_ANNOTATION_HISTORY = 'large_image.annotation_history'

--- a/server/models/annotation.py
+++ b/server/models/annotation.py
@@ -601,14 +601,10 @@ class Annotation(AccessControlledModel):
 
             with self._writeLock:
                 self.collection.delete_one = deleteElements
-                exc = None
                 try:
                     result = super(Annotation, self).remove(annotation, *args, **kwargs)
-                except Exception as e:
-                    exc = e
-                self.collection.delete_one = delete_one
-                if exc:
-                    raise exc
+                finally:
+                    self.collection.delete_one = delete_one
         return result
 
     def save(self, annotation, *args, **kwargs):
@@ -682,15 +678,11 @@ class Annotation(AccessControlledModel):
         with self._writeLock:
             self.collection.replace_one = replaceElements
             self.collection.insert_one = insertElements
-            exc = None
             try:
                 result = super(Annotation, self).save(annotation, *args, **kwargs)
-            except Exception as e:
-                exc = e
-            self.collection.replace_one = replace_one
-            self.collection.insert_one = insert_one
-            if exc:
-                raise exc
+            finally:
+                self.collection.replace_one = replace_one
+                self.collection.insert_one = insert_one
         if _elementQuery:
             result['_elementQuery'] = _elementQuery
         logger.debug('Saved annotation in %5.3fs' % (time.time() - starttime))

--- a/server/models/annotationelement.py
+++ b/server/models/annotationelement.py
@@ -117,7 +117,7 @@ class Annotationelement(Model):
         """
         region = region or {}
         query = {
-            'annotationId': annotation['_id'],
+            'annotationId': annotation.get('_annotationId', annotation['_id']),
             '_version': annotation['_version']
         }
         for key in region:

--- a/web_client/templates/largeImageConfig.pug
+++ b/web_client/templates/largeImageConfig.pug
@@ -65,5 +65,16 @@ form#g-large-image-form(role="form")
       | Caching files speeds up thumbnail retrieval but takes some storage space.  Use 0 to not cache thumbnails as files.
     input.input-sm.form-control.g-large-image-max-thumbnail-files(
       type="text", value=settings['large_image.max_thumbnail_files'], placeholder="Use 0 to not cache thumbnails as files.")
+  .form-group
+    label Store annotation history
+    p.g-large-image-description
+      | Whenever annotations are saved, a record of the annotation can be stored in a separate database collection.
+    .g-large-image-annotation-history-container
+      label.radio-inline
+        input.g-large-image-annotation-history-show(type="radio", name="g-large-image-annotation-history", checked=settings['large_image.annotation_history'] !== false ? 'checked': undefined)
+        | Record annotation history
+      label.radio-inline
+        input.g-large-image-annotation-history-hide(type="radio", name="g-large-image-annotation-history", checked=settings['large_image.annotation_history'] !== false ? undefined : 'checked')
+        | Don't store history
   p#g-large-image-error-message.g-validation-failed-message
   input.btn.btn-sm.btn-primary(type="submit", value="Save")

--- a/web_client/templates/largeImageConfig.pug
+++ b/web_client/templates/largeImageConfig.pug
@@ -68,7 +68,7 @@ form#g-large-image-form(role="form")
   .form-group
     label Store annotation history
     p.g-large-image-description
-      | Whenever annotations are saved, a record of the annotation can be stored in a separate database collection.
+      | Whenever annotations are saved, a record of the annotation's previous state can be kept.
     .g-large-image-annotation-history-container
       label.radio-inline
         input.g-large-image-annotation-history-show(type="radio", name="g-large-image-annotation-history", checked=settings['large_image.annotation_history'] !== false ? 'checked': undefined)

--- a/web_client/views/configView.js
+++ b/web_client/views/configView.js
@@ -39,6 +39,9 @@ var ConfigView = View.extend({
             }, {
                 key: 'large_image.show_extra_admin',
                 value: this.$('.g-large-image-show-extra-admin').val()
+            }, {
+                key: 'large_image.annotation_history',
+                value: this.$('.g-large-image-annotation-history-show').prop('checked')
             }]);
         }
     },
@@ -130,7 +133,20 @@ var ConfigView = View.extend({
         if (!ConfigView.settings) {
             restRequest({
                 type: 'GET',
-                url: 'large_image/settings'
+                // use the system/settings endpoints, because we need some
+                // admin-only settings
+                url: 'system/setting',
+                data: {list: JSON.stringify([
+                    'large_image.show_thumbnails',
+                    'large_image.show_extra',
+                    'large_image.show_extra_admin',
+                    'large_image.show_viewer',
+                    'large_image.default_viewer',
+                    'large_image.auto_set',
+                    'large_image.max_thumbnail_files',
+                    'large_image.max_small_image_size',
+                    'large_image.annotation_history'
+                ])}
             }).done((resp) => {
                 ConfigView.settings = resp;
                 if (callback) {


### PR DESCRIPTION
This exposes a setting on the plugin settings page to toggle whether history is saved.  It defaults to on.

If history is turned on, old versions of annotations are maintained in the annotation and annotationelement mongo collections.  There is a strictly monotonic version number for all annotations. 
 When an annotation is updated, the old elements are retained, and the old version of the annotation is saved with an _active=false marker.  These old versions have an _annotationId to reference the original annotation.

Historic versions can be listed via a new endpoint.  Historic versions can be fetched via the original annotation id and version number or via the historic record _id (all with appropriate user level authentication).  A revert endpoint allows switching to previous versions of an annotation.