### PR TITLE
Allow girder to show load errors in more cases.

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -18,8 +18,10 @@
 ###############################################################################
 
 try:
-    from .base import *  # noqa
-except ImportError as exc:
+    import girder
+    # This should include all of the explicitly required Girder plugins.
+    import girder.plugins.worker
+except ImportError:
     # If our import failed because either girder or a girder plugin is
     # unavailable, log it and start anyway (we may be running in a girder-less
     # environment).
@@ -28,3 +30,7 @@ except ImportError as exc:
     logger.debug('Girder is unavailable.  Run as a girder plugin for girder '
                  'access.')
     girder = None
+else:
+    # if girder is available, and we fail to import anything else, girder will
+    # show the failure
+    from .base import load  # noqa


### PR DESCRIPTION
If girder is installed but requirements of large_image are not, the plugin would report as enabled but not be functional.  This checks if girder is available, and, if so, allows girder to report errors.

Eventually, it will be nice to separate large_image without girder from the necessary girder parts to make this easier to manage.  For now, this should make diagnosis easier.

As a simple test, when everything works under girder, uninstall a required module (cachetools, for instance), and restart girder.  Before, no error was reported.  With this change, the missing module is reported.