### PR TITLE
Add some annotation controls to items

### DIFF
--- a/plugin_tests/annotations_test.py
+++ b/plugin_tests/annotations_test.py
@@ -775,6 +775,22 @@ class LargeImageAnnotationRestTest(common.LargeImageCommonTest):
         )
         self.assertStatus(resp, 400)
 
+        # Delete annotations
+        resp = self.request(
+            path='/annotation/item/{}'.format(itemDest['_id']),
+            method='DELETE',
+            user=None
+        )
+        self.assertStatus(resp, 401)
+
+        resp = self.request(
+            path='/annotation/item/{}'.format(itemDest['_id']),
+            method='DELETE',
+            user=self.admin
+        )
+        self.assertStatusOk(resp)
+        self.assertEqual(resp.json, 2)
+
     def testDeleteAnnotation(self):
         from girder.plugins.large_image.models.annotation import Annotation
         from girder.plugins.large_image import constants

--- a/plugin_tests/client/annotationListSpec.js
+++ b/plugin_tests/client/annotationListSpec.js
@@ -123,7 +123,7 @@ describe('AnnotationListWidget', function () {
             }, 15000);
             girderTest.waitForLoad();
             runs(function () {
-                expect($('.g-annotation-list-container *').length).toBe(0);
+                expect($('.g-annotation-list-container .g-annotation-row').length).toBe(0);
             });
         });
         it('get item model', function () {

--- a/plugin_tests/client/annotationListSpec.js
+++ b/plugin_tests/client/annotationListSpec.js
@@ -280,12 +280,93 @@ describe('AnnotationListWidget', function () {
                 expect(drawnAnnotations[id]).toBeUndefined();
             });
         });
+        it('test that neither the delete-all nor all-permissions icons are present', function () {
+            expect($('.g-annotation-list-header .g-annotation-permissions').length).toBe(0);
+            expect($('.g-annotation-list-header .g-annotation-delete').length).toBe(0);
+        });
         it('switch to a viewer that does not support annotations', function () {
             $('.g-item-image-viewer-select select').val('leaflet').trigger('change');
             waitForLargeImageViewer('leaflet');
             runs(function () {
                 expect($('.g-annotation-list .g-annotation-toggle input:first').prop('disabled')).toBe(true);
             });
+        });
+    });
+    describe('Test bulk actions as admin', function () {
+        it('logout', girderTest.logout('log out user'));
+        it('login as admin', girderTest.login('admin', 'Admin', 'Admin', 'testpassword'));
+        it('reload the item page', function () {
+            girder.router.navigate('', {trigger: true});
+            girderTest.waitForLoad();
+            runs(function () {
+                girder.router.navigate('item/' + item.id, {trigger: true});
+            });
+            girderTest.waitForLoad();
+            waitForLargeImageViewer('openseadragon');
+            runs(function () {
+                $('.g-item-image-viewer-select select').val('geojs').trigger('change');
+            });
+            waitForLargeImageViewer('geojs');
+        });
+        it('test upload annotation button with cancel', function () {
+            runs(function () {
+                $('.g-annotation-list-header .g-annotation-upload').click();
+            });
+            girderTest.waitForDialog();
+            runs(function () {
+                $('.modal-footer a.btn').click(); // cancel
+            });
+            girderTest.waitForLoad();
+        });
+        it('test upload annotation button with file', function () {
+            runs(function () {
+                $('.g-annotation-list-header .g-annotation-upload').click();
+            });
+            girderTest.waitForDialog();
+            runs(function () {
+                girderTest._prepareTestUpload();
+                girderTest._uploadDataExtra = 0;
+                girderTest.sendFile('plugins/large_image/plugin_tests/client/sample_annotation.json');
+            });
+            waitsFor(function () {
+                return $('.g-overall-progress-message i.icon-ok').length > 0;
+            }, 'the filesChanged event to happen');
+            runs(function () {
+                $('#g-files').parent().addClass('hide');
+                $('.g-start-upload').click();
+            });
+            girderTest.waitForLoad();
+            waitsFor(function () {
+                var $el = $('.g-annotation-list .g-annotation-row');
+                console.log($el.length);
+                return $el.length === 10;
+            }, 'the upload to finish');
+        });
+        it('test header permission editor link', function () {
+            var $el = $('.g-annotation-list-header');
+            expect($el.find('.g-annotation-permissions').length).toBe(1);
+            $el.find('.g-annotation-permissions').click();
+
+            girderTest.waitForDialog();
+            runs(function () {
+                expect($('#g-dialog-container .modal-title').text()).toBe('Access control');
+                $('#g-dialog-container .g-save-access-list').click();
+            });
+            girderTest.waitForLoad();
+        });
+        it('test header delete link', function () {
+            var $el = $('.g-annotation-list-header');
+            expect($el.find('.g-annotation-delete').length).toBe(1);
+            $el.find('.g-annotation-delete').click();
+
+            girderTest.waitForDialog();
+            runs(function () {
+                $('#g-dialog-container #g-confirm-button').click();
+            });
+
+            waitsFor(function () {
+                return $('.g-annotation-list .g-annotation-row').length === 0;
+            }, 'all annotations to be removed');
         });
     });
 });

--- a/plugin_tests/client/sample_annotation.json
+++ b/plugin_tests/client/sample_annotation.json
@@ -1,0 +1,1 @@
+{"description": "", "elements": [{"center":[86609.34,15840.20,0],"height":2452.37,"width":3780.74,"fillColor":"rgba(0, 0, 0, 0.5)","lineColor":"rgb(0, 0, 0)","rotation":0,"lineWidth":2,"type":"rectangle"},{"center":[91462.99,15738.01,0],"fillColor":"rgba(0, 0, 0, 0.5)","lineColor":"rgb(0, 0, 0)","lineWidth":2,"type":"point"}], "name": "Sample"}

--- a/plugin_tests/source_mapnik_test.py
+++ b/plugin_tests/source_mapnik_test.py
@@ -89,8 +89,8 @@ class LargeImageSourceMapnikTest(common.LargeImageCommonTest):
         self.assertEqual(tileMetadata['bounds']['xmin'], 367185.0)
         self.assertEqual(tileMetadata['bounds']['ymax'], 3788115.0)
         self.assertEqual(tileMetadata['bounds']['ymin'], 3552885.0)
-        self.assertEqual(tileMetadata['bounds']['srs'],
-                         '+proj=utm +zone=11 +datum=WGS84 +units=m +no_defs ')
+        self.assertEqual(tileMetadata['bounds']['srs'].strip(),
+                         '+proj=utm +zone=11 +datum=WGS84 +units=m +no_defs')
         self.assertTrue(tileMetadata['geospatial'])
         # Check that we read some band data, too
         self.assertEqual(len(tileMetadata['bands']), 3)

--- a/server/rest/annotation.py
+++ b/server/rest/annotation.py
@@ -471,8 +471,7 @@ class AnnotationResource(Resource):
         .jsonParam('annotations', 'A JSON list of annotation model records or '
                    'annotations.  If these are complete models, the value of '
                    'the "annotation" key is used and the other information is '
-                   'ignored (such as original creator ID).', paramType='body',
-                   requireArray=True)
+                   'ignored (such as original creator ID).', paramType='body')
         .errorResponse('ID was invalid.')
         .errorResponse('Write access was denied for the item.', 403)
         .errorResponse('Invalid JSON passed in request body.')
@@ -481,6 +480,8 @@ class AnnotationResource(Resource):
     @access.user
     def createItemAnnotations(self, item, annotations):
         user = self.getCurrentUser()
+        if not isinstance(annotations, list):
+            annotations = [annotations]
         for entry in annotations:
             if not isinstance(entry, dict):
                 raise RestException('Entries in the annotation list must be JSON objects.')

--- a/web_client/templates/annotationListWidget.pug
+++ b/web_client/templates/annotationListWidget.pug
@@ -1,8 +1,20 @@
-if annotations.length
-  .g-annotation-list-header
-    i.icon-pencil
-    | Annotations
+.g-annotation-list-header
+  i.icon-pencil
+  | Annotations
+  .btn-group.pull-right
+    if annotations.length
+      a.g-annotation-download(href=`${apiRoot}/annotation/item/${item.id}`, title='Download annotations', download=`${item.get('name')}_annotations.json`)
+        i.icon-download
+    if accessLevel >= AccessType.WRITE
+      a.g-annotation-upload(title='Upload annotation')
+        i.icon-upload
+    if accessLevel >= AccessType.ADMIN && annotations.length
+      a.g-annotation-permissions(title='Adjust permissions')
+        i.icon-lock
+      a.g-annotation-delete(title='Delete')
+        i.icon-cancel
 
+if annotations.length
   table.g-annotation-list.table.table-hover.table-condensed
     thead
       th.g-annotation-toggle

--- a/web_client/views/annotationListWidget.js
+++ b/web_client/views/annotationListWidget.js
@@ -2,10 +2,13 @@ import _ from 'underscore';
 
 import { AccessType } from 'girder/constants';
 import { confirm } from 'girder/dialog';
-import { getApiRoot } from 'girder/rest';
+import { getApiRoot, restRequest } from 'girder/rest';
 import AccessWidget from 'girder/views/widgets/AccessWidget';
 import UserCollection from 'girder/collections/UserCollection';
 import View from 'girder/views/View';
+import events from 'girder/events';
+import FileModel from 'girder/models/FileModel';
+import UploadWidget from 'girder/views/widgets/UploadWidget';
 
 import AnnotationCollection from '../collections/AnnotationCollection';
 
@@ -17,6 +20,7 @@ const AnnotationListWidget = View.extend({
     events: {
         'change .g-annotation-toggle': '_displayAnnotation',
         'click .g-annotation-delete': '_deleteAnnotation',
+        'click .g-annotation-upload': '_uploadAnnotation',
         'click .g-annotation-permissions': '_changePermissions',
         'click .g-annotation-row'(evt) {
             var $el = $(evt.currentTarget);
@@ -52,6 +56,8 @@ const AnnotationListWidget = View.extend({
 
     render() {
         this.$el.html(annotationList({
+            item: this.model,
+            accessLevel: this.model.getAccessLevel(),
             annotations: this.collection,
             users: this.users,
             canDraw: this._viewer && this._viewer.annotationAPI(),
@@ -89,6 +95,22 @@ const AnnotationListWidget = View.extend({
     _deleteAnnotation(evt) {
         const $el = $(evt.currentTarget);
         const id = $el.parents('.g-annotation-row').data('annotationId');
+        if (!id) {
+            confirm({
+                text: `Are you sure you want to delete <b>ALL</b> annotations?`,
+                escapedHtml: true,
+                yesText: 'Delete',
+                confirmCallback: () => {
+                    restRequest({
+                        url: `annotation/item/${this.model.id}`,
+                        method: 'DELETE'
+                    }).done(() => {
+                        this.collection.fetch(null, true);
+                    });
+                }
+            });
+            return;
+        }
         const model = this.collection.get(id);
 
         confirm({
@@ -102,10 +124,90 @@ const AnnotationListWidget = View.extend({
         });
     },
 
+    _uploadAnnotation() {
+        var uploadWidget = new UploadWidget({
+            el: $('#g-dialog-container'),
+            title: 'Upload Annotation',
+            parent: this._makeUploadParent(),
+            parentType: 'file', // invokes special upload widget code
+            parentView: this,
+            multiFile: true
+        }).on('g:uploadFinished', function () {
+            events.trigger('g:alert', {
+                icon: 'ok',
+                text: 'Uploaded annotations.',
+                type: 'success',
+                timeout: 4000
+            });
+        }, this);
+        this._uploadWidget = uploadWidget;
+        uploadWidget.render();
+        uploadWidget.on('g:uploadFinished', () => {
+            this.collection.fetch(null, true);
+        });
+    },
+
+    _makeUploadParent() {
+        var parent = new FileModel();
+        parent.updateContents = (data) => {
+            restRequest({
+                url: `annotation/item/${this.model.id}`,
+                method: 'POST',
+                data: data,
+                contentType: 'application/json',
+                processData: false
+            }).done((resp) => {
+                parent.name = this.model.name();
+                parent.trigger('g:upload.progress', {
+                    startByte: 0,
+                    loaded: data.size,
+                    total: data.size,
+                    file: parent
+                });
+                this._uploadWidget.parent = this._makeUploadParent();
+                parent.trigger('g:upload.complete');
+            }).fail((resp) => {
+                this._uploadWidget.parent = this._makeUploadParent();
+                parent.trigger('g:upload.error', {
+                    message: 'An error occurred while uploading, check console.',
+                    response: resp
+                });
+            });
+        };
+        parent.name = () => {
+            return this.model.name();
+        };
+        parent.get = () => {
+            return this.model.get.apply(this.model, arguments);
+        };
+        return parent;
+    },
+
     _changePermissions(evt) {
         const $el = $(evt.currentTarget);
-        const id = $el.parents('.g-annotation-row').data('annotationId');
-        const model = this.collection.get(id);
+        let id = $el.parents('.g-annotation-row').data('annotationId');
+        if (!id && this.collection.length === 1) {
+            id = this.collection.at(0).id;
+        }
+        const model = id ? this.collection.get(id) : this.collection.at(0).clone();
+        if (!id) {
+            model.get('annotation').name = 'All Annotations';
+            model.save = () => {};
+            model.updateAccess = () => {
+                const access = {
+                    access: model.get('access'),
+                    public: model.get('public'),
+                    publicFlags: model.get('publicFlags')
+                };
+                this.collection.each((loopmodel) => {
+                    loopmodel.set(access);
+                    loopmodel.updateAccess();
+                });
+                this.collection.fetch(null, true);
+                model.trigger('g:accessListSaved');
+            };
+        }
+        // if id is not set, override widget's saveAccessList
         new AccessWidget({
             el: $('#g-dialog-container'),
             type: 'annotation',

--- a/web_client/views/annotationListWidget.js
+++ b/web_client/views/annotationListWidget.js
@@ -191,6 +191,7 @@ const AnnotationListWidget = View.extend({
         }
         const model = id ? this.collection.get(id) : this.collection.at(0).clone();
         if (!id) {
+            // if id is not set, override widget's saveAccessList
             model.get('annotation').name = 'All Annotations';
             model.save = () => {};
             model.updateAccess = () => {
@@ -207,7 +208,6 @@ const AnnotationListWidget = View.extend({
                 model.trigger('g:accessListSaved');
             };
         }
-        // if id is not set, override widget's saveAccessList
         new AccessWidget({
             el: $('#g-dialog-container'),
             type: 'annotation',


### PR DESCRIPTION
This adds four controls on the Annotations section title bar: delete, upload, download, and set access level.

![image](https://user-images.githubusercontent.com/8781639/58435549-fa073b00-808e-11e9-8541-0cd988c907f9.png)
