### PR TITLE
Add a name method to AnnotationModel

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -420,5 +420,15 @@ describe('Annotations', function () {
                 model.save();
             }).toThrow();
         });
+
+        it('get an annotation name', function () {
+            var model = new largeImage.models.AnnotationModel({
+                itemId: item._id,
+                annotation: {
+                    name: 'test annotation'
+                }
+            });
+            expect(model.name()).toBe('test annotation');
+        });
     });
 });

--- a/web_client/models/AnnotationModel.js
+++ b/web_client/models/AnnotationModel.js
@@ -166,6 +166,10 @@ export default AccessControlledModel.extend({
         return this.delete(options);
     },
 
+    name() {
+        return (this.get('annotation') || {}).name;
+    },
+
     /**
      * Perform a DELETE request on the annotation model and reset the id
      * attribute, but don't remove event listeners.


### PR DESCRIPTION
Girder uses this method in several places to inject document names into generic widgets.