### PR TITLE
Improve support for link files.

### DIFF
--- a/devops/mapnik_py36/Dockerfile
+++ b/devops/mapnik_py36/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /build
 RUN apt-get update && apt-get install -y python3-mapnik \
     git python3-pip
 
+RUN rm /usr/lib/mapnik/3.0/input/ogr.input
+
 RUN git clone https://github.com/girder/girder.git /build/girder --single-branch -b 2.x-maintenance
 
 # Overwrite GIRDER_TEST_DB property

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -1810,7 +1810,11 @@ if girder:  # noqa - the whole class is allowed to exceed complexity rules
                     except FilePathException:
                         pass
                 if not largeImagePath:
-                    largeImagePath = File().getLocalFilePath(largeImageFile)
+                    try:
+                        largeImagePath = File().getLocalFilePath(largeImageFile)
+                    except AttributeError as e:
+                        raise TileSourceException(
+                            'No local file path for this file: %s' % e.args[0])
                 return largeImagePath
             except (TileSourceAssetstoreException, FilePathException):
                 raise


### PR DESCRIPTION
For the mapnik tilesource, link files can be read directly.  For other tilesources, they can be converted via vips.