### PR TITLE
Allow a color array to be passed in place of a palette name.

### DIFF
--- a/plugin_tests/source_mapnik_test.py
+++ b/plugin_tests/source_mapnik_test.py
@@ -326,6 +326,24 @@ class LargeImageSourceMapnikTest(common.LargeImageCommonTest):
         self.assertStatusOk(resp)
         self.assertEqual(resp.json, {
             'r': 225, 'g': 100, 'b': 98, 'a': 255, 'bands': {'1': 77.0, '2': 82.0, '3': 84.0}})
+        # Test with palette as an array of colors
+        resp = self.request(
+            path='/item/%s/tiles/pixel' % itemId, user=self.admin,
+            params={
+                'left': -13132910,
+                'top': 4010586,
+                'projection': 'EPSG:3857',
+                'units': 'projection',
+                'style': json.dumps({
+                    'band': 1,
+                    'min': 0,
+                    'max': 100,
+                    'palette': ['#0000ff', '#00ff00', '#ff0000']
+                }),
+            })
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, {
+            'r': 0, 'g': 255, 'b': 0, 'a': 255, 'bands': {'1': 77.0, '2': 82.0, '3': 84.0}})
         # Test with projection units
         resp = self.request(
             path='/item/%s/tiles/pixel' % itemId, user=self.admin,

--- a/server/tilesource/mapniksource.py
+++ b/server/tilesource/mapniksource.py
@@ -384,9 +384,12 @@ class MapnikTileSource(FileTileSource):
             if band != -1 and isinstance(band, int):
                 minimum = self.style.get('min', 0)
                 maximum = self.style.get('max', 256)
-                palette = self.style.get('palette',
-                                         'cmocean.diverging.Curl_10')
-                colors = self.getHexColors(palette)
+                colors = self.style.get('palette', 'cmocean.diverging.Curl_10')
+                if not isinstance(colors, list):
+                    colors = self.getHexColors(colors)
+                else:
+                    colors = [color if isinstance(color, six.binary_type) else
+                              color.encode('utf8') for color in colors]
                 values = self.interpolateMinMax(minimum,
                                                 maximum,
                                                 len(colors))


### PR DESCRIPTION
When styling a mapnik tile source, `palette` is the name of a palettable class.  It can now also be an array of colors, for instance `["#0000ff", "white", "#ff0000"]`.