### PR TITLE
Add a refresh flag to the annotation model.

### DIFF
--- a/plugin_tests/client/geojsSpec.js
+++ b/plugin_tests/client/geojsSpec.js
@@ -122,6 +122,7 @@ $(function () {
         });
 
         it('drawAnnotation', function () {
+            var setViewSpy, firstCount;
             runs(function () {
                 annotation = new large_image.models.AnnotationModel({
                     _id: annotationId
@@ -131,7 +132,7 @@ $(function () {
 
             girderTest.waitForLoad();
             runs(function () {
-                sinon.spy(annotation, 'setView');
+                setViewSpy = sinon.spy(annotation, 'setView');
                 viewer.drawAnnotation(annotation);
                 viewer.viewer.zoom(5);
             });
@@ -145,7 +146,11 @@ $(function () {
                 featureSpy = sinon.spy(viewer._annotations[annotationId].features[0], '_exit');
 
                 sinon.assert.called(annotation.setView);
+                firstCount = setViewSpy.callCount;
+                viewer.viewer.zoomRange({max: 12});
+                viewer.viewer.zoom(12);
                 viewer.viewer.zoom(1);
+                expect(setViewSpy.callCount).toBe(firstCount + 2);
             });
         });
 

--- a/web_client/models/AnnotationModel.js
+++ b/web_client/models/AnnotationModel.js
@@ -102,6 +102,21 @@ export default AccessControlledModel.extend({
     },
 
     /**
+     * Get/set for a refresh flag.
+     *
+     * @param {boolean} [val] If specified, set the refresh flag.  If not
+     *    specified, return the refresh flag.
+     * @returns {boolean|this}
+     */
+    refresh(val) {
+        if (val === undefined) {
+            return self._refresh;
+        }
+        self._refresh = val;
+        return this;
+    },
+
+    /**
      * Perform a PUT or POST request on the annotation data depending
      * on whether the annotation is new or not.  This mirrors somewhat
      * the api of `Backbone.Model.save`.  For new models, the `itemId`
@@ -204,12 +219,14 @@ export default AccessControlledModel.extend({
      * Callers should listen for the g:fetched event to know when new elements
      * have been fetched.
      *
-     * @param {object} bounds: the corners of the visible region.  This is an
+     * @param {object} bounds the corners of the visible region.  This is an
      *      object with left, top, right, bottom in pixels.
-     * @param {number} zoom: the zoom factor.
-     * @param {number} maxZoom: the maximum zoom factor.
+     * @param {number} zoom the zoom factor.
+     * @param {number} maxZoom the maximum zoom factor.
+     * @param {boolean} noFetch Truthy to not perform a fetch if the view
+     *  changes.
      */
-    setView(bounds, zoom, maxZoom) {
+    setView(bounds, zoom, maxZoom, noFetch) {
         if (this._pageElements === false || this.isNew()) {
             return;
         }
@@ -235,6 +252,9 @@ export default AccessControlledModel.extend({
         /* ask for items that will be at least 0.5 pixels, minus a bit */
         this._lastZoom = zoom;
         this._region.minimumSize = Math.pow(2, maxZoom - zoom - 1) - 1;
+        if (noFetch) {
+            return;
+        }
         if (!this._nextFetch) {
             var nextFetch = () => {
                 this.fetch();


### PR DESCRIPTION
If the refresh flag is set, annotations will be fetched even if present.  This is intended to resolve an issue with reloading annotations in HistomicsTK.

Also, added a flag to `setView` to update the bounds without fetching.