### PR TITLE
Allow multiband styles for gdal sources.

### DIFF
--- a/server/tilesource/pil.py
+++ b/server/tilesource/pil.py
@@ -169,7 +169,7 @@ if girder:
         @staticmethod
         def getLRUHash(*args, **kwargs):
             return strhash(
-                super(PILGirderTileSource, PILGirderTileSource).getLRUHash(
+                GirderTileSource.getLRUHash(
                     *args, **kwargs),
                 kwargs.get('maxSize', args[1] if len(args) >= 2 else None))
 


### PR DESCRIPTION
The default for bands has changed.  This fixes rendering palettized gdal sources, as transparency is now supported for palettized data.  For data with red, green, blue, or gray channels, render them using the band metadata maximum and minimum metadata if either the maximum or minimum are out of the range [0, 255], otherwise use [0, 255] as the range.  If rendering default red, green, blue, gray, or palettized channel(s) and an alpha band exists, render that as well.

The original rendering can be obtained by specifying `style={"band":-1}`.  Bands can be specified by index or color interpretation.  `nodata` is supported.  Multiple bands can be composited by giving a list of bands to the style, e.g., `style={"bands":[{"band":"red", "nodata":0, "palette":["#000000","#ff0000"], "scheme":"linear"}, {"band":6, "palette":["#000000","#00ffff"], "scheme":"linear"}]}`.

This also fixes a few hash issues:

The mapnik and pil Girder tile sources were using the entire girder item for the source hash key, rather than the item number and update stamp.  This meant that changing metadata could invalidate a cache when not necessary.

The tile hash key included the source hash key as well as other parameters.  memcached only uses the first 250 bytes of a key, and this could result in key collisions.  Use the python hash function to shorten tile keys.