### PR TITLE
Change the download path to vips.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,16 +167,16 @@ before_install:
   # Build vips to use our libraries
   - if [ "$BUILD_VIPS" = "yes" ]; then
       cd $lib_build_path &&
-      if [ ! -f vips-8.5.9/config.status ]; then
-        if [[ ! -d vips-8.5.9 ]]; then
-          wget -O vips-8.5.9.tar.gz https://github.com/jcupitt/libvips/releases/download/v8.5.9/vips-8.5.9.tar.gz &&
-          tar -zxpf vips-8.5.9.tar.gz ;
+      if [ ! -f vips-8.7.0/config.status ]; then
+        if [[ ! -d vips-8.7.0 ]]; then
+          wget -O vips-8.7.0.tar.gz https://github.com/libvips/libvips/releases/download/v8.7.0/vips-8.7.0.tar.gz &&
+          tar -zxpf vips-8.7.0.tar.gz ;
         fi &&
-        cd vips-8.5.9 &&
+        cd vips-8.7.0 &&
         ./configure &&
         make -j 3 >/tmp/vips_build.txt ;
       else
-        cd vips-8.5.9 ;
+        cd vips-8.7.0 ;
       fi &&
       sudo make install &&
       sudo ldconfig ;

--- a/devops/mapnik_py35/Dockerfile
+++ b/devops/mapnik_py35/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /build
 RUN apt-get update && apt-get install -y python3-mapnik \
     git python3-pip
 
-RUN git clone https://github.com/girder/girder.git /build/girder
+RUN git clone https://github.com/girder/girder.git /build/girder --single-branch -b 2.x-maintenance
 
 # Overwrite GIRDER_TEST_DB property
 # Mongo host name should be mongodb as opposed to localhost


### PR DESCRIPTION
The path we had been using no longer works.  This should be the more canonical path.

Also, update the Dockerfile used by the circle-ci tests to use the Girder 2.x-maintenance branch.