### PR TITLE
Handle deleting a file from a largeImage item.

### DIFF
--- a/plugin_tests/client/imageViewerSpec.js
+++ b/plugin_tests/client/imageViewerSpec.js
@@ -65,6 +65,71 @@ $(function () {
         });
     });
 
+    describe('removal', function () {
+        it('unmake a large image', function () {
+            runs(function () {
+                $('.g-large-image-remove').click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return !$('.g-item-image-viewer-select').length;
+            }, 15000);
+            girderTest.waitForLoad();
+        });
+        it('remake a large image and then remove the image file', function () {
+            runs(function () {
+                $('.g-large-image-create').click();
+            });
+            girderTest.waitForLoad();
+            // wait for job to complete
+            waitsFor(function () {
+                return $('.g-item-image-viewer-select').length !== 0;
+            }, 15000);
+            girderTest.waitForLoad();
+            runs(function () {
+                $('.g-delete-file').click();
+            });
+            girderTest.waitForDialog();
+            runs(function () {
+                $('#g-confirm-button').click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return !$('.g-item-image-viewer-select').length;
+            }, 15000);
+            girderTest.waitForLoad();
+        });
+        it('upload test file', function () {
+            girderTest.waitForLoad();
+            runs(function () {
+                $('.g-item-breadcrumb-link[data-type="folder"]:last').click();
+            });
+            girderTest.waitForLoad();
+            runs(function () {
+                girderTest.binaryUpload('plugins/large_image/plugin_tests/test_files/yb10kx5k.png');
+            });
+            girderTest.waitForLoad();
+        });
+        it('navigate to item and make a large image', function () {
+            runs(function () {
+                $('a.g-item-list-link').click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                return $('.g-large-image-create').length !== 0;
+            });
+            runs(function () {
+                $('.g-large-image-create').click();
+            });
+            girderTest.waitForLoad();
+            // wait for job to complete
+            waitsFor(function () {
+                return $('.g-item-image-viewer-select').length !== 0;
+            }, 15000);
+            girderTest.waitForLoad();
+        });
+    });
+
     describe('Image Viewer selection', function () {
         var viewers = [], jQuery; // use the original jQuery
         it('One viewer is loaded', function () {

--- a/server/base.py
+++ b/server/base.py
@@ -177,6 +177,18 @@ def handleCopyItem(event):
         Item().save(newItem, triggerEvents=False)
 
 
+def handleRemoveFile(event):
+    """
+    When a file is removed, check if it is a largeImage fileId.  If so, delete
+    the largeImage record.
+    """
+    fileObj = event.info
+    if fileObj.get('itemId'):
+        item = Item().load(fileObj['itemId'], force=True, exc=False)
+        if item and 'largeImage' in item and item['largeImage'].get('fileId') == fileObj['_id']:
+            ImageItem().delete(item, [fileObj['_id']])
+
+
 # Validators
 
 @setting_utilities.validator({
@@ -285,3 +297,4 @@ def load(info):
                 checkForLargeImageFiles)
     events.bind('model.item.remove', 'large_image', removeThumbnails)
     events.bind('server_fuse.unmount', 'large_image', cache_util.cachesClear)
+    events.bind('model.file.remove', 'large_image', handleRemoveFile)

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -207,7 +207,7 @@ class ImageItem(Item):
         tileMimeType = tileSource.getTileMimeType()
         return tileData, tileMimeType
 
-    def delete(self, item):
+    def delete(self, item, skipFileIds=None):
         deleted = False
         if 'largeImage' in item:
             job = None
@@ -240,7 +240,9 @@ class ImageItem(Item):
                 assert item['largeImage']['originalId'] != \
                     item['largeImage'].get('fileId')
 
-                if 'fileId' in item['largeImage']:
+                if ('fileId' in item['largeImage'] and (
+                        not skipFileIds or
+                        item['largeImage']['fileId'] not in skipFileIds)):
                     file = File().load(id=item['largeImage']['fileId'], force=True)
                     if file:
                         File().remove(file)

--- a/web_client/views/fileList.js
+++ b/web_client/views/fileList.js
@@ -29,6 +29,12 @@ wrap(FileListWidget, 'render', function (render) {
             file: file, largeImage: largeImage});
         if (fileAction) {
             actions.prepend(fileAction);
+            if (actions.has('.g-large-image-remove').length) {
+                file.on('g:deleted', () => {
+                    this.parentItem.unset('largeImage');
+                    this.parentItem.fetch();
+                });
+            }
         }
     });
     this.$('.g-large-image-remove').on('click', () => {


### PR DESCRIPTION
If you deleted a largeImage file from the item, the large image would still be displayed.  When the file is deleted, this appropriately removes the large image information.  On the web client, it will rerender the page to remove the viewer, too.