### PR TITLE
Annotation small details

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,14 @@ jobs:
           name: Install Docker Compose
           command: |
             pip install docker-compose
-
       - run:
           name: Get the environment up and running
           command: |
             cd devops/mapnik_py35 && docker-compose build && docker-compose up -d
-
+      - run:
+          name: upgrade pip
+          command: |
+            docker exec large-image-mapnik-python35 pip3 install --upgrade pip
       - run:
           name: Install large image plugin
           command: |
@@ -45,12 +47,14 @@ jobs:
           name: Install Docker Compose
           command: |
             pip install docker-compose
-
       - run:
           name: Get the environment up and running
           command: |
             cd devops/mapnik_py36 && docker-compose build && docker-compose up -d
-
+      - run:
+          name: upgrade pip
+          command: |
+            docker exec large-image-mapnik-python36 pip3 install --upgrade pip
       - run:
           name: Install large image plugin
           command: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -221,6 +221,7 @@ before_install:
 install:
   - pushd $girder_path
   - pip install --no-cache-dir -U -r requirements-dev.txt -e .[mount]
+  - pip install 'pydocstyle<4'
   - popd
   - girder-install plugin --symlink $large_image_path
   # Install all extras (since "girder-install plugin" does not provide a mechanism to specify them

--- a/server/rest/tiles.py
+++ b/server/rest/tiles.py
@@ -757,6 +757,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
+    @access.cookie
     @access.public
     def getAssociatedImage(self, itemId, image, params):
         _adjustParams(params)

--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -144,11 +144,15 @@ def _encodeImage(image, encoding='JPEG', jpegQuality=95, jpegSubsampling=0,
         else:
             encoding = TileOutputPILFormat.get(encoding, encoding)
             output = BytesIO()
+            params = {}
             if encoding == 'JPEG' and image.mode not in ('L', 'RGB'):
                 image = image.convert('RGB')
-            image.save(
-                output, encoding, quality=jpegQuality,
-                subsampling=jpegSubsampling, compression=tiffCompression)
+            if encoding == 'JPEG':
+                params['quality'] = jpegQuality
+                params['subsampling'] = jpegSubsampling
+            elif encoding == 'TIFF':
+                params['compression'] = tiffCompression
+            image.save(output, encoding, **params)
             imageData = output.getvalue()
     return imageData, imageFormatOrMimeType
 
@@ -1105,9 +1109,13 @@ class TileSource(object):
             tile.fp.seek(0)
             return tile.fp.read()
         output = BytesIO()
-        tile.save(
-            output, encoding, quality=self.jpegQuality,
-            subsampling=self.jpegSubsampling, compression=self.tiffCompression)
+        params = {}
+        if encoding == 'JPEG':
+            params['quality'] = self.jpegQuality
+            params['subsampling'] = self.jpegSubsampling
+        elif encoding == 'TIFF':
+            params['compression'] = self.tiffCompression
+        tile.save(output, encoding, **params)
         return output.getvalue()
 
     def _getAssociatedImage(self, imageKey):

--- a/web_client/views/annotationListWidget.js
+++ b/web_client/views/annotationListWidget.js
@@ -74,7 +74,12 @@ const AnnotationListWidget = View.extend({
         const annotation = this.collection.get(id);
         if ($el.find('input').prop('checked')) {
             this._drawn.add(id);
-            this._viewer.drawAnnotation(annotation);
+            annotation.fetch().then(() => {
+                if (this._drawn.has(id)) {
+                    this._viewer.drawAnnotation(annotation);
+                }
+                return null;
+            });
         } else {
             this._drawn.delete(id);
             this._viewer.removeAnnotation(annotation);


### PR DESCRIPTION
When using the Girder viewer, turning on an annotation would always try to page the results by detail level, even when it should not have.