### PR TITLE
Fix clobbering annotation elements when changing access.

### DIFF
--- a/plugin_tests/annotations_test.py
+++ b/plugin_tests/annotations_test.py
@@ -861,6 +861,13 @@ class LargeImageAnnotationRestTest(common.LargeImageCommonTest):
             user=self.user
         )
         self.assertStatus(resp, 403)
+        # The admin should still be able to get the annotation with elements
+        resp = self.request(
+            '/annotation/%s' % annot['_id'],
+            user=self.admin
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(len(resp.json['annotation']['elements']), 1)
 
         # Give the user admin access
         access['users'].append({

--- a/server/rest/annotation.py
+++ b/server/rest/annotation.py
@@ -354,8 +354,13 @@ class AnnotationResource(Resource):
         access = json.loads(params['access'])
         public = self.boolParam('public', params, False)
         annotation = Annotation().setPublic(annotation, public)
-        return Annotation().setAccessList(
-            annotation, access, save=True, user=self.getCurrentUser())
+        annotation = Annotation().setAccessList(
+            annotation, access, save=False, user=self.getCurrentUser())
+        Annotation().update({'_id': annotation['_id']}, {'$set': {
+            key: annotation[key] for key in ('access', 'public', 'publicFlags')
+            if key in annotation
+        }})
+        return annotation
 
     @autoDescribeRoute(
         Description('Get a list of an annotation\'s history.')


### PR DESCRIPTION
We avoid loading annotation elements into memory when we don't need to work with them, but we were saving the entire annotation document when changing access permissions.  This functionally deleted the elements.  Rather, update the annotation record to update the acl.  This is both more efficient and avoids the problem.

This fixes https://github.com/DigitalSlideArchive/HistomicsTK/issues/537