### PR TITLE
Change the order a new annotation and its element are stored.

### DIFF
--- a/server/models/annotation.py
+++ b/server/models/annotation.py
@@ -670,12 +670,13 @@ class Annotation(AccessControlledModel):
             # elements aren't set (this is unavoidable without database
             # transactions, as we need the annotation's id to set the
             # elements).
-            ret = insert_one(doc, *args, **kwargs)
+            doc.setdefault('_id', ObjectId())
             if elements is not None:
                 doc['annotation']['elements'] = elements
                 Annotationelement().updateElements(doc)
             # If we are inserting, we shouldn't have any old elements, so don't
             # bother removing them.
+            ret = insert_one(doc, *args, **kwargs)
             return ret
 
         with self._writeLock:


### PR DESCRIPTION
Before, we wrote (inserted) an `annotation` to the mongo collection, then wrote the set of `annotationelement`s.  If an item's annotations were listed before this finished, the new annotation would be included in the list.  Requesting the annotation could return partial results for the annotation elements.  By saving the annotation after the annotation elements, this problem is avoided.