### PR TITLE
Add a getPixel method and rest endpoint.

### DIFF
--- a/plugin_tests/sources_test.py
+++ b/plugin_tests/sources_test.py
@@ -521,9 +521,15 @@ class LargeImageSourcesTest(common.LargeImageCommonTest):
         self.assertAlmostEqual(targetRegion['width'], 4.6411, places=3)
         self.assertAlmostEqual(targetRegion['height'], 4.0857, places=3)
         self.assertEqual(targetRegion['units'], 'mm')
-        with six.assertRaisesRegex(self, ValueError, 'No mm_x'):
-            source.convertRegionScale(
-                sourceRegion, sourceScale, None, targetUnits='mm')
+
+        targetRegion = source.convertRegionScale(
+            sourceRegion, sourceScale, None, targetUnits='mm')
+        self.assertAlmostEqual(targetRegion['width'], 4.6411, places=3)
+        self.assertAlmostEqual(targetRegion['height'], 4.0857, places=3)
+        self.assertEqual(targetRegion['units'], 'mm')
+        # with six.assertRaisesRegex(self, ValueError, 'No mm_x'):
+        #     source.convertRegionScale(
+        #         sourceRegion, sourceScale, None, targetUnits='mm')
 
         targetRegion = source.convertRegionScale(
             sourceRegion, sourceScale, targetScale, targetUnits='pixels')
@@ -575,7 +581,6 @@ class LargeImageSourcesTest(common.LargeImageCommonTest):
             (500000, 800), {'magnification': 5}, 'mag_pixels',
             {'magnification': 20}, 'mag_pixels')
         self.assertEqual(point, (2000000.0, 3200.0))
-        # ##DWM::
 
     def testGetSingleTile(self):
         from girder.plugins.large_image.models.image_item import ImageItem
@@ -621,3 +626,28 @@ class LargeImageSourcesTest(common.LargeImageCommonTest):
         self.assertEqual(tile['iterator_range']['region_x_max'], 11)
         self.assertEqual(tile['iterator_range']['region_y_max'], 3)
         self.assertEqual(tile['iterator_range']['position'], 33)
+
+    def testGetPixel(self):
+        from girder.plugins.large_image.models.image_item import ImageItem
+
+        file = self._uploadFile(os.path.join(
+            os.environ['LARGE_IMAGE_DATA'], 'sample_jp2k_33003_TCGA-CV-7242-'
+            '11A-01-TS1.1838afb1-9eee-4a70-9ae3-50e3ab45e242.svs'))
+        itemId = str(file['itemId'])
+        item = Item().load(itemId, user=self.admin)
+        source = ImageItem().tileSource(item)
+
+        pixel = source.getPixel(region={'left': 12125, 'top': 10640})
+        self.assertEqual(pixel, {'r': 156, 'g': 98, 'b': 138, 'a': 255})
+
+        pixel = source.getPixel(region={'left': 3.0555, 'top': 2.68128, 'units': 'mm'})
+        self.assertEqual(pixel, {'r': 156, 'g': 98, 'b': 138, 'a': 255})
+
+        pixel = source.getPixel(region={'top': 10640, 'right': 12126, 'bottom': 12000})
+        self.assertEqual(pixel, {'r': 156, 'g': 98, 'b': 138, 'a': 255})
+
+        pixel = source.getPixel(region={'left': 12125, 'top': 10640, 'right': 13000})
+        self.assertEqual(pixel, {'r': 156, 'g': 98, 'b': 138, 'a': 255})
+
+        pixel = source.getPixel(region={'left': 12125, 'top': 10640}, includeTileRecord=True)
+        self.assertIn('tile', pixel)

--- a/server/cache_util/cache.py
+++ b/server/cache_util/cache.py
@@ -91,6 +91,8 @@ def methodcache(key=None):
         @six.wraps(func)
         def wrapper(self, *args, **kwargs):
             k = key(*args, **kwargs) if key else self.wrapKey(*args, **kwargs)
+            if hasattr(self, '_classkey'):
+                k = self._classkey + ' ' + k
             lock = getattr(self, 'cache_lock', None)
             try:
                 if lock:
@@ -180,6 +182,7 @@ class LruCacheMetaclass(type):
             except KeyError:
                 instance = super(LruCacheMetaclass, cls).__call__(*args, **kwargs)
                 cache[key] = instance
+                instance._classkey = key
 
         return instance
 

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -361,6 +361,18 @@ class ImageItem(Item):
         regionData, regionMime = tileSource.getRegion(**kwargs)
         return regionData, regionMime
 
+    def getPixel(self, item, **kwargs):
+        """
+        Using a tile source, get a single pixel from the image.
+
+        :param item: the item with the tile source.
+        :param **kwargs: optional arguments.  Some options are left, top.
+        :returns: a dictionary of the color channel values, possibly with
+            additional information
+        """
+        tileSource = self._loadTileSource(item, **kwargs)
+        return tileSource.getPixel(**kwargs)
+
     def tileSource(self, item, **kwargs):
         """
         Get a tile source for an item.


### PR DESCRIPTION
Internally, `getRegion` can now specify width and height in different units than the edges of a region.  This allows a 1-pixel square region to be specified with the left and top specified via non-pixel units. 
 `getPixel` gets a 1x1 pixel region and returns a tuple of the channel values as an object.  Subclasses of the tile source can augment this with additional information (such as band data).

For the mapnik source, this also returns band information at the pixel.

Also, the generated hash key for methods in cached classes now includes the class hash key.  Without this change, either the methodcache decorators need more parameters or a change in the source may use a cached tile (for instance, just changing the mapnik/gdal style).