### PR TITLE
Speed up annotation output.

### DIFF
--- a/plugin_tests/tiles_test.py
+++ b/plugin_tests/tiles_test.py
@@ -366,7 +366,7 @@ class LargeImageTilesTest(common.LargeImageCommonTest):
             'encoding': 2,
         }
         for key in badParams:
-            err = ('parameter is an incorrect' if key is not 'encoding' else
+            err = ('parameter is an incorrect' if key != 'encoding' else
                    'Invalid encoding')
             self._createTestTiles({key: badParams[key]}, error=err)
 


### PR DESCRIPTION
We stream annotation elements since outputting them as a single blob of json can use a lot of memory and causes a delay between fetching them from the database and emitting them.  However, emitting elements one at a time is slower then emitting them in batches.  This batches 100 elements at a time, which, experimentally, provides a balance between good speed and rapid start.

As an example, a whole slide image with ~370,000 detected nuclei annotations when from taking ~9 seconds to emit the top 25000 annotations to taking ~2.4 seconds.