### PR TITLE
Reduce number of draw calls when highlighting annotations.

### DIFF
--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -232,7 +232,7 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
             const features = layer.features;
             this._mutateFeaturePropertiesForHighlight(annotationId, features);
         });
-        this.viewer.draw();
+        this.viewer.scheduleAnimationFrame(this.viewer.draw);
         return this;
     },
 
@@ -249,12 +249,10 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
                 // this slows down interactivity considerably.
                 return;
             }
-            const fillOpacityArray = [];
-            const strokeOpacityArray = [];
-
             // pre-allocate arrays for performance
-            fillOpacityArray.length = data.length;
-            strokeOpacityArray.length = data.length;
+            const fillOpacityArray = new Array(data.length);
+            const strokeOpacityArray = new Array(data.length);
+
             for (let i = 0; i < data.length; i += 1) {
                 const id = data[i].id;
                 const fillOpacity = data[i].fillOpacity;


### PR DESCRIPTION
Calling `viewer.draw()` results in updating the drawing information.  Frequently when highlighting annotations, multiple such calls are made in a row.  Ideally, only one `draw()` call should be made per combined set of updates.  These can be aggregated by scheduling the draw for the next animation frame using the geojs scheduler for that (which prevents duplicates).

Also, allocate arrays in a single step as they are created.