### PR TITLE
Add the updated field to those that should be indexed in mongo.

### DIFF
--- a/server/models/annotation.py
+++ b/server/models/annotation.py
@@ -415,7 +415,8 @@ class Annotation(AccessControlledModel):
             ([
                 ('_annotationId', SortDir.ASCENDING),
                 ('_version', SortDir.DESCENDING),
-            ], {})
+            ], {}),
+            'updated',
         ])
         self.ensureTextIndex({
             'annotation.name': 10,


### PR DESCRIPTION
When we find annotations, we default to sorting by most recently updated.  This needs an index when there are enough annotations.