### PR TITLE
Upgrade geojs.

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -9,7 +9,7 @@
     "npm": {
         "dependencies": {
             "hammerjs": "^2.0.8",
-            "geojs": "^0.13.0",
+            "geojs": "^0.15.0",
             "slideatlas-viewer": "4.0.3",
             "sinon": "^2.1.0",
             "tinycolor2": "^1.4.1"


### PR DESCRIPTION
The latest version has much faster line updates, which is useful for annotation rendering.