### PR TITLE
Add mrxs to the list of extensions.

### DIFF
--- a/server/base.py
+++ b/server/base.py
@@ -124,7 +124,7 @@ def checkForLargeImageFiles(event):
     if mimeType in ('image/tiff', 'image/x-tiff', 'image/x-ptif'):
         possible = True
     exts = file.get('exts')
-    if exts and exts[-1] in ('svs', 'ptif', 'tif', 'tiff', 'ndpi'):
+    if exts and exts[-1] in ('svs', 'ptif', 'tif', 'tiff', 'ndpi', 'mrxs'):
         possible = True
     if not file.get('itemId') or not possible:
         return


### PR DESCRIPTION
If a file with this extension is imported it will automatically be tested to see if it can be used as a large image.