### PR TITLE
Use the Girder FUSE mount.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,8 @@ addons:
       - python-mapnik
       # girder worker - not needed; included in travis
       # - rabbitmq-server
+      # fuse plugin tests - not needed; included in travis
+      # - fuse
 
 services:
   - rabbitmq
@@ -209,10 +211,13 @@ before_install:
 
   - pip install --no-cache-dir numpy>=1.11.3  # needed because libtiff doesn't install correctly without it.  This ensures we have the same version for libtiff as for the project.
 
+  # Allow access to /etc/fuse.conf by all users
+  - sudo chmod a+r /etc/fuse.conf
+
 
 install:
   - pushd $girder_path
-  - pip install --no-cache-dir -U -r requirements-dev.txt -e .
+  - pip install --no-cache-dir -U -r requirements-dev.txt -e .[mount]
   - popd
   - girder-install plugin --symlink $large_image_path
   # Install all extras (since "girder-install plugin" does not provide a mechanism to specify them

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ before_install:
   - lib_build_path=$HOME/lib_build
   - girder_build_path=$HOME/girder_build
 
-  - nvm install v6
+  - nvm install v8
   - npm install -g npm
 
   - git clone https://github.com/girder/girder.git $girder_path && git -C $girder_path checkout $GIRDER_VERSION

--- a/plugin.cmake
+++ b/plugin.cmake
@@ -85,6 +85,13 @@ add_python_test(sources PLUGIN large_image BIND_SERVER
 set_property(TEST server_large_image.sources APPEND PROPERTY ENVIRONMENT
   "LARGE_IMAGE_DATA=${PROJECT_BINARY_DIR}/data/plugins/large_image")
 
+add_python_test(fuse_off PLUGIN large_image BIND_SERVER)
+set_property(TEST server_large_image.fuse_off APPEND PROPERTY ENVIRONMENT
+  "LARGE_IMAGE_DATA=${PROJECT_BINARY_DIR}/data/plugins/large_image")
+
+add_python_test(fuse_on PLUGIN large_image BIND_SERVER)
+set_property(TEST server_large_image.fuse_on APPEND PROPERTY ENVIRONMENT
+  "LARGE_IMAGE_DATA=${PROJECT_BINARY_DIR}/data/plugins/large_image")
 
 add_python_test(import PLUGIN large_image BIND_SERVER)
 

--- a/plugin_tests/common.py
+++ b/plugin_tests/common.py
@@ -38,8 +38,8 @@ TIFFHeader = b'II\x2a\x00'
 
 
 class LargeImageCommonTest(base.TestCase):
-    def setUp(self):
-        base.TestCase.setUp(self)
+    def setUp(self, *args, **kwargs):
+        base.TestCase.setUp(self, *args, **kwargs)
         admin = {
             'email': 'admin@email.com',
             'login': 'adminlogin',

--- a/plugin_tests/fuse_off_test.py
+++ b/plugin_tests/fuse_off_test.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#############################################################################
+
+import os
+import six
+
+from girder import config
+from girder.models.file import File
+from girder.models.item import Item
+from tests import base
+
+from . import common
+
+
+# boiler plate to start and stop the server
+
+os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_TEST_PORT', '20200')
+config.loadConfig()  # Must reload config to pickup correct port
+
+
+def setUpModule():
+    base.enabledPlugins.append('large_image')
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class LargeImageWithoutFuseGridFSTest(common.LargeImageCommonTest):
+    def setUp(self):
+        super(LargeImageWithoutFuseGridFSTest, self).setUp(assetstoreType='gridfs')
+
+    def testGridFSAssetstore(self):
+        from girder.plugins.large_image.models.image_item import ImageItem
+        from girder.plugins.large_image.tilesource import TileSourceException
+
+        file = self._uploadFile(os.path.join(
+            os.environ['LARGE_IMAGE_DATA'], 'sample_image.ptif'))
+        itemId = str(file['itemId'])
+        item = Item().load(itemId, user=self.admin)
+        # We should get an error that this isn't a large image
+        with six.assertRaisesRegex(self, TileSourceException, 'No large image file in this item'):
+            ImageItem().tileSource(item)
+
+
+class LargeImageWithoutFuseFSTest(common.LargeImageCommonTest):
+    def testFilesystemAssetstore(self):
+        from girder.plugins.large_image.models.image_item import ImageItem
+
+        file = self._uploadFile(os.path.join(
+            os.environ['LARGE_IMAGE_DATA'], 'sample_image.ptif'))
+        itemId = str(file['itemId'])
+        item = Item().load(itemId, user=self.admin)
+        file = File().load(item['largeImage']['fileId'], force=True)
+        # With a second file, large image would prefer to use the Girder mount,
+        # if available
+        File().createLinkFile('second', item, 'item', 'http://nourl.com', self.admin)
+        source = ImageItem().tileSource(item)
+        # The file path should just be the local path
+        self.assertEqual(source._getLargeImagePath(), File().getLocalFilePath(file))

--- a/plugin_tests/fuse_on_test.py
+++ b/plugin_tests/fuse_on_test.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+#############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#############################################################################
+
+import os
+import subprocess
+import tempfile
+import time
+
+from girder import config
+from girder.models.file import File
+from girder.models.item import Item
+from tests import base
+
+from . import common
+
+
+# boiler plate to start and stop the server
+
+os.environ['GIRDER_PORT'] = os.environ.get('GIRDER_TEST_PORT', '20200')
+config.loadConfig()  # Must reload config to pickup correct port
+
+
+def setUpModule():
+    # The mount is not done in the module setup, as the test framework clears
+    # the test databasei as part of TestCase.setUp , which loses the mount
+    # information.
+    base.enabledPlugins.append('large_image')
+    base.startServer()
+
+
+def tearDownModule():
+    base.stopServer()
+
+
+class LargeImageGirderMountTest(common.LargeImageCommonTest):
+    def setUp(self, *args, **kwargs):
+        super(LargeImageGirderMountTest, self).setUp(*args, **kwargs)
+        self.mountPath = tempfile.mkdtemp()
+        # Start the mount
+        subprocess.check_call([
+            'girder', 'mount', self.mountPath, '--plugins', 'large_image',
+            '-d', os.environ['GIRDER_TEST_DB'], '--quiet'])
+        # Wait until it is mounted before proceeding
+        endTime = time.time() + 10  # maximum time to wait
+        while time.time() < endTime:
+            if os.path.exists(os.path.join(self.mountPath, 'user')):
+                break
+            time.sleep(0.1)
+
+    def tearDown(self):
+        super(LargeImageGirderMountTest, self).tearDown()
+        # unmount
+        subprocess.check_call(['girder', 'mount', self.mountPath, '-u'])
+        # Wait until finished
+        endTime = time.time() + 10  # maximum time to wait
+        while time.time() < endTime:
+            if not os.path.exists(os.path.join(self.mountPath, 'user')):
+                break
+            time.sleep(0.1)
+        os.rmdir(self.mountPath)
+
+
+class LargeImageWithFuseGridFSTest(LargeImageGirderMountTest):
+    def setUp(self):
+        super(LargeImageWithFuseGridFSTest, self).setUp(assetstoreType='gridfs')
+
+    def testGridFSAssetstore(self):
+        from girder.plugins.large_image.models.image_item import ImageItem
+
+        file = self._uploadFile(os.path.join(
+            os.environ['LARGE_IMAGE_DATA'], 'sample_image.ptif'))
+        itemId = str(file['itemId'])
+        item = Item().load(itemId, user=self.admin)
+        # We should be able to read the metadata
+        source = ImageItem().tileSource(item)
+        metadata = source.getMetadata()
+        self.assertEqual(metadata['sizeX'], 58368)
+        self.assertEqual(metadata['sizeY'], 12288)
+        self.assertEqual(metadata['levels'], 9)
+
+
+class LargeImageWithFuseFSTest(LargeImageGirderMountTest):
+    def testFilesystemAssetstore(self):
+        from girder.plugins.large_image.models.image_item import ImageItem
+
+        file = self._uploadFile(os.path.join(
+            os.environ['LARGE_IMAGE_DATA'], 'sample_image.ptif'))
+        itemId = str(file['itemId'])
+        item = Item().load(itemId, user=self.admin)
+        file = File().load(item['largeImage']['fileId'], force=True)
+        # With a second file, large image would prefer to use the Girder mount,
+        # if available
+        File().createLinkFile('second', item, 'item', 'http://nourl.com', self.admin)
+        source = ImageItem().tileSource(item)
+        # The file path should not be the local path, since we told it we might
+        # have adjacent files.
+        self.assertNotEqual(source._getLargeImagePath(), File().getLocalFilePath(file))

--- a/plugin_tests/fuse_on_test.py
+++ b/plugin_tests/fuse_on_test.py
@@ -65,6 +65,15 @@ class LargeImageGirderMountTest(common.LargeImageCommonTest):
 
     def tearDown(self):
         super(LargeImageGirderMountTest, self).tearDown()
+        # Even if we close all of our references, we aren't guaranteed that
+        # all files are released immediately.  At this point, the data.process
+        # thread (regardless of whether it is synchronous or asynchronous)
+        # still has a reference to the source that was tested with canRead.
+        # This seems to only be a testing artifact.  If we do a garbage
+        # collection, it will properly release those references and we can
+        # unmount immediately.
+        import gc
+        gc.collect()
         # unmount
         subprocess.check_call(['girder', 'mount', self.mountPath, '-u'])
         # Wait until finished

--- a/server/base.py
+++ b/server/base.py
@@ -33,6 +33,7 @@ from . import constants
 from .models.annotation import Annotation
 from .models.image_item import ImageItem
 from .loadmodelcache import invalidateLoadModelCache
+from . import cache_util
 
 
 def _postUpload(event):
@@ -283,3 +284,4 @@ def load(info):
     events.bind('model.file.save.after', 'large_image',
                 checkForLargeImageFiles)
     events.bind('model.item.remove', 'large_image', removeThumbnails)
+    events.bind('server_fuse.unmount', 'large_image', cache_util.cachesClear)


### PR DESCRIPTION
The direct path will be used on the filesystem assetstore unless the Girder item has a file besides the large_item file and an originating file.