### PR TITLE
Correct the pyproj minimum version.

### DIFF
--- a/sources/mapnik/setup.py
+++ b/sources/mapnik/setup.py
@@ -45,7 +45,7 @@ setup(
         'gdal',
         'mapnik',
         'palettable',
-        'pyproj>=2.0.0',
+        'pyproj>=2.2.0',
     ],
     extras_require={
         'girder': 'girder-large-image>=1.0.0',


### PR DESCRIPTION
We use the `always_xy` flag to ensure consist transforms, and this was added in pyproj 2.2.0.