### PR TITLE
Add a setting to show different associated images to anonymous users.

### DIFF
--- a/plugin_tests/client/largeImageSpec.js
+++ b/plugin_tests/client/largeImageSpec.js
@@ -46,6 +46,7 @@ $(function () {
                 $('.g-large-image-auto-set-off').trigger('click');
                 $('.g-large-image-max-thumbnail-files').val('5');
                 $('.g-large-image-max-small-image-size').val('1024');
+                $('.g-large-image-show-extra-public').val('{}');
                 $('.g-large-image-show-extra').val('{}');
                 $('.g-large-image-show-extra-admin').val('{"images": ["label", "macro"]}');
                 $('#g-large-image-form input.btn-primary').click();
@@ -63,6 +64,7 @@ $(function () {
                         settings['large_image.default_viewer'] === 'geojs' &&
                         settings['large_image.max_thumbnail_files'] === 5 &&
                         settings['large_image.max_small_image_size'] === 1024 &&
+                        settings['large_image.show_extra_public'] === '{}' &&
                         settings['large_image.show_extra'] === '{}' &&
                         settings['large_image.show_extra_admin'] === '{"images": ["label", "macro"]}');
             }, 'large_image settings to change');

--- a/plugin_tests/large_image_test.py
+++ b/plugin_tests/large_image_test.py
@@ -100,7 +100,8 @@ class LargeImageLargeImageTest(common.LargeImageCommonTest):
                                        'must be a boolean'):
                 Setting().set(key, 'not valid')
         testExtraVal = json.dumps({'images': ['label']})
-        for key in (constants.PluginSettings.LARGE_IMAGE_SHOW_EXTRA,
+        for key in (constants.PluginSettings.LARGE_IMAGE_SHOW_EXTRA_PUBLIC,
+                    constants.PluginSettings.LARGE_IMAGE_SHOW_EXTRA,
                     constants.PluginSettings.LARGE_IMAGE_SHOW_EXTRA_ADMIN):
             Setting().set(key, '')
             self.assertEqual(Setting().get(key), '')
@@ -143,6 +144,8 @@ class LargeImageLargeImageTest(common.LargeImageCommonTest):
             constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER], True)
         self.assertEqual(settings[
             constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS], True)
+        self.assertEqual(settings[
+            constants.PluginSettings.LARGE_IMAGE_SHOW_EXTRA_PUBLIC], testExtraVal)
         self.assertEqual(settings[
             constants.PluginSettings.LARGE_IMAGE_SHOW_EXTRA], testExtraVal)
         self.assertEqual(settings[

--- a/server/base.py
+++ b/server/base.py
@@ -205,6 +205,7 @@ def validateBoolean(doc):
 
 
 @setting_utilities.validator({
+    constants.PluginSettings.LARGE_IMAGE_SHOW_EXTRA_PUBLIC,
     constants.PluginSettings.LARGE_IMAGE_SHOW_EXTRA,
     constants.PluginSettings.LARGE_IMAGE_SHOW_EXTRA_ADMIN,
 })

--- a/server/constants.py
+++ b/server/constants.py
@@ -21,6 +21,7 @@
 # Constants representing the setting keys for this plugin
 class PluginSettings(object):
     LARGE_IMAGE_SHOW_THUMBNAILS = 'large_image.show_thumbnails'
+    LARGE_IMAGE_SHOW_EXTRA_PUBLIC = 'large_image.show_extra_public'
     LARGE_IMAGE_SHOW_EXTRA = 'large_image.show_extra'
     LARGE_IMAGE_SHOW_EXTRA_ADMIN = 'large_image.show_extra_admin'
     LARGE_IMAGE_SHOW_VIEWER = 'large_image.show_viewer'

--- a/server/rest/large_image.py
+++ b/server/rest/large_image.py
@@ -250,6 +250,7 @@ class LargeImageResource(Resource):
         keys = [
             constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
             constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
+            constants.PluginSettings.LARGE_IMAGE_SHOW_EXTRA_PUBLIC,
             constants.PluginSettings.LARGE_IMAGE_SHOW_EXTRA,
             constants.PluginSettings.LARGE_IMAGE_SHOW_EXTRA_ADMIN,
             constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER,

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     install_requires=[
         'cachetools>=3.0.0',
         'enum34>=1.1.6',
-        'futures; python_version == "2.7"',
+        'futures;python_version<"3.4"',
         'jsonschema>=2.5.1',
         'libtiff>=0.4.1',
         'numpy>=1.10.2',

--- a/web_client/templates/largeImageConfig.pug
+++ b/web_client/templates/largeImageConfig.pug
@@ -49,7 +49,12 @@ form#g-large-image-form(role="form")
     label
       | Additional details to show in item lists
     p.g-large-image-description
-      | Details to show for all users.
+      | Details to show to anonymous users.
+    input.input-sm.form-control.g-large-image-show-extra-public(
+      type="text", value=settings['large_image.show_extra_public'], placeholder='A JSON object listing extra details to show.  For example: {"images": ["label", "macro"]}',
+      title='This can be specified images and metadata as a JSON object such as {"images": ["label", "macro"]}')
+    p.g-large-image-description
+      | Details to show for all logged-in users.
     input.input-sm.form-control.g-large-image-show-extra(
       type="text", value=settings['large_image.show_extra'], placeholder='A JSON object listing extra details to show.  For example: {"images": ["label", "macro"]}',
       title='This can be specified images and metadata as a JSON object such as {"images": ["label", "macro"]}')

--- a/web_client/views/configView.js
+++ b/web_client/views/configView.js
@@ -34,6 +34,9 @@ var ConfigView = View.extend({
                 key: 'large_image.max_small_image_size',
                 value: +this.$('.g-large-image-max-small-image-size').val()
             }, {
+                key: 'large_image.show_extra_public',
+                value: this.$('.g-large-image-show-extra-public').val()
+            }, {
                 key: 'large_image.show_extra',
                 value: this.$('.g-large-image-show-extra').val()
             }, {

--- a/web_client/views/itemList.js
+++ b/web_client/views/itemList.js
@@ -2,6 +2,7 @@ import _ from 'underscore';
 
 import { wrap } from 'girder/utilities/PluginUtils';
 import { apiRoot } from 'girder/rest';
+import { getCurrentUser } from 'girder/auth';
 import { AccessType } from 'girder/constants';
 import ItemListWidget from 'girder/views/widgets/ItemListWidget';
 
@@ -46,6 +47,9 @@ wrap(ItemListWidget, 'render', function (render) {
                 item.id + '/tiles/thumbnail?width=160&height=100'));
         var access = item.getAccessLevel();
         var extra = extraInfo[access] || extraInfo[AccessType.READ] || {};
+        if (!getCurrentUser()) {
+            extra = extraInfo[null] || {};
+        }
 
         /* Set the maximum number of columns we have so that we can let css
          * perform alignment. */
@@ -85,6 +89,12 @@ wrap(ItemListWidget, 'render', function (render) {
         // we will want to also show metadata, so these entries might look like
         // {images: ['label', 'macro'],  meta: [{key: 'abc', label: 'ABC'}]}
         var extraInfo = {};
+        if (settings['large_image.show_extra_public']) {
+            try {
+                extraInfo[null] = JSON.parse(settings['large_image.show_extra_public']);
+            } catch (err) {
+            }
+        }
         if (settings['large_image.show_extra']) {
             try {
                 extraInfo[AccessType.READ] = JSON.parse(settings['large_image.show_extra']);


### PR DESCRIPTION
This allows, for instance, only showing label images to logged in users.