### PR TITLE
Use the loadModel cache on anonymous accesses, too.

### DIFF
--- a/plugin_tests/fuse_off_test.py
+++ b/plugin_tests/fuse_off_test.py
@@ -63,6 +63,7 @@ class LargeImageWithoutFuseGridFSTest(common.LargeImageCommonTest):
 class LargeImageWithoutFuseFSTest(common.LargeImageCommonTest):
     def testFilesystemAssetstore(self):
         from girder.plugins.large_image.models.image_item import ImageItem
+        from girder.plugins.large_image.cache_util import cachesClear
 
         file = self._uploadFile(os.path.join(
             os.environ['LARGE_IMAGE_DATA'], 'sample_image.ptif'))
@@ -72,6 +73,7 @@ class LargeImageWithoutFuseFSTest(common.LargeImageCommonTest):
         # With a second file, large image would prefer to use the Girder mount,
         # if available
         File().createLinkFile('second', item, 'item', 'http://nourl.com', self.admin)
+        cachesClear()
         source = ImageItem().tileSource(item)
         # The file path should just be the local path
         self.assertEqual(source._getLargeImagePath(), File().getLocalFilePath(file))

--- a/plugin_tests/fuse_on_test.py
+++ b/plugin_tests/fuse_on_test.py
@@ -107,6 +107,7 @@ class LargeImageWithFuseGridFSTest(LargeImageGirderMountTest):
 class LargeImageWithFuseFSTest(LargeImageGirderMountTest):
     def testFilesystemAssetstore(self):
         from girder.plugins.large_image.models.image_item import ImageItem
+        from girder.plugins.large_image.cache_util import cachesClear
 
         file = self._uploadFile(os.path.join(
             os.environ['LARGE_IMAGE_DATA'], 'sample_image.ptif'))
@@ -116,6 +117,7 @@ class LargeImageWithFuseFSTest(LargeImageGirderMountTest):
         # With a second file, large image would prefer to use the Girder mount,
         # if available
         File().createLinkFile('second', item, 'item', 'http://nourl.com', self.admin)
+        cachesClear()
         source = ImageItem().tileSource(item)
         # The file path should not be the local path, since we told it we might
         # have adjacent files.

--- a/server/loadmodelcache.py
+++ b/server/loadmodelcache.py
@@ -57,8 +57,7 @@ def loadModel(resource, model, plugin='_core', id=None, allowCookie=False,
         tokenStr = cherrypy.request.headers['Girder-Token']
     elif 'girderToken' in cherrypy.request.cookie and allowCookie:
         tokenStr = cherrypy.request.cookie['girderToken'].value
-    if tokenStr:
-        key = (model, tokenStr, id)
+    key = (model, tokenStr, id)
     cacheEntry = LoadModelCache.get(key)
     if cacheEntry and cacheEntry['expiry'] > time.time():
         entry = cacheEntry['result']
@@ -71,17 +70,16 @@ def loadModel(resource, model, plugin='_core', id=None, allowCookie=False,
             setattr(cherrypy.request, 'girderAllowCookie', True)
         entry = resource.model(model, plugin).load(
             id=id, level=level, user=resource.getCurrentUser())
-        if key:
-            # If the cache becomes too large, just dump it -- this is simpler
-            # than dropping the oldest values and avoids having to add locking.
-            if len(LoadModelCache) > LoadModelCacheMaxEntries:
-                LoadModelCache.clear()
-            LoadModelCache[key] = {
-                'id': id,
-                'model': model,
-                'tokenId': tokenStr,
-                'expiry': time.time() + LoadModelCacheExpiryDuration,
-                'result': entry,
-                'hits': 0
-            }
+        # If the cache becomes too large, just dump it -- this is simpler
+        # than dropping the oldest values and avoids having to add locking.
+        if len(LoadModelCache) > LoadModelCacheMaxEntries:
+            LoadModelCache.clear()
+        LoadModelCache[key] = {
+            'id': id,
+            'model': model,
+            'tokenId': tokenStr,
+            'expiry': time.time() + LoadModelCacheExpiryDuration,
+            'result': entry,
+            'hits': 0
+        }
     return entry

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -1795,9 +1795,9 @@ if girder:  # noqa - the whole class is allowed to exceed complexity rules
                     # was derived from.  This is always the case if there are 3
                     # or more files.
                     fileIds = [str(file['_id']) for file in Item().childFiles(self.item, limit=3)]
-                    knownIds = [largeImageFileId]
+                    knownIds = [str(largeImageFileId)]
                     if 'originalId' in self.item['largeImage']:
-                        knownIds.append(self.item['largeImage']['originalId'])
+                        knownIds.append(str(self.item['largeImage']['originalId']))
                     self.mayHaveAdjacentFiles = (
                         len(fileIds) >= 3 or
                         fileIds[0] not in knownIds or


### PR DESCRIPTION
Also fix a comparison that checked if a string was equal to an objectId (which would fail).