### PR TITLE
Thread parallelize thumbnail generation.

### DIFF
--- a/server/models/image_item.py
+++ b/server/models/image_item.py
@@ -256,7 +256,7 @@ class ImageItem(Item):
         self.removeThumbnailFiles(item)
         return deleted
 
-    def getThumbnail(self, item, width=None, height=None, **kwargs):
+    def getThumbnail(self, item, checkAndCreate=False, width=None, height=None, **kwargs):
         """
         Using a tile source, get a basic thumbnail.  Aspect ratio is
         preserved.  If neither width nor height is given, a default value is
@@ -275,9 +275,9 @@ class ImageItem(Item):
         # check if a thumbnail file exists with a particular key
         keydict = dict(kwargs, width=width, height=height)
         return self._getAndCacheImage(
-            item, 'getThumbnail', keydict, width=width, height=height, **kwargs)
+            item, 'getThumbnail', checkAndCreate, keydict, width=width, height=height, **kwargs)
 
-    def _getAndCacheImage(self, item, imageFunc, keydict, **kwargs):
+    def _getAndCacheImage(self, item, imageFunc, checkAndCreate, keydict, **kwargs):
         if 'fill' in keydict and (keydict['fill']).lower() == 'none':
             del keydict['fill']
         keydict = {k: v for k, v in six.viewitems(keydict) if v is not None}
@@ -289,6 +289,8 @@ class ImageItem(Item):
             'thumbnailKey': key
         })
         if existing:
+            if checkAndCreate:
+                return True
             if kwargs.get('contentDisposition') != 'attachment':
                 contentDisposition = 'inline'
             else:
@@ -405,7 +407,7 @@ class ImageItem(Item):
         tileSource = self._loadTileSource(item, **kwargs)
         return tileSource.getAssociatedImagesList()
 
-    def getAssociatedImage(self, item, imageKey, *args, **kwargs):
+    def getAssociatedImage(self, item, imageKey, checkAndCreate=False, *args, **kwargs):
         """
         Return an associated image.
 
@@ -418,4 +420,4 @@ class ImageItem(Item):
         """
         keydict = dict(kwargs, imageKey=imageKey)
         return self._getAndCacheImage(
-            item, 'getAssociatedImage', keydict, imageKey=imageKey, **kwargs)
+            item, 'getAssociatedImage', checkAndCreate, keydict, imageKey=imageKey, **kwargs)

--- a/server/rest/large_image.py
+++ b/server/rest/large_image.py
@@ -61,6 +61,14 @@ def createThumbnailsJobTask(item, spec):
             status['failed'] += 1
             status['lastFailed'] = str(item['_id'])
             logger.info('Failed to get thumbnail for item %s: %r' % (item['_id'], exc))
+        except AttributeError:
+            raise
+        except Exception:
+            status['failed'] += 1
+            status['lastFailed'] = str(item['_id'])
+            logger.exception(
+                'Unexpected exception when trying to create a thumbnail for item %s' %
+                item['_id'])
     return status
 
 

--- a/server/rest/large_image.py
+++ b/server/rest/large_image.py
@@ -17,9 +17,12 @@
 #  limitations under the License.
 ##############################################################################
 
+import concurrent.futures
 import datetime
 import json
+import psutil
 import time
+from six.moves import range
 
 from girder import logger
 from girder.api import access
@@ -38,73 +41,163 @@ from ..models.base import TileGeneralException
 from ..models.image_item import ImageItem
 
 
+def createThumbnailsJobTask(item, spec):
+    """
+    For an individual item, check or create all of the appropriate thumbnails.
+
+    :param item: the image item.
+    :param spec: a list of thumbnail specifications.
+    :returns: a dictionary with the total status of the thumbnail job.
+    """
+    status = {'checked': 0, 'created': 0, 'failed': 0}
+    for entry in spec:
+        try:
+            if entry.get('imageKey'):
+                result = ImageItem().getAssociatedImage(item, checkAndCreate=True, **entry)
+            else:
+                result = ImageItem().getThumbnail(item, checkAndCreate=True, **entry)
+            status['checked' if result is True else 'created'] += 1
+        except TileGeneralException as exc:
+            status['failed'] += 1
+            status['lastFailed'] = str(item['_id'])
+            logger.info('Failed to get thumbnail for item %s: %r' % (item['_id'], exc))
+    return status
+
+
+def createThumbnailsJobLog(job, info, prefix='', status=None):
+    """
+    Log information aboyt the create thumbnails job.
+
+    :param job: the job object.
+    :param info: a dictionary with the number of thumbnails checked, created,
+        and failed.
+    :param prefix: a string to place in front of the log message.
+    :param status: if not None, a new status for the job.
+    """
+    msg = prefix + 'Checked %d, created %d thumbnail files' % (
+        info['checked'], info['created'])
+    if prefix == '' and info.get('items', 0) * info.get('specs', 0):
+        done = info['checked'] + info['created'] + info['failed']
+        if done < info['items'] * info['specs']:
+            msg += ' (estimated %4.2f%% done)' % (
+                100.0 * done / (info['items'] * info['specs']))
+    msg += '\n'
+    if info['failed']:
+        msg += 'Failed on %d thumbnail file%s (last failure on item %s)\n' % (
+            info['failed'],
+            's' if info['failed'] != 1 else '', info['lastFailed'])
+    job = Job().updateJob(job, log=msg, status=status)
+    return job, msg
+
+
+def cursorNextOrNone(cursor):
+    """
+    Given a Mongo cursor, return the next value if there is one.  If not,
+    return None.
+
+    :param cursor: a cursor to get a value from.
+    :returns: the next value or None.
+    """
+    try:
+        return cursor.next()
+    except StopIteration:
+        return None
+
+
 def createThumbnailsJob(job):
     """
     Create thumbnails for all of the large image items.
 
-    :param spec: an array, each entry of which is the parameter dictionary for
-        the model getThumbnail function.
+    :param job: the job object including kwargs which contains:
+        spec: an array, each entry of which is the parameter dictionary for
+            the model getThumbnail function.
+        logInterval: the time in seconds between log messages.  This also
+            controls the granularity of cancelling the job.
+        concurrent: the number of threads to use.  0 for the number of cpus.
     """
     job = Job().updateJob(
         job, log='Started creating large image thumbnails\n',
         status=JobStatus.RUNNING)
-    checkedOrCreated = 0
-    failedImages = 0
+    concurrency = int(job['kwargs'].get('concurrent', 0))
+    concurrency = psutil.cpu_count(logical=True) if concurrency < 1 else concurrency
+    status = {
+        'checked': 0,
+        'created': 0,
+        'failed': 0,
+    }
+
+    spec = job['kwargs']['spec']
+    logInterval = float(job['kwargs'].get('logInterval', 10))
+    job = Job().updateJob(job, log='Creating thumbnails (%d concurrent)\n' % concurrency)
+    nextLogTime = time.time() + logInterval
+    tasks = []
+    # This could be switched from ThreadPoolExecutor to ProcessPoolExecutor
+    # without any other changes.  Doing so would probably improve parallel
+    # performance, but may not work reliably under Python 2.x.
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=concurrency)
     try:
-        spec = job['kwargs']['spec']
-        logInterval = float(job['kwargs'].get('logInterval', 10))
-        for entry in spec:
-            job = Job().updateJob(
-                job, log='Creating thumbnails for %r\n' % entry)
-            lastLogTime = time.time()
-            items = Item().find({'largeImage.fileId': {'$exists': True}})
-            for item in items:
-                try:
-                    ImageItem().getThumbnail(item, **entry)
-                    checkedOrCreated += 1
-                except TileGeneralException as exc:
-                    failedImages += 1
-                    lastFailed = str(item['_id'])
-                    logger.info('Failed to get thumbnail for item %s: %r' % (
-                        lastFailed, exc))
-                # Periodically, log the state of the job and check if it was
-                # deleted or canceled.
-                if time.time() - lastLogTime > logInterval:
-                    job = Job().updateJob(
-                        job, log='Checked or created %d thumbnail file%s\n' % (
-                            checkedOrCreated,
-                            's' if checkedOrCreated != 1 else ''))
-                    if failedImages:
-                        job = Job().updateJob(
-                            job, log='Failed on %d thumbnail file%s (last '
-                            'failure on item %s)\n' % (
-                                failedImages,
-                                's' if failedImages != 1 else '', lastFailed))
-                    lastLogTime = time.time()
-                    # Check if the job was deleted or canceled; if so, quit
-                    job = Job().load(id=job['_id'], force=True)
-                    if (not job or job['status'] in (
-                            JobStatus.CANCELED, JobStatus.ERROR)):
-                        cause = {
-                            None: 'deleted',
-                            JobStatus.CANCELED: 'canceled',
-                            JobStatus.ERROR: 'stopped due to error',
-                        }[None if not job else job.get('status')]
-                        logger.info('Large image thumbnails job %s' % cause)
-                        return
+        # Get a cursor with the list of images
+        items = Item().find({'largeImage.fileId': {'$exists': True}})
+        if hasattr(items, 'count'):
+            status['items'] = items.count()
+        status['specs'] = len(spec)
+        nextitem = cursorNextOrNone(items)
+        while len(tasks) or nextitem is not None:
+            # Create more tasks than we strictly need so if one finishes before
+            # we check another will be ready.  This is balanced with not
+            # creating too many to avoid excessive memory use.  As such, we
+            # can't do a simple iteration over the database cursor, as it will
+            # be exhausted before we are done.
+            while len(tasks) < concurrency * 4 and nextitem is not None:
+                tasks.append(pool.submit(createThumbnailsJobTask, nextitem, spec))
+                nextitem = cursorNextOrNone(items)
+            # Wait a short time or until the oldest task is complete
+            try:
+                tasks[0].result(0.1)
+            except concurrent.futures.TimeoutError:
+                pass
+            # Remove completed tasks from our list, adding their results to the
+            # status.
+            for pos in range(len(tasks) - 1, -1, -1):
+                if tasks[pos].done():
+                    r = tasks[pos].result()
+                    status['created'] += r['created']
+                    status['checked'] += r['checked']
+                    status['failed'] += r['failed']
+                    status['lastFailed'] = r.get('lastFailed', status.get('lastFailed'))
+                    tasks[pos:pos + 1] = []
+            # Periodically, log the state of the job and check if it was
+            # deleted or canceled.
+            if time.time() > nextLogTime:
+                job, msg = createThumbnailsJobLog(job, status)
+                # Check if the job was deleted or canceled; if so, quit
+                job = Job().load(id=job['_id'], force=True)
+                if not job or job['status'] in (JobStatus.CANCELED, JobStatus.ERROR):
+                    cause = {
+                        None: 'deleted',
+                        JobStatus.CANCELED: 'canceled',
+                        JobStatus.ERROR: 'stopped due to error',
+                    }[None if not job else job.get('status')]
+                    msg = 'Large image thumbnails job %s' % cause
+                    logger.info(msg)
+                    # Cancel any outstanding tasks.  If they haven't started,
+                    # they are discarded.  Those that have started will still
+                    # run, though.
+                    for task in tasks:
+                        task.cancel()
+                    return
+                nextLogTime = time.time() + logInterval
     except Exception:
         logger.exception('Error with large image create thumbnails job')
-        job = Job().updateJob(
+        Job().updateJob(
             job, log='Error creating large image thumbnails\n',
             status=JobStatus.ERROR)
         return
-    msg = 'Finished creating large image thumbnails (%d checked or created)' % (
-        checkedOrCreated)
-    if failedImages:
-        msg += ' (%d failed, last failure on item %s)' % (
-            failedImages, lastFailed)
+    finally:
+        # Clean up the task pool asynchronously
+        pool.shutdown(False)
+    job, msg = createThumbnailsJobLog(job, status, 'Finished: ', JobStatus.SUCCESS)
     logger.info(msg)
-    job = Job().updateJob(job, log=msg + '\n', status=JobStatus.SUCCESS)
 
 
 class LargeImageResource(Resource):
@@ -212,6 +305,9 @@ class LargeImageResource(Resource):
                'it has been canceled or deleted.  A value of 0 will log after '
                'each thumbnail is checked or created.', required=False,
                dataType='float')
+        .param('concurrent', 'The number of concurrent threads to use when '
+               'making thumbnails.  0 or unspecified to base this on the '
+               'number of reported cpus.', required=False, dataType='int')
     )
     @access.admin
     def createThumbnails(self, params):
@@ -229,6 +325,8 @@ class LargeImageResource(Resource):
         jobKwargs = {'spec': spec}
         if params.get('logInterval') is not None:
             jobKwargs['logInterval'] = float(params['logInterval'])
+        if params.get('concurrent') is not None:
+            jobKwargs['concurrent'] = float(params['concurrent'])
         job = Job().createLocalJob(
             module='girder.plugins.large_image.rest.large_image',
             function='createThumbnailsJob',

--- a/server/tilesource/svs.py
+++ b/server/tilesource/svs.py
@@ -220,7 +220,7 @@ class SVSFileTileSource(FileTileSource):
             mag = self._openslide.properties[
                 openslide.PROPERTY_NAME_OBJECTIVE_POWER]
             mag = float(mag) if mag else None
-        except (KeyError, ValueError):
+        except (KeyError, ValueError, openslide.lowlevel.OpenSlideError):
             mag = None
         try:
             mm_x = float(self._openslide.properties[

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
     install_requires=[
         'cachetools>=3.0.0',
         'enum34>=1.1.6',
+        'futures; python_version == "2.7"',
         'jsonschema>=2.5.1',
         'libtiff>=0.4.1',
         'numpy>=1.10.2',


### PR DESCRIPTION
This also allows caching associated images as part of the thumbnail generation job.

Before, when more than one thumbnail specification was given, each specification was processed in turn.  Now, all specifications for each image are processed to avoid having to load the image multiple times.