### PR TITLE
Track girder cache changes.

### DIFF
--- a/plugin_tests/common.py
+++ b/plugin_tests/common.py
@@ -63,6 +63,12 @@ class LargeImageCommonTest(base.TestCase):
                 self.publicFolder = folder
             if folder['name'] == 'Private':
                 self.privateFolder = folder
+        folders = Folder().childFolders(self.user, 'user', user=self.admin)
+        for folder in folders:
+            if folder['name'] == 'Public':
+                self.userPublicFolder = folder
+            if folder['name'] == 'Private':
+                self.userPrivateFolder = folder
         # Authorize our user for Girder Worker
         resp = self.request(
             '/system/setting', method='PUT', user=self.admin, params={
@@ -83,16 +89,23 @@ class LargeImageCommonTest(base.TestCase):
         :param path: path to upload.
         :param name: optional name for the file.
         :param private: True to upload to the private folder, False for public.
+            'user' for the user's private folder.
         :returns: file: the created file.
         """
         if not name:
             name = os.path.basename(path)
         with open(path, 'rb') as file:
             data = file.read()
+        if private == 'user':
+            folderId = self.userPrivateFolder['_id']
+        elif private:
+            folderId = self.privateFolder['_id']
+        else:
+            folderId = self.publicFolder['_id']
         resp = self.request(
             path='/file', method='POST', user=self.admin, params={
                 'parentType': 'folder',
-                'parentId': self.privateFolder['_id'] if private else self.publicFolder['_id'],
+                'parentId': folderId,
                 'name': name,
                 'size': len(data)
             })

--- a/server/loadmodelcache.py
+++ b/server/loadmodelcache.py
@@ -68,6 +68,7 @@ def loadModel(resource, model, plugin='_core', id=None, allowCookie=False,
         # cookies.
         if allowCookie:
             getCurrentToken(allowCookie)
+            setattr(cherrypy.request, 'girderAllowCookie', True)
         entry = resource.model(model, plugin).load(
             id=id, level=level, user=resource.getCurrentUser())
         if key:


### PR DESCRIPTION
In Girder PR #2274, instead of using `getCurrentToken` to cache that cookies are being used, the cherrypy.request attr `girderAllowCookie` is used.  We cache loading models to avoid one or more database lookups per tile request, and this change broke that caching.