### PR TITLE
Pin girder worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ before_install:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then export PY3="true"; else export PY2="true"; fi
   - if [ -n "${PY3}" ]; then export MONGO_VERSION=3.6.2; export PY_COVG="OFF"; else export MONGO_VERSION=3.4.10; export PY_COVG="ON"; export DEPLOY=true; fi
   - GIRDER_VERSION=2.x-maintenance
-  - GIRDER_WORKER_VERSION=master
+  - GIRDER_WORKER_VERSION=v0.5.1
 
   # Define installation paths
   - large_image_path=$TRAVIS_BUILD_DIR

--- a/plugin_tests/source_mapnik_test.py
+++ b/plugin_tests/source_mapnik_test.py
@@ -472,4 +472,4 @@ class LargeImageSourceMapnikTest(common.LargeImageCommonTest):
         self.assertEqual(bounds['xmin'], -180.00416667)
         self.assertEqual(bounds['xmax'], 179.99583333)
         self.assertEqual(bounds['ymin'], -89.99583333)
-        self.assertEqual(bounds['ymax'], 89.999999)
+        self.assertEqual(bounds['ymax'], 90)

--- a/server/tilesource/mapniksource.py
+++ b/server/tilesource/mapniksource.py
@@ -107,7 +107,7 @@ class MapnikTileSource(FileTileSource):
             if the projection is None.  For projections, None uses the default,
             which is the distance between (-180,0) and (180,0) in EPSG:4326
             converted to the projection divided by the tile size.  Proj4
-            projections that are not latlong (is_latlong() is False) must
+            projections that are not latlong (is_geographic is False) must
             specify unitsPerPixel.
         """
         super(MapnikTileSource, self).__init__(path, **kwargs)
@@ -156,7 +156,7 @@ class MapnikTileSource(FileTileSource):
         inProj = self._proj4Proj('+init=epsg:4326')
         # Since we already converted to bytes decoding is safe here
         outProj = self._proj4Proj(self.projection)
-        if outProj.is_latlong():
+        if outProj.crs.is_geographic:
             raise TileSourceException(
                 'Projection must not be geographic (it needs to use linear '
                 'units, not longitude/latitude).')
@@ -308,7 +308,7 @@ class MapnikTileSource(FileTileSource):
                 'srs': nativeSrs,
             }
             # Make sure geographic coordinates do not exceed their limits
-            if pyproj.Proj(nativeSrs).is_latlong() and srs:
+            if pyproj.Proj(nativeSrs).crs.is_geographic and srs:
                 try:
                     pyproj.Proj(srs)(0, 90, errcheck=True)
                     yBound = 90.0


### PR DESCRIPTION
Girder Worker 0.6 will break our usage, so pin to v0.5.1.

Note that the girder-3 branch doesn't have this issue.

Also, update to pyproj 2.0 (we either have to update or pin or CI is broken).