### PR TITLE
Mirax files always have adjacent files.

### DIFF
--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -1803,6 +1803,8 @@ if girder:  # noqa - the whole class is allowed to exceed complexity rules
                         fileIds[0] not in knownIds or
                         fileIds[-1] not in knownIds)
                 largeImageFile = File().load(largeImageFileId, force=True)
+                if 'mrxs' in largeImageFile['exts']:
+                    self.mayHaveAdjacentFiles = True
                 largeImagePath = None
                 if self.mayHaveAdjacentFiles and hasattr(File(), 'getGirderMountFilePath'):
                     try:


### PR DESCRIPTION
This always uses the fuse path to access mrxs files if possible, as mrxs files always have adjacent files.  Fixes https://github.com/DigitalSlideArchive/HistomicsTK/issues/579.