### PR TITLE
Add a method to set the opacity of the annotation layer

### DIFF
--- a/plugin_tests/client/geojsSpec.js
+++ b/plugin_tests/client/geojsSpec.js
@@ -511,6 +511,24 @@ $(function () {
             });
         });
 
+        describe('global annotation opacity', function () {
+            var opacity, opacityFunction;
+            beforeEach(function () {
+                opacity = null;
+                opacityFunction = viewer.featureLayer.opacity;
+                viewer.featureLayer.opacity = function (_opacity) {
+                    opacity = _opacity;
+                };
+            });
+            afterEach(function () {
+                viewer.featureLayer.opacity = opacityFunction;
+            });
+            it('set global annotation opacity', function () {
+                viewer.setGlobalAnnotationOpacity(0.5);
+                expect(opacity).toBe(0.5);
+            });
+        });
+
         describe('highlight annotations', function () {
             var annotation1, annotation2;
             var element11 = '111111111111111111111111';

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -27,6 +27,7 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
     initialize: function (settings) {
         this._annotations = {};
         this._featureOpacity = {};
+        this._globalAnnotationOpacity = settings.globalAnnotationOpacity || 1.0;
         this._highlightFeatureSizeLimit = settings.highlightFeatureSizeLimit || 10000;
         this.listenTo(events, 's:widgetDrawRegion', this.drawRegion);
         this.listenTo(events, 'g:startDrawMode', this.startDrawMode);
@@ -107,6 +108,7 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
         this.featureLayer = this.viewer.createLayer('feature', {
             features: ['point', 'line', 'polygon']
         });
+        this.setGlobalAnnotationOpacity(this._globalAnnotationOpacity);
         this.featureLayer.geoOn(window.geo.event.pan, () => { this.setBounds(); });
         // the annotation layer is for annotations that are actively drawn
         this.annotationLayer = this.viewer.createLayer('annotation', {
@@ -401,6 +403,14 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
         );
         layer.mode(type);
         return defer.promise();
+    },
+
+    setGlobalAnnotationOpacity: function (opacity) {
+        this._globalAnnotationOpacity = opacity;
+        if (this.featureLayer) {
+            this.featureLayer.opacity(opacity);
+        }
+        return this;
     },
 
     _setEventTypes: function () {


### PR DESCRIPTION
This commit provides a more efficient mechanism for setting the opacity
globally for all annotations than the "highlightAnnotation" code path
which requires looping through each feature.  This will be used to
implement the following feature request on HistomicsTK:

  https://github.com/DigitalSlideArchive/HistomicsTK/issues/458