### PR TITLE
Always report a scale when getting a level magnification.

### DIFF
--- a/plugin_tests/sources_test.py
+++ b/plugin_tests/sources_test.py
@@ -63,11 +63,13 @@ class LargeImageSourcesTest(common.LargeImageCommonTest):
         self.assertEqual(mag['mm_x'], 0.000252)
         self.assertEqual(mag['mm_y'], 0.000252)
         self.assertEqual(mag['level'], 7)
+        self.assertEqual(mag['scale'], 1.0)
         mag = source.getMagnificationForLevel(0)
         self.assertEqual(mag['magnification'], 0.3125)
         self.assertEqual(mag['mm_x'], 0.032256)
         self.assertEqual(mag['mm_y'], 0.032256)
         self.assertEqual(mag['level'], 0)
+        self.assertEqual(mag['scale'], 128.0)
         self.assertEqual(source.getLevelForMagnification(), 7)
         self.assertEqual(source.getLevelForMagnification(exact=True), 7)
         self.assertEqual(source.getLevelForMagnification(40), 7)
@@ -536,9 +538,6 @@ class LargeImageSourcesTest(common.LargeImageCommonTest):
         self.assertEqual(int(targetRegion['width']), 575)
         self.assertEqual(int(targetRegion['height']), 506)
         self.assertEqual(targetRegion['units'], 'mag_pixels')
-        with six.assertRaisesRegex(self, ValueError, 'No magnification'):
-            source.convertRegionScale(
-                sourceRegion, sourceScale, None, targetUnits='pixels')
 
         # test getRegionAtAnotherScale
         image, imageFormat = source.getRegionAtAnotherScale(

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -1400,6 +1400,8 @@ class TileSource(object):
                 mag['mm_y'] *= mag['scale']
         if self.levels:
             mag['level'] = level if level is not None else self.levels - 1
+        if mag.get('level') == self.levels - 1:
+            mag['scale'] = 1.0
         return mag
 
     def getLevelForMagnification(self, magnification=None, exact=False,

--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -164,7 +164,7 @@ class TiffFileTileSource(FileTileSource):
         mm_x = pixelInfo.get('mm_x')
         mm_y = pixelInfo.get('mm_y')
         # Estimate the magnification if we don't have a direct value
-        mag = pixelInfo.get('magnification', 0.01 / mm_x if mm_x else None)
+        mag = pixelInfo.get('magnification') or 0.01 / mm_x if mm_x else None
         return {
             'magnification': mag,
             'mm_x': mm_x,


### PR DESCRIPTION
Before, if this returned the base level, no scale value was included (the scale is 1 in this case).

Also, reframe how magnification is calculated for the tiff tile source so if it is set but 0 we still replace it with a calculated value.