### PR TITLE
Guard against exceptions when fetching associated images.

### DIFF
--- a/server/tilesource/svs.py
+++ b/server/tilesource/svs.py
@@ -295,7 +295,10 @@ class SVSFileTileSource(FileTileSource):
 
         :return: the list of image keys.
         """
-        return sorted(self._openslide.associated_images)
+        try:
+            return sorted(self._openslide.associated_images)
+        except openslide.lowlevel.OpenSlideError:
+            return []
 
     def _getAssociatedImage(self, imageKey):
         """
@@ -304,8 +307,11 @@ class SVSFileTileSource(FileTileSource):
         :param imageKey: the key of the associated image.
         :return: the image in PIL format or None.
         """
-        if imageKey in self._openslide.associated_images:
-            return self._openslide.associated_images[imageKey]
+        try:
+            if imageKey in self._openslide.associated_images:
+                return self._openslide.associated_images[imageKey]
+        except openslide.lowlevel.OpenSlideError:
+            pass
         return None
 
 


### PR DESCRIPTION
If there is a bad image inside of a svs or tiff file, it can throw an error and prevent reading the entire file.  This guards against this problem withing the openslide reader.

Pylibtiff also needs a guard, but that has been committed to that repo.