### PR TITLE
Fix an issue when drawing selection rectangles.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -230,7 +230,7 @@ install:
     fi
   - ls -l $girder_path/plugins
   # Make sure we have a prefered version of celery for Girder Worker
-  - pip install -U 'celery>=4'
+  - pip install -U 'celery>=4,<4.2'
   # # Make sure we have a prefered version of cryptography for Girder Worker
   # - pip install -U 'cryptography>=1.7'
   - python -c "import openslide;print(openslide.__version__)"

--- a/plugin_tests/client/geojsAnnotationSpec.js
+++ b/plugin_tests/client/geojsAnnotationSpec.js
@@ -118,6 +118,24 @@ describe('geojs-annotations', function () {
                 lineWidth: lineWidth,
                 normal: [0, 0, 1]
             });
+
+            coordinates = [
+                {x: 3, y: 2},
+                {x: 3, y: 4},
+                {x: 1, y: 4},
+                {x: 1, y: 2}
+            ];
+            expect(geojs.types.rectangle(annotation)).toEqual({
+                type: 'rectangle',
+                center: [2, 3, 0],
+                width: 2,
+                height: 2,
+                rotation: 0,
+                fillColor: fillColor,
+                lineColor: lineColor,
+                lineWidth: lineWidth,
+                normal: [0, 0, 1]
+            });
         });
 
         it('rotated rectangle', function () {
@@ -133,12 +151,20 @@ describe('geojs-annotations', function () {
                 center: [0, 0, 0],
                 width: Math.sqrt(2),
                 height: Math.sqrt(2),
-                rotation: Math.PI / 4,
+                rotation: -Math.PI / 4,
                 fillColor: fillColor,
                 lineColor: lineColor,
                 lineWidth: lineWidth,
                 normal: [0, 0, 1]
             });
+
+            coordinates = [
+                {x: 1, y: 2},
+                {x: 9, y: 8},
+                {x: 5, y: 11},
+                {x: -3, y: 5}
+            ];
+            expect(geojs.types.rectangle(annotation).rotation).toBeCloseTo(Math.atan2(3, 4));
         });
 
         it('polygon', function () {

--- a/web_client/annotations/geojs/types/rectangle.js
+++ b/web_client/annotations/geojs/types/rectangle.js
@@ -8,7 +8,34 @@ import common from '../common';
  */
 function rectangle(annotation) {
     const element = common(annotation);
-    const [p1, p2, p3, p4] = annotation.coordinates();
+    let p = annotation.coordinates();
+    /* Sort the coordinates so they are always in the same winding order. */
+    let ang = [
+        Math.atan2(p[1].y - p[0].y, p[1].x - p[0].x),
+        Math.atan2(p[2].y - p[1].y, p[2].x - p[1].x),
+        Math.atan2(p[3].y - p[2].y, p[3].x - p[2].x),
+        Math.atan2(p[0].y - p[3].y, p[0].x - p[3].x)
+    ];
+    let ang0 = ang.indexOf(Math.min(...ang));
+    if (ang[(ang0 + 1) % 4] - ang[ang0] > Math.PI) {
+        p = [p[0], p[3], p[2], p[1]];
+        ang = [
+            Math.atan2(p[1].y - p[0].y, p[1].x - p[0].x),
+            Math.atan2(p[2].y - p[1].y, p[2].x - p[1].x),
+            Math.atan2(p[3].y - p[2].y, p[3].x - p[2].x),
+            Math.atan2(p[0].y - p[3].y, p[0].x - p[3].x)
+        ];
+        ang0 = ang.indexOf(Math.min(...ang));
+    }
+    /* If rotate, bias toward the more flat direction. */
+    if (ang[ang0] < -0.75 * Math.PI) {
+        ang0 += 1;
+    }
+    /* Sort the coordinates so that they are in a predictable order */
+    const p1 = p[ang0 % 4],
+        p2 = p[(ang0 + 1) % 4],
+        p3 = p[(ang0 + 2) % 4],
+        p4 = p[(ang0 + 3) % 4];
     const top = [p3.x - p2.x, p3.y - p2.y];
     const left = [p2.x - p1.x, p2.y - p1.y];
 


### PR DESCRIPTION
If, for instance, in HistomicsTK, you select a region by clicking and dragging, it works fine.  But if you select the same region by clicking opposite corners of the rectangle, the rectangle is deformed.  Specifically, this computes center, width, and height of a rectangle, and made two assumptions: that the first point was always a specific corner, and that the points always were in the same winding order.  Neither of these assumptions are always correct.  This avoids making assumptions, but otherwise maintains the same process.