### PR TITLE
Return annotations via yielding elements

### DIFF
--- a/server/rest/annotation.py
+++ b/server/rest/annotation.py
@@ -144,7 +144,6 @@ class AnnotationResource(Resource):
     )
     @access.cookie
     @access.public
-    # @filtermodel(model='annotation', plugin='large_image')
     def getAnnotation(self, id, params):
         user = self.getCurrentUser()
         annotation = Annotation().load(

--- a/server/rest/annotation.py
+++ b/server/rest/annotation.py
@@ -177,18 +177,6 @@ class AnnotationResource(Resource):
                 # could be used in its most default mode instead like so:
                 #   result = json.dumps(element, separators=(',', ':'))
                 result = ujson.dumps(element)
-                # By default, the json encoder outputs float values that happen
-                # to be integers as <value>.0.  This is a common occurrence.
-                # Javascript parses the json identically with and without the
-                # trailing '.0'.  If we can trivially do so, string these
-                # trailing values.  This splits the string on ", but only if it
-                # has no possibility of escaped quotes, then strips the
-                # trailing zeroes from the non-quoted sections, then puts the
-                # string back together.
-                if '.0' in result and '\\"' not in result:
-                    result = '"'.join([
-                        d if '.0' in d and di % 2 else d.replace('.0,', ',').replace('.0]', ']')
-                        for di, d in enumerate(result.split('"'))])
                 result = (b',' if idx else b'') + result.encode('utf8')
                 yield result
                 idx += 1

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ setup(
         'numpy>=1.10.2',
         'Pillow>=3.2.0',
         'psutil>=4.2.0',
-        'six>=1.10.0'
+        'six>=1.10.0',
+        'ujson>=1.35',
     ],
     extras_require={
         'memcached': [

--- a/web_client/models/AnnotationModel.js
+++ b/web_client/models/AnnotationModel.js
@@ -26,7 +26,7 @@ export default AccessControlledModel.extend({
 
     initialize() {
         this._region = {
-            maxDetails: 100000,
+            maxDetails: 250000,
             sort: 'size',
             sortdir: -1
         };
@@ -234,7 +234,7 @@ export default AccessControlledModel.extend({
         this._region.bottom = bounds.bottom + yoverlap;
         /* ask for items that will be at least 0.5 pixels, minus a bit */
         this._lastZoom = zoom;
-        this._region.minSize = Math.pow(2, maxZoom - zoom - 1) - 1;
+        this._region.minimumSize = Math.pow(2, maxZoom - zoom - 1) - 1;
         if (!this._nextFetch) {
             var nextFetch = () => {
                 this.fetch();


### PR DESCRIPTION
Instead of returning annotations as a monolithic response, yield from the database as the elements are read.  This reduces memory and speeds up the response.  For a large annotation set (~0.3 million polygons), this reduced output time by a factor of 3.

Use the ujson library for serializing annotation elements.  This takes 2/3 the time of the default json library for polygons.

Strip trailing .0 from floats that have integer values to reduce output size when it can be done trivially.  Javascript treats the results the same.