### PR TITLE
Handle KeyError when trying to get openslide properties.

### DIFF
--- a/server/tilesource/svs.py
+++ b/server/tilesource/svs.py
@@ -154,12 +154,12 @@ class SVSFileTileSource(FileTileSource):
         try:
             width = int(self._openslide.properties[
                 'openslide.level[0].tile-width'])
-        except ValueError:
+        except (ValueError, KeyError):
             pass
         try:
             height = int(self._openslide.properties[
                 'openslide.level[0].tile-height'])
-        except ValueError:
+        except (ValueError, KeyError):
             pass
         # If the tile size is too small (<4) or wrong (<=0), use a default value
         if width < 4:


### PR DESCRIPTION
This change allows a few more files to be opened by the svs tilesource.  For instance, if you import the .mrxs named file from a group of mrxs files, this will allow them to be displayed.