### PR TITLE
Suppress TIFF warnings.

### DIFF
--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -48,6 +48,9 @@ try:
 except ImportError:
     PIL = None
 
+# This suppress warnings about unknown tags
+libtiff_ctypes.suppress_warnings()
+
 
 def patchLibtiff():
     libtiff_ctypes.libtiff.TIFFFieldWithTag.restype = \


### PR DESCRIPTION
GeoTIFFs always print warning messages like "TIFFReadDirectory: Warning, Unknown field with tag 34736 (0x87b0) encountered.".  These are expected, and therefore not useful, so suppress them.