### PR TITLE
Add an annotation list widget to the item page

### DIFF
--- a/plugin.cmake
+++ b/plugin.cmake
@@ -150,6 +150,11 @@ add_web_client_test(
   "${CMAKE_CURRENT_LIST_DIR}/plugin_tests/client/geojsAnnotationSpec.js"
   PLUGIN large_image)
 
+add_web_client_test(
+  annotation_list
+  "${CMAKE_CURRENT_LIST_DIR}/plugin_tests/client/annotationListSpec.js"
+  PLUGIN large_image)
+
 #add_puglint_test(
 #  large_image
 #  "${CMAKE_CURRENT_LIST_DIR}/web_client/templates")

--- a/plugin_tests/client/annotationListSpec.js
+++ b/plugin_tests/client/annotationListSpec.js
@@ -122,6 +122,10 @@ describe('AnnotationListWidget', function () {
                 return $('.g-item-image-viewer-select').length !== 0;
             }, 15000);
             girderTest.waitForLoad();
+            runs(function () {
+                expect($('.g-annotation-list-container p').text()).toBe(
+                    'This image does not contain any annotations.');
+            });
         });
         it('get item model', function () {
             item = new girder.models.ItemModel();

--- a/plugin_tests/client/annotationListSpec.js
+++ b/plugin_tests/client/annotationListSpec.js
@@ -1,0 +1,282 @@
+girderTest.importPlugin('large_image');
+girderTest.startApp();
+
+function waitForLargeImageViewer(viewerName) {
+    waitsFor(function () {
+        return !$('.image-viewer:empty').not('.hidden').length &&
+               !$('.image-viewer.hidden').not(':empty').length &&
+               $('.image-viewer').not('.hidden').not(':empty').length &&
+               $('.image-viewer').not('.hidden').length === 1 &&
+               $('.image-viewer').not('.hidden').attr('id') === viewerName;
+    }, 'wait for ' + viewerName + ' to be visible');
+}
+
+describe('AnnotationListWidget', function () {
+    var girder;
+    var largeImage;
+    var item;
+    var drawnAnnotations;
+
+    beforeEach(function () {
+        girder = window.girder;
+        largeImage = girder.plugins.large_image;
+        drawnAnnotations = {};
+    });
+
+    describe('setup', function () {
+        it('mock VGL', function () {
+            var GeojsViewer = largeImage.views.imageViewerWidget.geojs;
+            girder.utilities.PluginUtils.wrap(GeojsViewer, 'initialize', function (initialize) {
+                this.drawAnnotation = function (annotation) {
+                    drawnAnnotations[annotation.id] = annotation;
+                };
+                this.removeAnnotation = function (annotation) {
+                    delete drawnAnnotations[annotation.id];
+                };
+
+                this.once('g:beforeFirstRender', function () {
+                    window.geo.util.mockVGLRenderer();
+                });
+                initialize.apply(this, _.rest(arguments));
+            });
+        });
+        it('create the admin user', function () {
+            girderTest.createUser(
+                'admin', 'admin@email.com', 'Admin', 'Admin', 'testpassword')();
+        });
+        it('go to collections page', function () {
+            runs(function () {
+                $("a.g-nav-link[g-target='collections']").click();
+            });
+
+            waitsFor(function () {
+                return $('.g-collection-create-button:visible').length > 0;
+            }, 'navigate to collections page');
+
+            runs(function () {
+                expect($('.g-collection-list-entry').length).toBe(0);
+            });
+        });
+        it('create collection', girderTest.createCollection('test', '', 'image'));
+        it('make collection and folder public', function () {
+            var done;
+            var collectionId;
+
+            girder.rest.restRequest({
+                url: 'collection'
+            }).then(function (collections) {
+                expect(collections.length).toBe(1);
+                collectionId = collections[0]._id;
+                return girder.rest.restRequest({
+                    url: 'collection/' + collectionId + '/access',
+                    method: 'PUT',
+                    data: {public: true, access: '{}'}
+                });
+            }).then(function () {
+                return girder.rest.restRequest({
+                    url: 'folder',
+                    data: {parentType: 'collection', parentId: collectionId}
+                });
+            }).then(function (folders) {
+                expect(folders.length).toBe(1);
+                return girder.rest.restRequest({
+                    url: 'folder/' + folders[0]._id + '/access',
+                    method: 'PUT',
+                    data: {public: true, access: '{}'}
+                });
+            }).done(function (folder) {
+                done = true;
+            }).fail(function (err) {
+                throw err;
+            });
+
+            waitsFor(function () {
+                return done;
+            }, 'requests to return');
+        });
+        it('upload test file', function () {
+            girderTest.waitForLoad();
+            runs(function () {
+                $('.g-folder-list-link:first').click();
+            });
+            girderTest.waitForLoad();
+            runs(function () {
+                girderTest.binaryUpload('plugins/large_image/plugin_tests/test_files/yb10kx5k.png');
+            });
+            girderTest.waitForLoad();
+        });
+        it('navigate to item and make a large image', function () {
+            runs(function () {
+                $('a.g-item-list-link').click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return $('.g-large-image-create').length !== 0;
+            });
+            runs(function () {
+                $('.g-large-image-create').click();
+            });
+            girderTest.waitForLoad();
+            // wait for job to complete
+            waitsFor(function () {
+                return $('.g-item-image-viewer-select').length !== 0;
+            }, 15000);
+            girderTest.waitForLoad();
+        });
+        it('get item model', function () {
+            item = new girder.models.ItemModel();
+            girder.rest.restRequest({url: 'item', data: {text: 'yb10kx5k.png'}}).done(function (resp) {
+                item.set(resp[0]);
+            });
+            waitsFor(function () {
+                return item.id;
+            }, 'item to be returned');
+        });
+        it('create annotations', function () {
+            var index;
+            var annotation;
+            var promises = [];
+            var done;
+
+            for (index = 1; index < 11; index += 1) {
+                annotation = new largeImage.models.AnnotationModel({
+                    itemId: item.id,
+                    annotation: {
+                        name: 'annotation ' + index
+                    }
+                });
+                promises.push(annotation.save());
+            }
+
+            $.when.apply($, promises).done(function () {
+                done = true;
+            });
+
+            waitsFor(function () {
+                return done;
+            }, 'annotations to be created');
+        });
+        it('reload the item page', function () {
+            girder.router.navigate('', {trigger: true});
+            girderTest.waitForLoad();
+            runs(function () {
+                girder.router.navigate('item/' + item.id, {trigger: true});
+            });
+            girderTest.waitForLoad();
+        });
+    });
+
+    describe('Test annotation list widget as admin', function () {
+        it('select the geojs viewer', function () {
+            $('.g-item-image-viewer-select select').val('geojs').trigger('change');
+            waitForLargeImageViewer('geojs');
+        });
+        it('check that all annotations are displayed', function () {
+            var $el = $('.g-annotation-list .g-annotation-row');
+            waitsFor(function () {
+                return $el.length > 0;
+            }, 'annotations list to load');
+            runs(function () {
+                expect($el.length).toBe(10);
+                $el.each(function () {
+                    expect($(this).find('.g-annotation-name').text()).toMatch(/annotation [0-9]+/);
+                });
+            });
+        });
+        it('check download link', function () {
+            var $el = $('.g-annotation-list .g-annotation-row:first');
+            var id = $el.data('annotationId');
+            expect($el.find('.g-annotation-download').prop('href')).toMatch(new RegExp('.*annotation/' + id + '$'));
+        });
+        it('test delete link', function () {
+            var $el = $('.g-annotation-list .g-annotation-row:first');
+            var id = $el.data('annotationId');
+            expect($el.find('.g-annotation-delete').length).toBe(1);
+            $el.find('.g-annotation-delete').click();
+
+            girderTest.waitForDialog();
+            runs(function () {
+                $('#g-dialog-container #g-confirm-button').click();
+            });
+
+            waitsFor(function () {
+                return $('.g-annotation-list .g-annotation-row[data-annotation-id="' + id + '"]').length === 0;
+            }, 'annotation to be removed');
+        });
+        it('test permission editor link', function () {
+            var $el = $('.g-annotation-list .g-annotation-row:first');
+            expect($el.find('.g-annotation-permissions').length).toBe(1);
+            $el.find('.g-annotation-permissions').click();
+
+            girderTest.waitForDialog();
+            runs(function () {
+                expect($('#g-dialog-container .modal-title').text()).toBe('Access control');
+                $('#g-dialog-container .g-save-access-list').click();
+            });
+            girderTest.waitForLoad();
+        });
+    });
+    describe('Test annotation list widget as user', function () {
+        it('logout', girderTest.logout('log out admin'));
+        it('login as a normal user', girderTest.createUser(
+            'user', 'user@email.com', 'User', 'User', 'testpassword'));
+        it('reload the item page', function () {
+            girder.router.navigate('', {trigger: true});
+            girderTest.waitForLoad();
+            runs(function () {
+                girder.router.navigate('item/' + item.id, {trigger: true});
+            });
+            girderTest.waitForLoad();
+            runs(function () {
+                $('.g-item-image-viewer-select select').val('geojs').trigger('change');
+            });
+            waitForLargeImageViewer('geojs');
+        });
+        it('check that all annotations are displayed', function () {
+            var $el = $('.g-annotation-list .g-annotation-row');
+            waitsFor(function () {
+                return $el.length > 0;
+            }, 'annotations list to load');
+            runs(function () {
+                expect($el.length).toBe(9);
+                $el.each(function () {
+                    expect($(this).find('.g-annotation-name').text()).toMatch(/annotation [0-9]+/);
+                });
+            });
+        });
+        it('check download link', function () {
+            var $el = $('.g-annotation-list .g-annotation-row:first');
+            var id = $el.data('annotationId');
+            expect($el.find('.g-annotation-download').prop('href')).toMatch(new RegExp('.*annotation/' + id + '$'));
+        });
+        it('test delete link', function () {
+            var $el = $('.g-annotation-list .g-annotation-row:first');
+            expect($el.find('.g-annotation-delete').length).toBe(0);
+        });
+        it('test permission editor link', function () {
+            var $el = $('.g-annotation-list .g-annotation-row:first');
+            expect($el.find('.g-annotation-permissions').length).toBe(0);
+        });
+        it('toggle annotation visibility', function () {
+            var id = $('.g-annotation-list .g-annotation-row:first').data('annotationId');
+            $('.g-annotation-list .g-annotation-row:first').click();
+
+            waitsFor(function () {
+                return drawnAnnotations[id];
+            }, 'annotation to draw');
+            runs(function () {
+                expect($('.g-annotation-list .g-annotation-toggle input:first').prop('checked')).toBe(true);
+                $('.g-annotation-list .g-annotation-row:first').click();
+                expect($('.g-annotation-list .g-annotation-toggle input:first').prop('checked')).toBe(false);
+                expect(drawnAnnotations[id]).toBeUndefined();
+            });
+        });
+        it('switch to a viewer that does not support annotations', function () {
+            $('.g-item-image-viewer-select select').val('leaflet').trigger('change');
+            waitForLargeImageViewer('leaflet');
+            runs(function () {
+                expect($('.g-annotation-list .g-annotation-toggle input:first').prop('disabled')).toBe(true);
+            });
+        });
+    });
+});

--- a/plugin_tests/client/annotationListSpec.js
+++ b/plugin_tests/client/annotationListSpec.js
@@ -123,8 +123,7 @@ describe('AnnotationListWidget', function () {
             }, 15000);
             girderTest.waitForLoad();
             runs(function () {
-                expect($('.g-annotation-list-container p').text()).toBe(
-                    'This image does not contain any annotations.');
+                expect($('.g-annotation-list-container *').length).toBe(0);
             });
         });
         it('get item model', function () {

--- a/plugin_tests/client/annotationListSpec.js
+++ b/plugin_tests/client/annotationListSpec.js
@@ -263,6 +263,10 @@ describe('AnnotationListWidget', function () {
             var $el = $('.g-annotation-list .g-annotation-row:first');
             expect($el.find('.g-annotation-permissions').length).toBe(0);
         });
+        it('check visibility checkbox tooltip', function () {
+            expect($('.g-annotation-list .g-annotation-toggle input:first').prop('title')).toBe(
+                'Show annotation');
+        });
         it('toggle annotation visibility', function () {
             var id = $('.g-annotation-list .g-annotation-row:first').data('annotationId');
             $('.g-annotation-list .g-annotation-row:first').click();

--- a/plugin_tests/client/annotationListSpec.js
+++ b/plugin_tests/client/annotationListSpec.js
@@ -163,6 +163,7 @@ describe('AnnotationListWidget', function () {
                 girder.router.navigate('item/' + item.id, {trigger: true});
             });
             girderTest.waitForLoad();
+            waitForLargeImageViewer('openseadragon');
         });
     });
 
@@ -227,6 +228,7 @@ describe('AnnotationListWidget', function () {
                 girder.router.navigate('item/' + item.id, {trigger: true});
             });
             girderTest.waitForLoad();
+            waitForLargeImageViewer('openseadragon');
             runs(function () {
                 $('.g-item-image-viewer-select select').val('geojs').trigger('change');
             });

--- a/web_client/collections/AnnotationCollection.js
+++ b/web_client/collections/AnnotationCollection.js
@@ -1,9 +1,12 @@
 import Collection from 'girder/collections/Collection';
+import { SORT_DESC } from 'girder/constants';
 
 import AnnotationModel from '../models/AnnotationModel';
 
 export default Collection.extend({
     resourceName: 'annotation',
     model: AnnotationModel,
-    pageLimit: 100
+    pageLimit: 100,
+    sortField: 'created',
+    sortDir: SORT_DESC
 });

--- a/web_client/collections/ElementCollection.js
+++ b/web_client/collections/ElementCollection.js
@@ -3,5 +3,6 @@ import Backbone from 'backbone';
 import ElementModel from '../models/ElementModel';
 
 export default Backbone.Collection.extend({
-    model: ElementModel
+    model: ElementModel,
+    comparator: undefined
 });

--- a/web_client/models/AnnotationModel.js
+++ b/web_client/models/AnnotationModel.js
@@ -1,5 +1,5 @@
 import _ from 'underscore';
-import Model from 'girder/models/Model';
+import AccessControlledModel from 'girder/models/AccessControlledModel';
 import { restRequest } from 'girder/rest';
 
 import ElementCollection from '../collections/ElementCollection';
@@ -17,7 +17,7 @@ import convert from '../annotations/convert';
  * and updates its own attribute in response.  Users
  * should not modify the "elements" attribute directly.
  */
-export default Model.extend({
+export default AccessControlledModel.extend({
     resourceName: 'annotation',
 
     defaults: {

--- a/web_client/stylesheets/annotationListWidget.styl
+++ b/web_client/stylesheets/annotationListWidget.styl
@@ -1,0 +1,22 @@
+.g-annotation-list-header
+  margin-top 20px
+  background-color #f0f0f0
+  padding 5px 6px
+  color #555
+  font-size 16px
+  font-weight bold
+
+.g-annotation-list
+  table-layout fixed
+
+  td
+    white-space nowrap
+    text-overflow ellipsis
+    overflow hidden
+
+  .g-annotation-toggle
+    width 30px
+
+  .g-annotation-actions
+    width 100px
+    text-align right

--- a/web_client/templates/annotationListWidget.pug
+++ b/web_client/templates/annotationListWidget.pug
@@ -17,7 +17,7 @@ if annotations.length
         - var creator = creatorModel ? creatorModel.get('login') : annotation.get('creatorId');
         tr.g-annotation-row(data-annotation-id=annotation.id)
           td.g-annotation-toggle
-            input(type='checkbox', disabled=!canDraw, checked=drawn.has(annotation.id))
+            input(type='checkbox', disabled=!canDraw, checked=drawn.has(annotation.id), title='Show annotation')
           td.g-annotation-name(title=name)
             = name
 

--- a/web_client/templates/annotationListWidget.pug
+++ b/web_client/templates/annotationListWidget.pug
@@ -2,36 +2,39 @@
   i.icon-pencil
   | Annotations
 
-table.g-annotation-list.table.table-hover.table-condensed
-  thead
-    th.g-annotation-toggle
-    th.g-annotation-name Name
-    th.g-annotation-user Creator
-    th.g-annotation-date Date
-    th.g-annotation-actions
-  tbody
-    for annotation in annotations.models
-      - var name = annotation.get('annotation').name;
-      - var creatorModel = users.get(annotation.get('creatorId'));
-      - var creator = creatorModel ? creatorModel.get('login') : annotation.get('creatorId');
-      tr.g-annotation-row(data-annotation-id=annotation.id)
-        td.g-annotation-toggle
-          input(type='checkbox', disabled=!canDraw, checked=drawn.has(annotation.id))
-        td.g-annotation-name(title=name)
-          = name
+if annotations.length
+  table.g-annotation-list.table.table-hover.table-condensed
+    thead
+      th.g-annotation-toggle
+      th.g-annotation-name Name
+      th.g-annotation-user Creator
+      th.g-annotation-date Date
+      th.g-annotation-actions
+    tbody
+      for annotation in annotations.models
+        - var name = annotation.get('annotation').name;
+        - var creatorModel = users.get(annotation.get('creatorId'));
+        - var creator = creatorModel ? creatorModel.get('login') : annotation.get('creatorId');
+        tr.g-annotation-row(data-annotation-id=annotation.id)
+          td.g-annotation-toggle
+            input(type='checkbox', disabled=!canDraw, checked=drawn.has(annotation.id))
+          td.g-annotation-name(title=name)
+            = name
 
-        td.g-annotation-user
-          a(href=`#user/${annotation.get('creatorId')}`)
-            = creator
+          td.g-annotation-user
+            a(href=`#user/${annotation.get('creatorId')}`)
+              = creator
 
-        td.g-annotation-date
-          = (new Date(annotation.get('created'))).toLocaleString()
-        td.g-annotation-actions
-          a.g-annotation-download(href=`${apiRoot}/annotation/${annotation.id}`, title='Download', download=`${name}.json`)
-            i.icon-download
-          if annotation.get('_accessLevel') >= AccessType.ADMIN
-            a.g-annotation-permissions(title='Adjust permissions')
-              i.icon-lock
-          if annotation.get('_accessLevel') >= AccessType.WRITE
-            a.g-annotation-delete(title='Delete')
-              i.icon-cancel
+          td.g-annotation-date
+            = (new Date(annotation.get('created'))).toLocaleString()
+          td.g-annotation-actions
+            a.g-annotation-download(href=`${apiRoot}/annotation/${annotation.id}`, title='Download', download=`${name}.json`)
+              i.icon-download
+            if annotation.get('_accessLevel') >= AccessType.ADMIN
+              a.g-annotation-permissions(title='Adjust permissions')
+                i.icon-lock
+            if annotation.get('_accessLevel') >= AccessType.WRITE
+              a.g-annotation-delete(title='Delete')
+                i.icon-cancel
+else
+  p This image does not contain any annotations.

--- a/web_client/templates/annotationListWidget.pug
+++ b/web_client/templates/annotationListWidget.pug
@@ -1,8 +1,8 @@
-.g-annotation-list-header
-  i.icon-pencil
-  | Annotations
-
 if annotations.length
+  .g-annotation-list-header
+    i.icon-pencil
+    | Annotations
+
   table.g-annotation-list.table.table-hover.table-condensed
     thead
       th.g-annotation-toggle
@@ -36,5 +36,3 @@ if annotations.length
             if annotation.get('_accessLevel') >= AccessType.WRITE
               a.g-annotation-delete(title='Delete')
                 i.icon-cancel
-else
-  p This image does not contain any annotations.

--- a/web_client/templates/annotationListWidget.pug
+++ b/web_client/templates/annotationListWidget.pug
@@ -1,0 +1,37 @@
+.g-annotation-list-header
+  i.icon-pencil
+  | Annotations
+
+table.g-annotation-list.table.table-hover.table-condensed
+  thead
+    th.g-annotation-toggle
+    th.g-annotation-name Name
+    th.g-annotation-user Creator
+    th.g-annotation-date Date
+    th.g-annotation-actions
+  tbody
+    for annotation in annotations.models
+      - var name = annotation.get('annotation').name;
+      - var creatorModel = users.get(annotation.get('creatorId'));
+      - var creator = creatorModel ? creatorModel.get('login') : annotation.get('creatorId');
+      tr.g-annotation-row(data-annotation-id=annotation.id)
+        td.g-annotation-toggle
+          input(type='checkbox', disabled=!canDraw, checked=drawn.has(annotation.id))
+        td.g-annotation-name(title=name)
+          = name
+
+        td.g-annotation-user
+          a(href=`#user/${annotation.get('creatorId')}`)
+            = creator
+
+        td.g-annotation-date
+          = (new Date(annotation.get('created'))).toLocaleString()
+        td.g-annotation-actions
+          a.g-annotation-download(href=`${apiRoot}/annotation/${annotation.id}`, title='Download', download=`${name}.json`)
+            i.icon-download
+          if annotation.get('_accessLevel') >= AccessType.ADMIN
+            a.g-annotation-permissions(title='Adjust permissions')
+              i.icon-lock
+          if annotation.get('_accessLevel') >= AccessType.WRITE
+            a.g-annotation-delete(title='Delete')
+              i.icon-cancel

--- a/web_client/templates/imageViewerSelectWidget.pug
+++ b/web_client/templates/imageViewerSelectWidget.pug
@@ -7,3 +7,5 @@
       option(value=viewer.name) #{viewer.label}
 each viewer in viewers
   .image-viewer.hidden(id=viewer.name)
+
+.g-annotation-list-container

--- a/web_client/views/annotationListWidget.js
+++ b/web_client/views/annotationListWidget.js
@@ -1,0 +1,127 @@
+import _ from 'underscore';
+
+import { AccessType } from 'girder/constants';
+import { confirm } from 'girder/dialog';
+import { getApiRoot } from 'girder/rest';
+import AccessWidget from 'girder/views/widgets/AccessWidget';
+import UserCollection from 'girder/collections/UserCollection';
+import View from 'girder/views/View';
+
+import AnnotationCollection from '../collections/AnnotationCollection';
+
+import annotationList from '../templates/annotationListWidget.pug';
+
+import '../stylesheets/annotationListWidget.styl';
+
+const AnnotationListWidget = View.extend({
+    events: {
+        'change .g-annotation-toggle': '_displayAnnotation',
+        'click .g-annotation-delete': '_deleteAnnotation',
+        'click .g-annotation-permissions': '_changePermissions',
+        'click .g-annotation-row'(evt) {
+            var $el = $(evt.currentTarget);
+            $el.find('.g-annotation-toggle > input').click();
+        },
+        'click .g-annotation-row a,input'(evt) {
+            evt.stopPropagation();
+        }
+    },
+
+    initialize() {
+        this._drawn = new Set();
+        this._viewer = null;
+        this._sort = {
+            'field': 'name',
+            'direction': 1
+        };
+
+        this.collection = this.collection || new AnnotationCollection();
+        this.users = new UserCollection();
+
+        this.listenTo(this.collection, 'all', this.render);
+        this.listenTo(this.users, 'all', this.render);
+
+        this.collection.fetch({
+            itemId: this.model.id,
+            sort: 'created',
+            sortdir: -1
+        }).done(() => {
+            this._fetchUsers();
+        });
+    },
+
+    render() {
+        this.$el.html(annotationList({
+            annotations: this.collection,
+            users: this.users,
+            canDraw: this._viewer && this._viewer.annotationAPI(),
+            drawn: this._drawn,
+            apiRoot: getApiRoot(),
+            AccessType
+        }));
+        return this;
+    },
+
+    setViewer(viewer) {
+        this._drawn.clear();
+        this._viewer = viewer;
+        return this;
+    },
+
+    _displayAnnotation(evt) {
+        const $el = $(evt.currentTarget);
+        const id = $el.parent().data('annotationId');
+        const annotation = this.collection.get(id);
+        if ($el.find('input').prop('checked')) {
+            this._drawn.add(id);
+            this._viewer.drawAnnotation(annotation);
+        } else {
+            this._drawn.delete(id);
+            this._viewer.removeAnnotation(annotation);
+        }
+    },
+
+    _deleteAnnotation(evt) {
+        const $el = $(evt.currentTarget);
+        const id = $el.parents('.g-annotation-row').data('annotationId');
+        const model = this.collection.get(id);
+
+        confirm({
+            text: `Are you sure you want to delete <b>${_.escape(model.get('annotation').name)}</b>?`,
+            escapedHtml: true,
+            yesText: 'Delete',
+            confirmCallback: () => {
+                this._drawn.delete(id);
+                model.destroy();
+            }
+        });
+    },
+
+    _changePermissions(evt) {
+        const $el = $(evt.currentTarget);
+        const id = $el.parents('.g-annotation-row').data('annotationId');
+        const model = this.collection.get(id);
+        new AccessWidget({
+            el: $('#g-dialog-container'),
+            type: 'annotation',
+            hideRecurseOption: true,
+            parentView: this,
+            model
+        }).on('g:accessListSaved', () => {
+            this.collection.fetch(null, true);
+        });
+    },
+
+    _fetchUsers() {
+        this.collection.each((model) => {
+            this.users.add({'_id': model.get('creatorId')});
+        });
+        $.when.apply($, this.users.map((model) => {
+            return model.fetch();
+        })).always(() => {
+            this.render();
+        });
+    }
+});
+
+export default AnnotationListWidget;

--- a/web_client/views/annotationListWidget.js
+++ b/web_client/views/annotationListWidget.js
@@ -35,7 +35,7 @@ const AnnotationListWidget = View.extend({
             'direction': 1
         };
 
-        this.collection = this.collection || new AnnotationCollection();
+        this.collection = this.collection || new AnnotationCollection({comparator: null});
         this.users = new UserCollection();
 
         this.listenTo(this.collection, 'all', this.render);

--- a/web_client/views/annotationListWidget.js
+++ b/web_client/views/annotationListWidget.js
@@ -35,7 +35,7 @@ const AnnotationListWidget = View.extend({
             'direction': 1
         };
 
-        this.collection = this.collection || new AnnotationCollection({comparator: null});
+        this.collection = this.collection || new AnnotationCollection([], {comparator: null});
         this.users = new UserCollection();
 
         this.listenTo(this.collection, 'all', this.render);

--- a/web_client/views/imageViewerSelectWidget.js
+++ b/web_client/views/imageViewerSelectWidget.js
@@ -8,6 +8,8 @@ import View from 'girder/views/View';
 import largeImageConfig from './configView';
 import * as viewers from './imageViewerWidget';
 
+import AnnotationListWidget from './annotationListWidget';
+
 import imageViewerSelectWidget from '../templates/imageViewerSelectWidget.pug';
 import '../stylesheets/imageViewerSelectWidget.styl';
 
@@ -42,6 +44,10 @@ var ImageViewerSelectWidget = View.extend({
         this.itemId = settings.imageModel.id;
         this.model = settings.imageModel;
         this.currentViewer = null;
+        this._annotationList = new AnnotationListWidget({
+            model: this.model,
+            parentView: this
+        });
         largeImageConfig.getSettings(() => this.render());
     },
 
@@ -58,6 +64,11 @@ var ImageViewerSelectWidget = View.extend({
         }
         this.$('select.form-control').val(name);
         this._selectViewer(name);
+
+        this._annotationList
+            .setViewer(this.currentViewer)
+            .setElement(this.$('.g-annotation-list-container'))
+            .render();
         return this;
     },
 
@@ -85,6 +96,9 @@ var ImageViewerSelectWidget = View.extend({
             model: this.model
         });
         this.currentViewer.name = viewerName;
+        this._annotationList
+            .setViewer(this.currentViewer)
+            .render();
     }
 });
 

--- a/web_client/views/imageViewerWidget/base.js
+++ b/web_client/views/imageViewerWidget/base.js
@@ -1,3 +1,5 @@
+import _ from 'underscore';
+
 import { apiRoot, restRequest } from 'girder/rest';
 import View from 'girder/views/View';
 
@@ -36,6 +38,12 @@ var ImageViewerWidget = View.extend({
         }
         return url;
     },
+
+    /**
+     * Returns whether or not the view supports drawing and rendering
+     * annotations.
+     */
+    annotationAPI: _.constant(false),
 
     /**
      * Render an annotation model on the image.

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -144,6 +144,8 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
         ImageViewerWidget.prototype.destroy.call(this);
     },
 
+    annotationAPI: _.constant(true),
+
     /**
      * Render an annotation model on the image.  Currently,
      * this is limited to annotation types that can be directly


### PR DESCRIPTION
This adds a simple table displaying annotations attached to the current item.  The user can click on them to view them if using the GeoJS viewer (the only one capable of rendering annotations at the moment).  The delete and access buttons are only visible if the user has the necessary permissions.

![test](https://user-images.githubusercontent.com/31890/39248542-5b9609fe-486a-11e8-9780-a9774c30088c.png)