### PR TITLE
Support some uncompressed tiled tiffs via the tiff reader.

### DIFF
--- a/server/tilesource/tiff.py
+++ b/server/tilesource/tiff.py
@@ -46,6 +46,25 @@ except ImportError:
     PIL = None
 
 
+def _nearPowerOfTwo(val1, val2, tolerance=0.02):
+    """
+    Check if two values are different by nearly a power of two.
+
+    :param val1: the first value to check.
+    :param val2: the second value to check.
+    :param tolerance: the maximum difference in the log2 ratio's mantissa.
+    :return: True if the valeus are nearly a power of two different from each
+        other; false otherwise.
+    """
+    # If one or more of the values is zero or they have different signs, then
+    # return False
+    if val1 * val2 <= 0:
+        return False
+    log2ratio = math.log(float(val1) / float(val2)) / math.log(2)
+    # Compare the mantissa of the ratio's log2 value.
+    return abs(log2ratio - round(log2ratio)) < tolerance
+
+
 @six.add_metaclass(LruCacheMetaclass)
 class TiffFileTileSource(FileTileSource):
     """
@@ -102,7 +121,7 @@ class TiffFileTileSource(FileTileSource):
                 float(td.imageWidth) / td.tileWidth,
                 float(td.imageHeight) / td.tileHeight)) / math.log(2))))
             # Store information for sorting with the directory.
-            alldir.append((td.tileWidth * td.tileHeight, level, td))
+            alldir.append((td.tileWidth * td.tileHeight, level, directoryNum, td))
         # If there are no tiled images, raise an exception.
         if not len(alldir):
             msg = 'File %s didn\'t meet requirements for tile source: %s' % (
@@ -119,17 +138,26 @@ class TiffFileTileSource(FileTileSource):
         # preferred image
         for tdir in alldir:
             td = tdir[-1]
-            level = tdir[-2]
+            level = tdir[1]
             if (td.tileWidth != highest.tileWidth or
                     td.tileHeight != highest.tileHeight):
                 continue
+            # If a layer's image is not a multiple of the tile size, it should
+            # be near a power of two of the highest resolution image.
+            if (((td.imageWidth % td.tileWidth) and
+                    not _nearPowerOfTwo(td.imageWidth, highest.imageWidth)) or
+                    ((td.imageHeight % td.tileHeight) and
+                        not _nearPowerOfTwo(td.imageHeight, highest.imageHeight))):
+                continue
             directories[level] = td
+        if len(directories) < 2 and max(directories.keys()) + 1 > 4:
+            raise TileSourceException(
+                'Tiff image must have at least two levels.')
 
         # Sort the directories so that the highest resolution is the last one;
         # if a level is missing, put a None value in its place.
         self._tiffDirectories = [directories.get(key) for key in
                                  range(max(directories.keys()) + 1)]
-
         self.tileWidth = highest.tileWidth
         self.tileHeight = highest.tileHeight
         self.levels = len(self._tiffDirectories)

--- a/server/tilesource/tiff_reader.py
+++ b/server/tilesource/tiff_reader.py
@@ -201,13 +201,15 @@ class TiledTiffDirectory(object):
             raise ValidationTiffException(
                 'Only RGB and greyscale TIFF files are supported')
 
-        if self._tiffInfo.get('bitspersample') != 8:
+        if (self._tiffInfo.get('bitspersample') != 8 and (
+                self._tiffInfo.get('compression') != libtiff_ctypes.COMPRESSION_NONE or
+                self._tiffInfo.get('bitspersample') != 16)):
             raise ValidationTiffException(
                 'Only single-byte sampled TIFF files are supported')
 
-        if self._tiffInfo.get('sampleformat') not in (
+        if self._tiffInfo.get('sampleformat') not in {
                 None,  # default is still SAMPLEFORMAT_UINT
-                libtiff_ctypes.SAMPLEFORMAT_UINT):
+                libtiff_ctypes.SAMPLEFORMAT_UINT}:
             raise ValidationTiffException(
                 'Only unsigned int sampled TIFF files are supported')
 
@@ -215,22 +217,24 @@ class TiledTiffDirectory(object):
             raise ValidationTiffException(
                 'Only contiguous planar configuration TIFF files are supported')
 
-        if self._tiffInfo.get('photometric') not in (
+        if self._tiffInfo.get('photometric') not in {
                 libtiff_ctypes.PHOTOMETRIC_MINISBLACK,
                 libtiff_ctypes.PHOTOMETRIC_RGB,
-                libtiff_ctypes.PHOTOMETRIC_YCBCR):
+                libtiff_ctypes.PHOTOMETRIC_YCBCR}:
             raise ValidationTiffException(
                 'Only greyscale (black is 0), RGB, and YCbCr photometric '
                 'interpretation TIFF files are supported')
 
-        if self._tiffInfo.get('orientation') != libtiff_ctypes.ORIENTATION_TOPLEFT:
+        if self._tiffInfo.get('orientation') not in {None, libtiff_ctypes.ORIENTATION_TOPLEFT}:
             raise ValidationTiffException(
                 'Only top-left orientation TIFF files are supported')
 
-        if self._tiffInfo.get('compression') not in (
-                libtiff_ctypes.COMPRESSION_JPEG, 33003, 33005):
+        if self._tiffInfo.get('compression') not in {
+                libtiff_ctypes.COMPRESSION_NONE,
+                libtiff_ctypes.COMPRESSION_JPEG,
+                33003, 33005}:
             raise ValidationTiffException(
-                'Only JPEG compression TIFF files are supported')
+                'Only uncompressed and JPEG compressed TIFF files are supported')
         if (not self._tiffInfo.get('istiled') or
                 not self._tiffInfo.get('tilewidth') or
                 not self._tiffInfo.get('tilelength')):
@@ -488,6 +492,30 @@ class TiledTiffDirectory(object):
         tileData = frameBuffer.raw[frameStartPos:-2]
         return tileData
 
+    def _getUncompressedTile(self, tileNum):
+        """
+        Get an uncompressed tile.
+
+        :param tileNum: The internal tile number of the desired tile.
+        :type tileNum: int
+        :return: the tile as a PIL 8-bit-per-channel images.
+        :rtype: PIL.Image
+        :raises: IOTiffException
+        """
+        tileSize = libtiff_ctypes.libtiff.TIFFTileSize(self._tiffFile).value
+        imageBuffer = ctypes.create_string_buffer(tileSize)
+
+        readSize = libtiff_ctypes.libtiff.TIFFReadEncodedTile(
+            self._tiffFile, tileNum, imageBuffer, tileSize)
+        if readSize < tileSize:
+            raise IOTiffException('Read an unexpected number of bytes from an encoded tile')
+        mode = 'L' if self._tiffInfo.get('samplesperpixel') == 1 else 'RGB'
+        if self._tiffInfo.get('bitspersample') == 16:
+            # Just take the high byte
+            imageBuffer = imageBuffer[1::2]
+        image = PIL.Image.frombytes(mode, (self._tileWidth, self._tileHeight), imageBuffer)
+        return image
+
     @property
     def tileWidth(self):
         """
@@ -558,6 +586,8 @@ class TiledTiffDirectory(object):
             image = image.convert('RGB')
             return image
 
+        return self._getUncompressedTile(tileNum)
+
     def parse_image_description(self, meta=None):
 
         self._pixelInfo = {}
@@ -573,7 +603,7 @@ class TiledTiffDirectory(object):
             if 'AppMag = ' in meta:
                 try:
                     self._pixelInfo = {
-                        'magnification': float(meta.split('AppMag = ')[1])
+                        'magnification': float(meta.split('AppMag = ')[1].split('|')[0].strip())
                     }
                 except Exception:
                     pass


### PR DESCRIPTION
This allows us to read some additional tiffs that are not read by the openslider reader.  For instance, an uncompressed OME Tiff's first frame can be read with this change.