### PR TITLE
Allow units to specify any proj4 projection.

### DIFF
--- a/server/tilesource/pil.py
+++ b/server/tilesource/pil.py
@@ -170,7 +170,7 @@ if girder:
             return strhash(
                 super(PILGirderTileSource, PILGirderTileSource).getLRUHash(
                     *args, **kwargs),
-                kwargs.get('maxSize'))
+                kwargs.get('maxSize', args[1] if len(args) >= 2 else None))
 
         def getState(self):
             return super(PILGirderTileSource, self).getState() + ',' + str(


### PR DESCRIPTION
The projection parameter is the projection of the tiles.  It can be useful to have a different projection for the units, so allow the units to include a few enumerated values ('wgs84', '4326') or any string that starts with 'epsg:' or 'proj4:' (all case insensitive).  In these cases, convert from the specified units to pixels or the specified tile projection.

This also changes `toNativePixelCoordinates` to round to the nearest coordinates by default.  This resolves some differences in pixel values that were showing in tests.

There is a change in computing the class cache hashing string.  Before `MapnikTileSource(file, projection)` got different results than `MapnikTileSource(file, projection=projection)`, whereas it should not.  The change affects the mapnik and pil tile sources.