### PR TITLE
Invalidate the loadmodel cache when collections or users are changed.

### DIFF
--- a/server/base.py
+++ b/server/base.py
@@ -290,6 +290,10 @@ def load(info):
                 invalidateLoadModelCache)
     events.bind('model.group.save.after', 'large_image',
                 invalidateLoadModelCache)
+    events.bind('model.user.save.after', 'large_image',
+                invalidateLoadModelCache)
+    events.bind('model.collection.save.after', 'large_image',
+                invalidateLoadModelCache)
     events.bind('model.item.remove', 'large_image', invalidateLoadModelCache)
     events.bind('model.item.copy.prepare', 'large_image', prepareCopyItem)
     events.bind('model.item.copy.after', 'large_image', handleCopyItem)


### PR DESCRIPTION
Since we use a resource path to some large images, renaming a collection or user will change that path.  As such, we need to invalidate the loadmodel cache when that happens.