### PR TITLE
Use a consistent hash function for long keys and memcached.

### DIFF
--- a/server/cache_util/cache.py
+++ b/server/cache_util/cache.py
@@ -21,6 +21,7 @@ try:
     import resource
 except ImportError:
     resource = None
+import hashlib
 import six
 
 try:
@@ -93,8 +94,9 @@ def methodcache(key=None):
             k = key(*args, **kwargs) if key else self.wrapKey(*args, **kwargs)
             if hasattr(self, '_classkey'):
                 k = self._classkey + ' ' + k
-            # hash the key to make sure it isn't particularly long.
-            hashed_k = str(hash(k)) if len(k) > 200 else k
+            # hash the key to make sure it isn't particularly long.  We can't
+            # use Python's hash(), as it may not be the same between runs.
+            hashed_k = hashlib.sha256(k.encode('utf8')).hexdigest() if len(k) > 200 else k
             lock = getattr(self, 'cache_lock', None)
             try:
                 if lock:
@@ -104,6 +106,9 @@ def methodcache(key=None):
                     return self.cache[hashed_k]
             except KeyError:
                 pass  # key not found
+            except ValueError:
+                # this can happen if a different version of python wrote the record
+                pass
             v = func(self, *args, **kwargs)
             try:
                 if lock:

--- a/server/tilesource/mapniksource.py
+++ b/server/tilesource/mapniksource.py
@@ -122,6 +122,7 @@ class MapnikTileSource(FileTileSource):
         if projection and not isinstance(projection, six.binary_type):
             projection = projection.encode('utf8')
         self.projection = projection
+        self._jsonstyle = style
         if style:
             try:
                 self.style = json.loads(style)
@@ -146,6 +147,7 @@ class MapnikTileSource(FileTileSource):
         self.sourceLevels = self.levels = int(max(0, math.ceil(max(
             math.log(float(self.sizeX) / self.tileWidth),
             math.log(float(self.sizeY) / self.tileHeight)) / math.log(2))) + 1)
+        self._unitsPerPixel = unitsPerPixel
         if self.projection:
             self._initWithProjection(unitsPerPixel)
 
@@ -193,6 +195,10 @@ class MapnikTileSource(FileTileSource):
             kwargs.get('projection', args[1] if len(args) >= 2 else None),
             kwargs.get('style', args[2] if len(args) >= 3 else None),
             kwargs.get('unitsPerPixel', args[3] if len(args) >= 4 else None))
+
+    def getState(self):
+        return super(MapnikTileSource, self).getState() + ',' + str((
+            self.projection, self._jsonstyle, self._unitsPerPixel))
 
     def getProj4String(self):
         """


### PR DESCRIPTION
We had been using Python's hash() function to reduce a long key to a shorter key for the cache keys in memcached.  However, Python 2 can be optionally set to use a random or non-standard seed for hash(), and Python 3 uses a random seed for hash() by default.  This means that subsequent runs of a program would not utilize the memcached tile cache from previous runs.

Also, improve the default class key for the mapnik tile source, as this allows easier programmatic reuse of tiles.