### PR TITLE
Memoize annotation style color.

### DIFF
--- a/web_client/annotations/style.js
+++ b/web_client/annotations/style.js
@@ -1,37 +1,41 @@
-import _ from 'underscore';
 import tc from 'tinycolor2';
 
-const props = [
-    'label'
-];
+var memoizeColorAlpha = {entries: 0};
 
 function colorAlpha(color) {
-    if (!color) {
-        return null;
+    if (memoizeColorAlpha[color]) {
+        return memoizeColorAlpha[color];
     }
-    color = tc(color);
-    return {
-        rgb: color.toHexString(),
-        alpha: color.getAlpha()
-    };
+    var tccolor = tc(color),
+        value = {
+            rgb: tccolor.toHexString(),
+            alpha: tccolor.getAlpha()
+        };
+    memoizeColorAlpha.entries += 1;
+    if (memoizeColorAlpha.entries > 100) {
+        memoizeColorAlpha = {entries: 0};
+    }
+    memoizeColorAlpha[color] = value;
+    return value;
 }
 
 export default function style(json) {
     var color;
-    const style = _.pick(json, ...props);
+    const style = {};
 
-    color = colorAlpha(json.fillColor);
-    if (color) {
+    if (json.label) {
+        style.label = json.label;
+    }
+    if (json.fillColor) {
+        color = colorAlpha(json.fillColor);
         style.fillColor = color.rgb;
         style.fillOpacity = color.alpha;
     }
-
-    color = colorAlpha(json.lineColor);
-    if (color) {
+    if (json.lineColor) {
+        color = colorAlpha(json.lineColor);
         style.strokeColor = color.rgb;
         style.strokeOpacity = color.alpha;
     }
-
     if (json.lineWidth) {
         style.strokeWidth = json.lineWidth;
     }


### PR DESCRIPTION
A significant fraction of the time preparing annotation with many elements is spent calling tinycolor.  Since most elements will share colors, memoizing this speeds it up substantially.