### PR TITLE
Change the tileIterator resample default to True.

### DIFF
--- a/plugin_tests/sources_test.py
+++ b/plugin_tests/sources_test.py
@@ -149,7 +149,7 @@ class LargeImageSourcesTest(common.LargeImageCommonTest):
         # Check with a non-native magnfication without resampling
         tileCount = 0
         for tile in source.tileIterator(
-                format=tilesource.TILE_FORMAT_PIL, scale={'magnification': 2}):
+                format=tilesource.TILE_FORMAT_PIL, scale={'magnification': 2}, resample=False):
             tileCount += 1
             self.assertEqual(tile['tile'].size, (tile['width'], tile['height']))
             self.assertEqual(tile['width'], 256 if tile['level_x'] < 11 else 61)
@@ -163,6 +163,10 @@ class LargeImageSourcesTest(common.LargeImageCommonTest):
             self.assertEqual(tile['tile'].size, (tile['width'], tile['height']))
             self.assertEqual(tile['width'], 256 if tile['level_x'] < 4 else 126)
             self.assertEqual(tile['height'], 256 if tile['level_y'] < 4 else 134)
+        self.assertEqual(tileCount, 25)
+        # Check that the default is with resampling
+        tileCount = len(list(source.tileIterator(
+            format=tilesource.TILE_FORMAT_PIL, scale={'magnification': 2})))
         self.assertEqual(tileCount, 25)
 
         # Ask for numpy array as results
@@ -555,7 +559,7 @@ class LargeImageSourcesTest(common.LargeImageCommonTest):
         tileCount = 0
         for tile in source.tileIteratorAtAnotherScale(
                 sourceRegion, sourceScale, targetScale,
-                format=tilesource.TILE_FORMAT_NUMPY):
+                format=tilesource.TILE_FORMAT_NUMPY, resample=False):
             tileCount += 1
         self.assertEqual(tileCount, 72)
         with six.assertRaisesRegex(self, TypeError, 'unexpected keyword'):

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -247,6 +247,8 @@ class LazyTileDict(dict):
             self['tile_y'] = self.get('tile_y', self['y'])
             self['tile_width'] = self.get('tile_width', self.width)
             self['tile_height'] = self.get('tile_width', self.height)
+            if self.get('magnification', None):
+                self['tile_magnification'] = self.get('tile_magnification', self['magnification'])
             self['x'] = float(self['tile_x'])
             self['y'] = float(self['tile_y'])
             # Add provisional width and height
@@ -255,6 +257,8 @@ class LazyTileDict(dict):
                     self['tile_width'] / self.requestedScale))
                 self['height'] = max(1, int(
                     self['tile_height'] / self.requestedScale))
+                if self.get('tile_magnification', None):
+                    self['magnification'] = self['tile_magnification'] / self.requestedScale
             # If we can resample the tile, many parameters may change once the
             # image is loaded.  Don't include width and height in this list;
             # the provisional values are sufficient.
@@ -1456,7 +1460,7 @@ class TileSource(object):
             level = max(0, min(mag['level'], level))
         return level
 
-    def tileIterator(self, format=(TILE_FORMAT_NUMPY, ), resample=False,
+    def tileIterator(self, format=(TILE_FORMAT_NUMPY, ), resample=True,
                      **kwargs):
         """
         Iterate on all tiles in the specifed region at the specified scale.
@@ -1505,13 +1509,14 @@ class TileSource(object):
             specified.
         :param resample: If True or one of PIL.Image.NEAREST, LANCZOS,
             BILINEAR, or BICUBIC to resample tiles that are not the target
-            output size.  Tiles that are resampled may have non-integer x, y,
-            width, and height values, and will have an additional dictionary
-            entries of:
+            output size.  Tiles that are resampled will have additional
+            dictionary entries of:
                 scaled: the scaling factor that was applied (less than 1 is
                     downsampled).
                 tile_x, tile_y: (left, top) coordinates before scaling
                 tile_width, tile_height: size of the current tile before
+                    scaling.
+                tile_magnification: magnificaiton of the current tile before
                     scaling.
             Note that scipy.misc.imresize uses PIL internally.
         :param region: a dictionary of optional values which specify the part


### PR DESCRIPTION
Prior to this, `resample` in the `tileIterator` defaulted to `False`.  This led to surprising results when a magnification was asked for that was not a native tile level in a source image, such as svs files where not all levels are present.

When tiles need to be resampled, make the `tile['magnification']` value reflect the output magnification and the the `tile['tile_magnification']` value be the magnification before resampling.

Improve some documentation for the `resample` parameter.