### PR TITLE
Expose setConfig at large_image.config.setConfig.

### DIFF
--- a/large_image/__init__.py
+++ b/large_image/__init__.py
@@ -21,11 +21,13 @@ try:
     from . import server   # Works in non-editable install
     from .server import tilesource
     from .server import cache_util
+    from .server.cache_util import cachefactory as config
 except ImportError:
     import server          # Works in editable install
     from server import tilesource
     from server import cache_util
+    from server.cache_util import cachefactory as config
 
 getTileSource = tilesource.getTileSource  # noqa
 
-__all__ = ['server', 'tilesource', 'getTileSource', 'cache_util']
+__all__ = ['server', 'tilesource', 'getTileSource', 'cache_util', 'config']


### PR DESCRIPTION
By doing this, other code that sets config in this manner and doesn't use girder should be able to switch to the pypi releases or use from current master.

For instance, instead of doing 
```
large_image.cache_util.cachefactory.defaultConfig['cache_backend'] = 'memcached'
```
code can do
```
large_image.config.setConfig('cache_backend', 'memcached')
```
This will now work on both the master branch and the pypi deployments made by the girder-3 branch.