### PR TITLE
Return a list of element groups with annotation endpoints

### DIFF
--- a/plugin_tests/annotations_test.py
+++ b/plugin_tests/annotations_test.py
@@ -1016,18 +1016,18 @@ class LargeImageAnnotationElementGroups(common.LargeImageCommonTest):
         self.assertEqual(len(resp.json), 3)
         for annotation in resp.json:
             if annotation['_id'] == str(self.noGroups['_id']):
-                self.assertEqual(annotation['groups'], [])
+                self.assertEqual(annotation['groups'], [None])
             elif annotation['_id'] == str(self.notMigrated['_id']):
                 self.assertEqual(annotation['groups'], ['a', 'b'])
             elif annotation['_id'] == str(self.hasGroups['_id']):
-                self.assertEqual(annotation['groups'], ['a', 'c'])
+                self.assertEqual(annotation['groups'], ['a', 'c', None])
             else:
                 raise Exception('Unexpected annotation id')
 
     def testLoadAnnotation(self):
         resp = self.request('/annotation/%s' % str(self.hasGroups['_id']), user=self.admin)
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json['groups'], ['a', 'c'])
+        self.assertEqual(resp.json['groups'], ['a', 'c', None])
 
     def testCreateAnnotation(self):
         annotation = {

--- a/plugin_tests/annotations_test.py
+++ b/plugin_tests/annotations_test.py
@@ -934,6 +934,151 @@ class LargeImageAnnotationRestTest(common.LargeImageCommonTest):
     # find
 
 
+class LargeImageAnnotationElementGroups(common.LargeImageCommonTest):
+    def setUp(self):
+        from girder.plugins.large_image.models.annotation import Annotation
+
+        super(LargeImageAnnotationElementGroups, self).setUp()
+
+        self.item = Item().createItem('sample', self.admin, self.publicFolder)
+        annotationModel = Annotation()
+
+        self.noGroups = annotationModel.createAnnotation(
+            self.item, self.admin,
+            {
+                'name': 'nogroups',
+                'elements': [{
+                    'type': 'rectangle',
+                    'center': [20.0, 25.0, 0],
+                    'width': 14.0,
+                    'height': 15.0,
+                }, {
+                    'type': 'rectangle',
+                    'center': [40.0, 15.0, 0],
+                    'width': 5.0,
+                    'height': 5.0
+                }]
+            }
+        )
+
+        self.notMigrated = annotationModel.createAnnotation(
+            self.item, self.admin,
+            {
+                'name': 'notmigrated',
+                'elements': [{
+                    'type': 'rectangle',
+                    'center': [20.0, 25.0, 0],
+                    'width': 14.0,
+                    'height': 15.0,
+                    'group': 'b'
+                }, {
+                    'type': 'rectangle',
+                    'center': [40.0, 15.0, 0],
+                    'width': 5.0,
+                    'height': 5.0,
+                    'group': 'a'
+                }]
+            }
+        )
+        annotationModel.collection.update_one(
+            {'_id': self.notMigrated['_id']},
+            {'$unset': {'groups': ''}}
+        )
+
+        self.hasGroups = annotationModel.createAnnotation(
+            self.item, self.admin,
+            {
+                'name': 'hasgroups',
+                'elements': [{
+                    'type': 'rectangle',
+                    'center': [20.0, 25.0, 0],
+                    'width': 14.0,
+                    'height': 15.0,
+                    'group': 'a'
+                }, {
+                    'type': 'rectangle',
+                    'center': [40.0, 15.0, 0],
+                    'width': 5.0,
+                    'height': 5.0,
+                    'group': 'c'
+                }, {
+                    'type': 'rectangle',
+                    'center': [50.0, 10.0, 0],
+                    'width': 5.0,
+                    'height': 5.0
+                }]
+            }
+        )
+
+    def testFindAnnotations(self):
+        resp = self.request('/annotation', user=self.admin, params={'itemId': self.item['_id']})
+        self.assertStatusOk(resp)
+        self.assertEqual(len(resp.json), 3)
+        for annotation in resp.json:
+            if annotation['_id'] == str(self.noGroups['_id']):
+                self.assertEqual(annotation['groups'], [])
+            elif annotation['_id'] == str(self.notMigrated['_id']):
+                self.assertEqual(annotation['groups'], ['a', 'b'])
+            elif annotation['_id'] == str(self.hasGroups['_id']):
+                self.assertEqual(annotation['groups'], ['a', 'c'])
+            else:
+                raise Exception('Unexpected annotation id')
+
+    def testLoadAnnotation(self):
+        resp = self.request('/annotation/%s' % str(self.hasGroups['_id']), user=self.admin)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json['groups'], ['a', 'c'])
+
+    def testCreateAnnotation(self):
+        annotation = {
+            'name': 'created',
+            'elements': [{
+                'type': 'rectangle',
+                'center': [20.0, 25.0, 0],
+                'width': 14.0,
+                'height': 15.0,
+                'group': 'a'
+            }]
+        }
+        resp = self.request(
+            '/annotation',
+            user=self.admin,
+            method='POST',
+            params={'itemId': str(self.item['_id'])},
+            type='application/json',
+            body=json.dumps(annotation)
+        )
+        self.assertStatusOk(resp)
+
+        resp = self.request('/annotation/%s' % resp.json['_id'], user=self.admin)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json['groups'], ['a'])
+
+    def testUpdateAnnotation(self):
+        annotation = {
+            'name': 'created',
+            'elements': [{
+                'type': 'rectangle',
+                'center': [20.0, 25.0, 0],
+                'width': 14.0,
+                'height': 15.0,
+                'group': 'd'
+            }]
+        }
+        resp = self.request(
+            '/annotation/%s' % str(self.hasGroups['_id']),
+            user=self.admin,
+            method='PUT',
+            type='application/json',
+            body=json.dumps(annotation)
+        )
+        self.assertStatusOk(resp)
+
+        resp = self.request('/annotation/%s' % resp.json['_id'], user=self.admin)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json['groups'], ['d'])
+
+
 class LargeImageAnnotationAccessMigrationTest(common.LargeImageCommonTest):
 
     def testMigrateAnnotationAccessControl(self):

--- a/server/models/annotation.py
+++ b/server/models/annotation.py
@@ -939,8 +939,7 @@ class Annotation(AccessControlledModel):
 
     def injectAnnotationGroupSet(self, annotation):
         if 'groups' not in annotation:
-            annotation['groups'] = sorted(
-                Annotationelement().getElementGroupSet(annotation))
+            annotation['groups'] = Annotationelement().getElementGroupSet(annotation)
             query = {
                 '_id': ObjectId(annotation['_id'])
             }

--- a/server/models/annotation.py
+++ b/server/models/annotation.py
@@ -393,7 +393,8 @@ class Annotation(AccessControlledModel):
         'updated',
         'updatedId',
         'public',
-        'publicFlags'
+        'publicFlags',
+        'groups'
         # 'skill',
         # 'startTime'
         # 'stopTime'
@@ -578,6 +579,7 @@ class Annotation(AccessControlledModel):
                     break
                 annotation = recheck
 
+        self.injectAnnotationGroupSet(annotation)
         return annotation
 
     def remove(self, annotation, *args, **kwargs):
@@ -686,6 +688,10 @@ class Annotation(AccessControlledModel):
                 self.collection.insert_one = insert_one
         if _elementQuery:
             result['_elementQuery'] = _elementQuery
+
+        annotation.pop('groups', None)
+        self.injectAnnotationGroupSet(annotation)
+
         logger.debug('Saved annotation in %5.3fs' % (time.time() - starttime))
         events.trigger('large_image.annotations.save_history', {
             'annotation': annotation
@@ -930,3 +936,18 @@ class Annotation(AccessControlledModel):
             if token.startswith(matchString):
                 return True
         return False
+
+    def injectAnnotationGroupSet(self, annotation):
+        if 'groups' not in annotation:
+            annotation['groups'] = sorted(
+                Annotationelement().getElementGroupSet(annotation))
+            query = {
+                '_id': ObjectId(annotation['_id'])
+            }
+            update = {
+                '$set': {
+                    'groups': annotation['groups']
+                }
+            }
+            self.collection.update_one(query, update)
+        return annotation

--- a/server/models/annotationelement.py
+++ b/server/models/annotationelement.py
@@ -20,6 +20,7 @@
 import datetime
 import math
 import time
+import six
 from six.moves import range
 
 from girder.constants import AccessType, SortDir
@@ -307,7 +308,10 @@ class Annotationelement(Model):
             'annotationId': annotation.get('_annotationId', annotation['_id']),
             '_version': annotation['_version']
         }
-        groups = sorted(self.collection.distinct('element.group', filter=query))
+        groups = sorted([
+            group for group in self.collection.distinct('element.group', filter=query)
+            if isinstance(group, six.string_types)
+        ])
         query['element.group'] = None
         if self.collection.find_one(query):
             groups.append(None)

--- a/server/models/annotationelement.py
+++ b/server/models/annotationelement.py
@@ -302,4 +302,8 @@ class Annotationelement(Model):
             'annotationId': annotation.get('_annotationId', annotation['_id']),
             '_version': annotation['_version']
         }
-        return self.collection.distinct('element.group', filter=query)
+        groups = sorted(self.collection.distinct('element.group', filter=query))
+        query['element.group'] = None
+        if self.collection.find_one(query):
+            groups.append(None)
+        return groups

--- a/server/models/annotationelement.py
+++ b/server/models/annotationelement.py
@@ -296,3 +296,10 @@ class Annotationelement(Model):
         if time.time() - startTime > 10:
             logger.info('inserted %d elements in %4.2fs' % (
                 len(elements), time.time() - startTime))
+
+    def getElementGroupSet(self, annotation):
+        query = {
+            'annotationId': annotation.get('_annotationId', annotation['_id']),
+            '_version': annotation['_version']
+        }
+        return self.collection.distinct('element.group', filter=query)

--- a/server/models/annotationelement.py
+++ b/server/models/annotationelement.py
@@ -54,7 +54,12 @@ class Annotationelement(Model):
             ([
                 ('annotationId', SortDir.ASCENDING),
                 ('bbox.size', SortDir.DESCENDING),
-            ], {})
+            ], {}),
+            ([
+                ('annotationId', SortDir.ASCENDING),
+                ('_version', SortDir.DESCENDING),
+                ('element.group', SortDir.ASCENDING),
+            ], {}),
         ])
 
         self.exposeFields(AccessType.READ, (

--- a/server/rest/annotation.py
+++ b/server/rest/annotation.py
@@ -85,12 +85,17 @@ class AnnotationResource(Resource):
             query['$text'] = {'$search': params['text']}
         if params.get('name'):
             query['annotation.name'] = params['name']
-        fields = list(('annotation.name', 'annotation.description', 'access') +
-                      Annotation().baseFields)
-        return list(Annotation().filterResultsByPermission(
+        fields = list(
+            (
+                'annotation.name', 'annotation.description', 'access', 'groups', '_version'
+            ) + Annotation().baseFields)
+        annotations = list(Annotation().filterResultsByPermission(
             cursor=Annotation().find(query, sort=sort, fields=fields),
             user=self.getCurrentUser(), level=AccessType.READ, limit=limit, offset=offset
         ))
+        for annotation in annotations:
+            Annotation().injectAnnotationGroupSet(annotation)
+        return annotations
 
     @describeRoute(
         Description('Get the official Annotation schema')


### PR DESCRIPTION
To support the use case of grouping annotations when listing them on the client, this maintains a denormalized list of "groups" on the annotation object inside the database.  This property is calculated on demand for annotations that existed before this change; otherwise, it is added/modified automatically on `annotation.save(...)`.

I would have preferred to keep this code entirely on the model layer, but the only place to inject the migration behavior for the listing endpoint is in the `find` method.  This however returns a mongo cursor rather than a normal iterator and would be difficult to override.