### PR TITLE
Copy element data when converting to geojson

### DIFF
--- a/plugin_tests/client/annotationSpec.js
+++ b/plugin_tests/client/annotationSpec.js
@@ -196,7 +196,7 @@ describe('Annotations', function () {
             expect(properties.fillOpacity).toBe(0);
             expect(properties.strokeColor).toBe('#000000');
             expect(properties.strokeOpacity).toBe(1);
-            expect(properties.element).toEqual(element);
+            expect(properties.element.type).toEqual(element.type);
         });
 
         it('polyline', function () {
@@ -221,7 +221,7 @@ describe('Annotations', function () {
             expect(properties.fillOpacity).toBe(0);
             expect(properties.strokeColor).toBe('#000000');
             expect(properties.strokeOpacity).toBe(1);
-            expect(properties.element).toEqual(element);
+            expect(properties.element.type).toEqual(element.type);
         });
     });
 

--- a/web_client/annotations/convert.js
+++ b/web_client/annotations/convert.js
@@ -7,7 +7,7 @@ import style from './style';
 function convertOne(properties) {
     return function (annotation) {
         const type = annotation.type;
-        _.defaults(annotation, defaults[type] || {});
+        annotation = _.defaults({}, annotation, defaults[type] || {});
         if (!_.has(geometry, type)) {
             return;
         }


### PR DESCRIPTION
We are injecting properties into the element model when converting to
geojson.  This can cause unexpected results when using the converted
model elsewhere (e.g. a validation error when saving back to the
server).