### PR TITLE
Add an option to have a scale widget.

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -8,8 +8,9 @@
     },
     "npm": {
         "dependencies": {
+            "d3": "^3.5.16",
             "hammerjs": "^2.0.8",
-            "geojs": "^0.15.0",
+            "geojs": "^0.15.2",
             "slideatlas-viewer": "4.0.3",
             "sinon": "^2.1.0",
             "tinycolor2": "^1.4.1"

--- a/plugin_tests/client/geojsSpec.js
+++ b/plugin_tests/client/geojsSpec.js
@@ -645,10 +645,28 @@ $(function () {
                 checkFeatureOpacity(annotation2.id, 0.5, 1);
             });
         });
-
         it('destroy the viewer', function () {
             viewer.destroy();
             expect($('.geojs-layer').length).toBe(0);
+        });
+
+        it('scale', function () {
+            viewer = new GeojsViewer({
+                el: $el,
+                itemId: itemId,
+                parentView: null,
+                scale: {position: {bottom: 20, right: 10}, scale: 0.0005}
+            });
+            viewer.once('g:beforeFirstRender', function () {
+                window.geo.util.mockVGLRenderer();
+            });
+            waitsFor(function () {
+                return $('.geojs-layer.active').length >= 1 && viewer.scaleWidget;
+            }, 'viewer and scale to load');
+            runs(function () {
+                expect(viewer.scaleWidget instanceof window.geo.gui.scaleWidget).toBe(true);
+                viewer.destroy();
+            });
         });
     });
 });


### PR DESCRIPTION
This also works around a potential issue destroying a geojs map.

If the remote worker is not enabled, we need to explicitly include d3.  It is probably best to do this anyway, since the remove worker only has d3 as a side effect of including vega.