### PR TITLE
Allow all settings to be fetched.

### DIFF
--- a/server/rest/large_image.py
+++ b/server/rest/large_image.py
@@ -132,6 +132,7 @@ class LargeImageResource(Resource):
             constants.PluginSettings.LARGE_IMAGE_AUTO_SET,
             constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES,
             constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE,
+            constants.PluginSettings.LARGE_IMAGE_ANNOTATION_HISTORY,
         ]
         return {k: Setting().get(k) for k in keys}
 

--- a/web_client/views/configView.js
+++ b/web_client/views/configView.js
@@ -133,20 +133,7 @@ var ConfigView = View.extend({
         if (!ConfigView.settings) {
             restRequest({
                 type: 'GET',
-                // use the system/settings endpoints, because we need some
-                // admin-only settings
-                url: 'system/setting',
-                data: {list: JSON.stringify([
-                    'large_image.show_thumbnails',
-                    'large_image.show_extra',
-                    'large_image.show_extra_admin',
-                    'large_image.show_viewer',
-                    'large_image.default_viewer',
-                    'large_image.auto_set',
-                    'large_image.max_thumbnail_files',
-                    'large_image.max_small_image_size',
-                    'large_image.annotation_history'
-                ])}
+                url: 'large_image/settings'
             }).done((resp) => {
                 ConfigView.settings = resp;
                 if (callback) {


### PR DESCRIPTION
We use `ConfigView.getSettings` in a few places to get settings.  Allow all of the settings to be fetched from the large_image/settings endpoint.  If we really need an admin-only setting, we will need to add a second method to get those settings.

This fixes a bug introduced in PR #250 where a non-admin user can't view a large image in Girder because we fail to obtain the setting for which viewer should be shown.