### PR TITLE
Improve level power-of-two detection.

### DIFF
--- a/plugin_tests/girderless_test.py
+++ b/plugin_tests/girderless_test.py
@@ -195,3 +195,14 @@ class LargeImageGirderlessTest(unittest.TestCase):
         self.assertEqual(tileMetadata['sizeY'], 10880)
         self.assertEqual(tileMetadata['levels'], 7)
         self._testTilesZXY(source, tileMetadata, params, PNGHeader)
+
+    def testSVSNearPowerOfTwo(self):
+        from server.tilesource import svs
+
+        self.assertTrue(svs._nearPowerOfTwo(45808, 11456))
+        self.assertTrue(svs._nearPowerOfTwo(45808, 11450))
+        self.assertFalse(svs._nearPowerOfTwo(45808, 11200))
+        self.assertTrue(svs._nearPowerOfTwo(45808, 11400))
+        self.assertFalse(svs._nearPowerOfTwo(45808, 11400, 0.005))
+        self.assertTrue(svs._nearPowerOfTwo(45808, 11500))
+        self.assertFalse(svs._nearPowerOfTwo(45808, 11500, 0.005))

--- a/server/tilesource/svs.py
+++ b/server/tilesource/svs.py
@@ -53,8 +53,8 @@ def _nearPowerOfTwo(val1, val2, tolerance=0.02):
     if val1 * val2 <= 0:
         return False
     log2ratio = math.log(float(val1) / float(val2)) / math.log(2)
-    # Use modf()[0] to get the mantissa of the ratio's log2 value.
-    return abs(math.modf(log2ratio)[0]) < tolerance
+    # Compare the mantissa of the ratio's log2 value.
+    return abs(log2ratio - round(log2ratio)) < tolerance
 
 
 @six.add_metaclass(LruCacheMetaclass)


### PR DESCRIPTION
For SVS tile sources, we check if each level is a power of two of the base level.  Using `abs(modf(log2ratio)[0])` to get the mantissa, this could sometimes return a failure (such as with 45808 and 11456), since the mantissa was near to 1 rather than near to zero.  Using `round` to get the mantissa is better.