### PR TITLE
Add tools for reporting on and clearing the cache.

### DIFF
--- a/plugin_tests/common.py
+++ b/plugin_tests/common.py
@@ -81,6 +81,13 @@ class LargeImageCommonTest(base.TestCase):
                     }])})
         self.assertStatusOk(resp)
 
+    def tearDown(self):
+        from girder.plugins.large_image import cache_util
+
+        # Clear the cache so tests can't affect each other.
+        cache_util.cachesClear()
+        base.TestCase.tearDown(self)
+
     def _uploadFile(self, path, name=None, private=False):
         """
         Upload the specified path to the admin user's public or private folder

--- a/server/cache_util/cache.py
+++ b/server/cache_util/cache.py
@@ -56,7 +56,7 @@ CacheProperties = {
         # Cache size is based on what the class needs, which does not include
         # individual tiles
         'cacheMaxSize': pickAvailableCache(
-            1024 ** 2, maxItems=MaximumTileSources),
+            24 * 1024 ** 2, maxItems=MaximumTileSources),
         # The cache timeout is not currently being used, but it is set here in
         # case we ever choose to implement it.
         'cacheTimeout': 300,


### PR DESCRIPTION
Tweak the calculation of the tile source cache size based on actual experience.