### PR TITLE
Change a few cache defaults.

### DIFF
--- a/server/cache_util/cachefactory.py
+++ b/server/cache_util/cachefactory.py
@@ -102,13 +102,14 @@ class CacheFactory(object):
 
     def getCacheSize(self, numItems):
         if numItems is None:
+            defaultPortion = 8 if config else 32
             try:
-                portion = int(getConfig('cache_python_memory_portion', 8))
+                portion = int(getConfig('cache_python_memory_portion', defaultPortion))
                 if portion < 3:
                     portion = 3
             except ValueError:
-                portion = 16
-            numItems = pickAvailableCache(256**2 * 4, portion)
+                portion = defaultPortion
+            numItems = pickAvailableCache(256**2 * 4 * 2, portion)
         return numItems
 
     def getCache(self, numItems=None):


### PR DESCRIPTION
If config is not set, then we aren't running in Girder, in which case use a smaller memory portion for caches.  A common use case is Dask with multiple workers, and the ordinary default would ideally be divided by the maximum number of workers on any given machine.

Also, double the expected memory per image tile by default.