### PR TITLE
Fix CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,10 @@ jobs:
     steps:
       - checkout
       - run:
+          name: upgrade pip
+          command: |
+            pip install --upgrade pip
+      - run:
           name: Install Docker Compose
           command: |
             pip install docker-compose
@@ -33,6 +37,10 @@ jobs:
     working_directory: /home/circleci/project
     steps:
       - checkout
+      - run:
+          name: upgrade pip
+          command: |
+            pip install --upgrade pip
       - run:
           name: Install Docker Compose
           command: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -228,7 +228,7 @@ install:
   - if [ -n "${PY3}" ]; then
       pip install -e $large_image_path[memcached,openslide] ;
     else
-      pip install gdal==1.10.0 &&
+      pip install gdal==1.10.0 pyproj==2.1.3 &&
       pip install -e $large_image_path[memcached,openslide,mapnik] ;
     fi
   - ls -l $girder_path/plugins


### PR DESCRIPTION
The old version of GDAL in travis Python 2 environment does not work with pyproj 2.2.1, but does with pyproj 2.1.3.

The circle-ci gdal tests need to use a newer version of pip.