### PR TITLE
Add a public param to PUT /annotations/:id/access

### DIFF
--- a/plugin_tests/annotations_test.py
+++ b/plugin_tests/annotations_test.py
@@ -843,9 +843,26 @@ class LargeImageAnnotationRestTest(common.LargeImageCommonTest):
         # Get the ACL's as an admin
         resp = self.request('/annotation/%s/access' % annot['_id'], user=self.admin)
         self.assertStatusOk(resp)
+        access = dict(**resp.json)
+
+        # Set the public flag to false and try to read as a user
+        resp = self.request(
+            '/annotation/%s/access' % annot['_id'],
+            method='PUT',
+            user=self.admin,
+            params={
+                'access': json.dumps(access),
+                'public': False
+            }
+        )
+        self.assertStatusOk(resp)
+        resp = self.request(
+            '/annotation/%s' % annot['_id'],
+            user=self.user
+        )
+        self.assertStatus(resp, 403)
 
         # Give the user admin access
-        access = dict(**resp.json)
         access['users'].append({
             'login': self.user['login'],
             'flags': [],

--- a/server/rest/annotation.py
+++ b/server/rest/annotation.py
@@ -304,7 +304,9 @@ class AnnotationResource(Resource):
     @describeRoute(
         Description('Update the access control list for an annotation.')
         .param('id', 'The ID of the annotation.', paramType='path')
-        .param('access', 'THe JSON-encoded access control list.')
+        .param('access', 'The JSON-encoded access control list.')
+        .param('public', 'Whether the annotation should be publicly visible.',
+               dataType='boolean', required=False)
         .errorResponse('ID was invalid.')
         .errorResponse('Admin access was denied for the annotation.', 403)
     )
@@ -313,6 +315,8 @@ class AnnotationResource(Resource):
     @filtermodel(model=Annotation, addFields={'access'})
     def updateAnnotationAccess(self, annotation, params):
         access = json.loads(params['access'])
+        public = self.boolParam('public', params, False)
+        annotation = Annotation().setPublic(annotation, public)
         return Annotation().setAccessList(
             annotation, access, save=True, user=self.getCurrentUser())
 


### PR DESCRIPTION
This parameter is required for compatibility with Girder's AccessWidget.