### PR TITLE
Cache associated image retrieval.

### DIFF
--- a/plugin_tests/large_image_test.py
+++ b/plugin_tests/large_image_test.py
@@ -331,4 +331,27 @@ class LargeImageLargeImageTest(common.LargeImageCommonTest):
         results = resp.json
         self.assertEqual(results['removed'], 1)
 
-#
+    def testAssociateImageCaching(self):
+        file = self._uploadFile(os.path.join(
+            os.environ['LARGE_IMAGE_DATA'], 'sample_image.ptif'))
+        itemId = str(file['itemId'])
+        resp = self.request(path='/item/%s/tiles/images/label' % itemId,
+                            user=self.admin, isJson=False)
+        self.assertStatusOk(resp)
+        # Test GET associated_images
+        resp = self.request(path='/large_image/associated_images', user=self.user)
+        self.assertStatus(resp, 403)
+        resp = self.request(path='/large_image/associated_images', user=self.admin)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, 1)
+        # Test DELETE associated_images
+        resp = self.request(
+            method='DELETE', path='/large_image/associated_images', user=self.user)
+        self.assertStatus(resp, 403)
+        resp = self.request(
+            method='DELETE', path='/large_image/associated_images', user=self.admin)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, 1)
+        resp = self.request(path='/large_image/associated_images', user=self.admin)
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, 0)

--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -1295,9 +1295,10 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
 
         # Test missing associated image
         resp = self.request(path='/item/%s/tiles/images/nosuchimage' % itemId,
-                            user=self.admin)
+                            user=self.admin, isJson=False)
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json, None)
+        image = self.getBody(resp, text=False)
+        self.assertEqual(image, b'')
 
         # Test with an SVS image
         file = self._uploadFile(os.path.join(
@@ -1313,9 +1314,10 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
         image = self.getBody(resp, text=False)
         self.assertEqual(image[:len(common.JPEGHeader)], common.JPEGHeader)
         resp = self.request(path='/item/%s/tiles/images/nosuchimage' % itemId,
-                            user=self.admin)
+                            user=self.admin, isJson=False)
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json, None)
+        image = self.getBody(resp, text=False)
+        self.assertEqual(image, b'')
 
         # Test with the Huron image
         file = self._uploadFile(os.path.join(
@@ -1330,9 +1332,10 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
         image = self.getBody(resp, text=False)
         self.assertEqual(image[:len(common.JPEGHeader)], common.JPEGHeader)
         resp = self.request(path='/item/%s/tiles/images/nosuchimage' % itemId,
-                            user=self.admin)
+                            user=self.admin, isJson=False)
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json, None)
+        image = self.getBody(resp, text=False)
+        self.assertEqual(image, b'')
 
         # Test with an image that doesn't have associated images
         file = self._uploadFile(os.path.join(
@@ -1347,9 +1350,10 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
         self.assertStatusOk(resp)
         self.assertEqual(resp.json, [])
         resp = self.request(path='/item/%s/tiles/images/nosuchimage' % itemId,
-                            user=self.admin)
+                            user=self.admin, isJson=False)
         self.assertStatusOk(resp)
-        self.assertEqual(resp.json, None)
+        image = self.getBody(resp, text=False)
+        self.assertEqual(image, b'')
 
     def testTilesAfterCopyItem(self):
         file = self._uploadFile(os.path.join(

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -298,7 +298,6 @@ class ImageItem(Item):
         result = getattr(tileSource, imageFunc)(**kwargs)
         if result is None:
             thumbData, thumbMime = b'', 'application/octet-stream'
-            # return result
         else:
             thumbData, thumbMime = result
         # The logic on which files to save could be more sophisticated.

--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -25,6 +25,7 @@ import time
 
 from girder.constants import SortDir
 from girder.exceptions import ValidationException
+from girder.models.assetstore import Assetstore
 from girder.models.file import File
 from girder.models.item import Item
 from girder.models.setting import Setting
@@ -273,6 +274,10 @@ class ImageItem(Item):
         """
         # check if a thumbnail file exists with a particular key
         keydict = dict(kwargs, width=width, height=height)
+        return self._getAndCacheImage(
+            item, 'getThumbnail', keydict, width=width, height=height, **kwargs)
+
+    def _getAndCacheImage(self, item, imageFunc, keydict, **kwargs):
         if 'fill' in keydict and (keydict['fill']).lower() == 'none':
             del keydict['fill']
         keydict = {k: v for k, v in six.viewitems(keydict) if v is not None}
@@ -290,8 +295,12 @@ class ImageItem(Item):
                 contentDisposition = kwargs['contentDisposition']
             return File().download(existing, contentDisposition=contentDisposition)
         tileSource = self._loadTileSource(item, **kwargs)
-        thumbData, thumbMime = tileSource.getThumbnail(
-            width, height, **kwargs)
+        result = getattr(tileSource, imageFunc)(**kwargs)
+        if result is None:
+            thumbData, thumbMime = b'', 'application/octet-stream'
+            # return result
+        else:
+            thumbData, thumbMime = result
         # The logic on which files to save could be more sophisticated.
         maxThumbnailFiles = int(Setting().get(
             constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES))
@@ -304,12 +313,15 @@ class ImageItem(Item):
                 six.BytesIO(thumbData), size=len(thumbData),
                 name='_largeImageThumbnail', parentType='item', parent=item,
                 user=None, mimeType=thumbMime, attachParent=True)
+            if not len(thumbData) and 'received' in thumbfile:
+                thumbfile = Upload().finalizeUpload(
+                    thumbfile, Assetstore().load(thumbfile['assetstoreId']))
             thumbfile.update({
                 'isLargeImageThumbnail': True,
                 'thumbnailKey': key,
             })
             # Ideally, we would check that the file is still wanted before we
-            # save it.  This is probably imposible without true transactions in
+            # save it.  This is probably impossible without true transactions in
             # Mongo.
             File().save(thumbfile)
         # Return the data
@@ -405,5 +417,6 @@ class ImageItem(Item):
         :returns: imageData, imageMime: the image data and the mime type, or
             None if the associated image doesn't exist.
         """
-        tileSource = self._loadTileSource(item, **kwargs)
-        return tileSource.getAssociatedImage(imageKey, *args, **kwargs)
+        keydict = dict(kwargs, imageKey=imageKey)
+        return self._getAndCacheImage(
+            item, 'getAssociatedImage', keydict, imageKey=imageKey, **kwargs)

--- a/server/rest/large_image.py
+++ b/server/rest/large_image.py
@@ -119,6 +119,8 @@ class LargeImageResource(Resource):
         self.route('GET', ('thumbnails',), self.countThumbnails)
         self.route('PUT', ('thumbnails',), self.createThumbnails)
         self.route('DELETE', ('thumbnails',), self.deleteThumbnails)
+        self.route('GET', ('associated_images',), self.countAssociatedImages)
+        self.route('DELETE', ('associated_images',), self.deleteAssociatedImages)
         self.route('DELETE', ('tiles', 'incomplete'),
                    self.deleteIncompleteTiles)
 
@@ -167,7 +169,17 @@ class LargeImageResource(Resource):
     )
     @access.admin
     def countThumbnails(self, params):
-        spec = params.get('spec')
+        return self._countCachedImages(params.get('spec'))
+
+    @describeRoute(
+        Description('Count the number of cached associated image files for '
+                    'large_image items.')
+    )
+    @access.admin
+    def countAssociatedImages(self, params):
+        return self._countCachedImages(None, associatedImages=True)
+
+    def _countCachedImages(self, spec, associatedImages=False):
         if spec is not None:
             try:
                 spec = json.loads(spec)
@@ -184,6 +196,8 @@ class LargeImageResource(Resource):
             query = {'isLargeImageThumbnail': True, 'attachedToType': 'item'}
             if entry is not None:
                 query['thumbnailKey'] = entry
+            elif associatedImages:
+                query['thumbnailKey'] = {'$regex': '"imageKey":'}
             count += File().find(query).count()
         return count
 
@@ -237,7 +251,16 @@ class LargeImageResource(Resource):
     )
     @access.admin
     def deleteThumbnails(self, params):
-        spec = params.get('spec')
+        return self._deleteCachedImages(params.get('spec'))
+
+    @describeRoute(
+        Description('Delete cached associated image files from large_image items.')
+    )
+    @access.admin
+    def deleteAssociatedImages(self, params):
+        return self._deleteCachedImages(None, associatedImages=True)
+
+    def _deleteCachedImages(self, spec, associatedImages=False):
         if spec is not None:
             try:
                 spec = json.loads(spec)
@@ -254,6 +277,8 @@ class LargeImageResource(Resource):
             query = {'isLargeImageThumbnail': True, 'attachedToType': 'item'}
             if entry is not None:
                 query['thumbnailKey'] = entry
+            elif associatedImages:
+                query['thumbnailKey'] = {'$regex': '"imageKey":'}
             for file in File().find(query):
                 File().remove(file)
                 removed += 1


### PR DESCRIPTION
This uses the same caching methods as thumbnails.  Deleting all cached thumbnails will delete cached associated images, though the spec parameter can also be used to target more specific cached images.  There are new endpoints `GET large_image/associated_images` and `DELETE large_image/associated_images` to efficiently report and delete just cached associated images.