### PR TITLE
Pass the geojs event object to annotation events

### DIFF
--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -456,7 +456,8 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
                 this.trigger(
                     eventType,
                     properties.element,
-                    properties.annotation
+                    properties.annotation,
+                    evt
                 );
             }
         }


### PR DESCRIPTION
This will allow downstream code to detect event modifiers (shift, ctrl, right click, etc.) in their handlers.