### PR TITLE
Add support for netcdf files.

### DIFF
--- a/plugin_tests/source_mapnik_test.py
+++ b/plugin_tests/source_mapnik_test.py
@@ -191,15 +191,15 @@ class LargeImageSourceMapnikTest(common.LargeImageCommonTest):
 
         self._assertStyleResponse(itemId, {
             'band': 1,
-            'min': 'min',
+            'min': 'bad',
             'max': 100,
-        }, 'Minimum and maximum values should be numbers or "auto".')
+        }, 'Minimum and maximum values should be numbers, "auto", "min", or "max".')
 
         self._assertStyleResponse(itemId, {
             'band': 1,
             'min': 0,
-            'max': 'max',
-        }, 'Minimum and maximum values should be numbers or "auto".')
+            'max': 'bad',
+        }, 'Minimum and maximum values should be numbers, "auto", "min", or "max".')
 
         self._assertStyleResponse(itemId, {
             'band': 1,

--- a/server/base.py
+++ b/server/base.py
@@ -125,7 +125,7 @@ def checkForLargeImageFiles(event):
     if mimeType in ('image/tiff', 'image/x-tiff', 'image/x-ptif'):
         possible = True
     exts = file.get('exts')
-    if exts and exts[-1] in ('svs', 'ptif', 'tif', 'tiff', 'ndpi', 'mrxs'):
+    if exts and exts[-1] in ('svs', 'ptif', 'tif', 'tiff', 'ndpi', 'mrxs', 'nc'):
         possible = True
     if not file.get('itemId') or not possible:
         return

--- a/web_client/views/imageViewerWidget/geojs.js
+++ b/web_client/views/imageViewerWidget/geojs.js
@@ -100,12 +100,14 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
             // the metadata levels is the count including level 0, so use one
             // less than the value specified
             this.viewer = geo.map({node: this.el, max: this.levels - 1});
-            this.viewer.bounds({
-                left: this.metadata.bounds.xmin,
-                right: this.metadata.bounds.xmax,
-                top: this.metadata.bounds.ymax,
-                bottom: this.metadata.bounds.ymin
-            }, 'EPSG:3857');
+            if (this.metadata.bounds.xmin !== this.metadata.bounds.xmax && this.metadata.bounds.ymin !== this.metadata.bounds.ymax) {
+                this.viewer.bounds({
+                    left: this.metadata.bounds.xmin,
+                    right: this.metadata.bounds.xmax,
+                    top: this.metadata.bounds.ymax,
+                    bottom: this.metadata.bounds.ymin
+                }, 'EPSG:3857');
+            }
             this.viewer.createLayer('osm');
             this.viewer.createLayer('osm', params);
         }


### PR DESCRIPTION
Some netcdf files are very slow to open, and the time penalty is incurred twice, once for gdal and once for mapnik.

Some data isn't rendered correctly at map boundaries.  This seems especially egregious in the region -180 to -160 longitude or so.

There are no tests yet.

You can access different time slices and subdata sets using the style parameter.  For instance, style={'band': 1} will get the first time slice of the default data set, band = 2 will get the second time slice, etc.  You can get non-default datasets by using the appropriate dataset name with the time slice, e.g., band = "precipitation_flux:1".

