### PR TITLE
Add an option to get centroids.

### DIFF
--- a/server/models/annotationelement.py
+++ b/server/models/annotationelement.py
@@ -128,7 +128,7 @@ class Annotationelement(Model):
             element for element in self.yieldElements(
                 annotation, region, annotation['_elementQuery'])]
 
-    def yieldElements(self, annotation, region=None, info=None):  # noqa
+    def yieldElements(self, annotation, region=None, info=None):
         """
         Given an annotation, fetch the elements from the database.
             When a region is used to request specific element, the following
@@ -201,6 +201,9 @@ class Annotationelement(Model):
             for key in propskeys:
                 fields['element.%s' % key] = True
             props = {}
+            info['centroids'] = True
+            info['props'] = proplist
+            info['propskeys'] = propskeys
         elementCursor = self.find(
             query=query, sort=[(sortkey, sortdir)], limit=queryLimit,
             offset=offset, fields=fields)
@@ -243,10 +246,6 @@ class Annotationelement(Model):
                 break
         info['returned'] = count
         info['details'] = details
-        if centroids:
-            info['centroids'] = True
-            info['props'] = proplist
-            info['propskeys'] = propskeys
 
     def removeWithQuery(self, query):
         """

--- a/server/models/annotationelement.py
+++ b/server/models/annotationelement.py
@@ -116,6 +116,8 @@ class Annotationelement(Model):
         The sum of the details values of the elements may exceed maxDetails
         slightly (the sum of all but the last element will be less than
         maxDetails, but the last element may exceed the value).
+            centroids: if specified and true, only return the id, center of the
+        bounding box, and bounding box size for each element.
 
         :param annotation: the annotation to get elements for.  Modified.
         :param region: if present, a dictionary restricting which annotations
@@ -126,10 +128,9 @@ class Annotationelement(Model):
             element for element in self.yieldElements(
                 annotation, region, annotation['_elementQuery'])]
 
-    def yieldElements(self, annotation, region=None, info=None):
+    def yieldElements(self, annotation, region=None, info=None):  # noqa
         """
-        Given an annotation, fetch the elements from the database and add them
-        to it.
+        Given an annotation, fetch the elements from the database.
             When a region is used to request specific element, the following
         keys can be specified:
             left, right, top, bottom, low, high: the spatial area where
@@ -149,10 +150,21 @@ class Annotationelement(Model):
         The sum of the details values of the elements may exceed maxDetails
         slightly (the sum of all but the last element will be less than
         maxDetails, but the last element may exceed the value).
+            centroids: if specified and true, only return the id, center of the
+        bounding box, and bounding box size for each element.
 
         :param annotation: the annotation to get elements for.  Modified.
         :param region: if present, a dictionary restricting which annotations
             are returned.
+        :param info: an optional dictionary that will be modified with
+            additional query information, including count (total number of
+            available elements), returned (number of elements in response),
+            maxDetails (as specified by the region dictionary), details (sum of
+            details returned), limit (as specified by region), centroids (a
+            boolean based on the region specification).
+        :returns: a list of elements.  If centroids were requested, each entry
+            is a list with str(id), x, y, size.  Otherwise, each entry is the
+            element record.
         """
         info = info if info is not None else {}
         region = region or {}
@@ -176,9 +188,22 @@ class Annotationelement(Model):
         queryLimit = maxDetails if maxDetails and (not limit or maxDetails < limit) else limit
         offset = int(region['offset']) if region.get('offset') else 0
         logger.debug('element query %r for %r', query, region)
+        fields = {'_id': True, 'element': True, 'bbox.details': True}
+        centroids = str(region.get('centroids')).lower() == 'true'
+        if centroids:
+            # fields = {'_id': True, 'element': True, 'bbox': True}
+            fields = {
+                '_id': True,
+                'element.id': True,
+                'bbox': True}
+            proplist = []
+            propskeys = ['type', 'fillColor', 'lineColor', 'lineWidth', 'closed']
+            for key in propskeys:
+                fields['element.%s' % key] = True
+            props = {}
         elementCursor = self.find(
-            query=query, sort=[(sortkey, sortdir)], limit=queryLimit, offset=offset,
-            fields={'_id': True, 'element': True, 'bbox.details': True})
+            query=query, sort=[(sortkey, sortdir)], limit=queryLimit,
+            offset=offset, fields=fields)
 
         info.update({
             'count': elementCursor.count(),
@@ -194,13 +219,34 @@ class Annotationelement(Model):
         for entry in elementCursor:
             element = entry['element']
             element.setdefault('id', entry['_id'])
-            yield element
+            if centroids:
+                bbox = entry.get('bbox')
+                if not bbox or 'lowx' not in bbox or 'size' not in bbox:
+                    continue
+                prop = tuple(element.get(key) for key in propskeys)
+                if prop not in props:
+                    props[prop] = len(props)
+                    proplist.append(list(prop))
+                yield [
+                    str(element['id']),
+                    (bbox['lowx'] + bbox['highx']) / 2,
+                    (bbox['lowy'] + bbox['highy']) / 2,
+                    bbox['size'] if entry.get('type') != 'point' else 0,
+                    props[prop]
+                ]
+                details += 1
+            else:
+                yield element
+                details += entry.get('bbox', {}).get('details', 1)
             count += 1
-            details += entry.get('bbox', {}).get('details', 1)
             if maxDetails and details >= maxDetails:
                 break
         info['returned'] = count
         info['details'] = details
+        if centroids:
+            info['centroids'] = True
+            info['props'] = proplist
+            info['propskeys'] = propskeys
 
     def removeWithQuery(self, query):
         """
@@ -301,6 +347,8 @@ class Annotationelement(Model):
         bbox['size'] = (
             (bbox['highy'] - bbox['lowy'])**2 +
             (bbox['highx'] - bbox['lowx'])**2) ** 0.5
+        # we may want to store perimeter or area as that could help when we
+        # simplify to points
         return bbox
 
     def updateElements(self, annotation):

--- a/server/rest/annotation.py
+++ b/server/rest/annotation.py
@@ -201,7 +201,7 @@ class AnnotationResource(Resource):
                 else:
                     element = struct.pack(
                         '>QL', int(element[0][:16], 16), int(element[0][16:24], 16)
-                        ) + struct.pack('<fffl', *element[1:])
+                    ) + struct.pack('<fffl', *element[1:])
                 # Use ujson; it is much faster.  The standard json library
                 # could be used in its most default mode instead like so:
                 #   result = json.dumps(element, separators=(',', ':'))

--- a/server/rest/annotation.py
+++ b/server/rest/annotation.py
@@ -18,6 +18,7 @@
 ##############################################################################
 
 import json
+import struct
 import ujson
 
 import cherrypy
@@ -139,6 +140,9 @@ class AnnotationResource(Resource):
                'points are used to defined it.  This is applied in addition '
                'to the limit.  Using maxDetails helps ensure results will be '
                'able to be rendered.', required=False, dataType='int')
+        .param('centroids', 'If true, only return the centroids of each '
+               'element.  The results are returned as a packed binary array '
+               'with a json wrapper.', dataType='boolean', required=False)
         .pagingParams(defaultSort='_id', defaultLimit=None,
                       defaultSortDir=SortDir.ASCENDING)
         .errorResponse('ID was invalid.')
@@ -176,6 +180,7 @@ class AnnotationResource(Resource):
         breakStr = b'"elements": ['
         base = json.dumps(annotation, sort_keys=True, allow_nan=False,
                           cls=JsonEncoder).encode('utf8').split(breakStr)
+        centroids = str(params.get('centroids')).lower() == 'true'
 
         def generateResult():
             info = {}
@@ -183,12 +188,20 @@ class AnnotationResource(Resource):
             yield base[0]
             yield breakStr
             collect = []
+            if centroids:
+                # Add a null byte to indicate the start of the binary data
+                yield b'\x00'
             for element in Annotationelement().yieldElements(annotation, params, info):
                 # The json conversion is fastest if we use defaults as much as
                 # possible.  The only value in an annotation element that needs
                 # special handling is the id, so cast that ourselves and then
                 # use a json encoder in the most compact form.
-                element['id'] = str(element['id'])
+                if isinstance(element, dict):
+                    element['id'] = str(element['id'])
+                else:
+                    element = struct.pack(
+                        '>QL', int(element[0][:16], 16), int(element[0][16:24], 16)
+                        ) + struct.pack('<fffl', *element[1:])
                 # Use ujson; it is much faster.  The standard json library
                 # could be used in its most default mode instead like so:
                 #   result = json.dumps(element, separators=(',', ':'))
@@ -198,18 +211,30 @@ class AnnotationResource(Resource):
                 # significantly faster than 10 and not much slower than 1000.
                 collect.append(element)
                 if len(collect) >= 100:
-                    yield (b',' if idx else b'') + ujson.dumps(collect).encode('utf8')[1:-1]
+                    if isinstance(collect[0], dict):
+                        yield (b',' if idx else b'') + ujson.dumps(collect).encode('utf8')[1:-1]
+                    else:
+                        yield b''.join(collect)
                     idx += 1
                     collect = []
             if len(collect):
-                yield (b',' if idx else b'') + ujson.dumps(collect).encode('utf8')[1:-1]
+                if isinstance(collect[0], dict):
+                    yield (b',' if idx else b'') + ujson.dumps(collect).encode('utf8')[1:-1]
+                else:
+                    yield b''.join(collect)
+            if centroids:
+                # Add a final null byte to indicate the end of the binary data
+                yield b'\x00'
             yield base[1].rstrip().rstrip(b'}')
             yield b', "_elementQuery": '
             yield json.dumps(
                 info, sort_keys=True, allow_nan=False, cls=JsonEncoder).encode('utf8')
             yield b'}'
 
-        setResponseHeader('Content-Type', 'application/json')
+        if centroids:
+            setResponseHeader('Content-Type', 'application/octet-stream')
+        else:
+            setResponseHeader('Content-Type', 'application/json')
         return generateResult
 
     @describeRoute(

--- a/web_client/models/AnnotationModel.js
+++ b/web_client/models/AnnotationModel.js
@@ -5,6 +5,8 @@ import { restRequest } from 'girder/rest';
 import ElementCollection from '../collections/ElementCollection';
 import convert from '../annotations/convert';
 
+import style from '../annotations/style.js';
+
 /**
  * Define a backbone model representing an annotation.
  * An annotation contains zero or more "elements" or
@@ -49,6 +51,103 @@ export default AccessControlledModel.extend({
     },
 
     /**
+     * Fetch the centroids and unpack the bianry data.
+     */
+    fetchCentroids: function () {
+        var url = (this.altUrl || this.resourceName) + '/' + this.get('_id');
+        var restOpts = {
+            url: url,
+            data: {sort: 'size', sortdir: -1, centroids: true, limit: 2000000},
+            xhrFields: {
+                responseType: 'arraybuffer'
+            },
+            error: null
+        };
+
+        return restRequest(restOpts).done((resp) => {
+            let dv = new DataView(resp);
+            let z0 = 0, z1 = dv.byteLength - 1;
+            for (; dv.getUint8(z0) && z0 < dv.byteLength; z0 += 1);
+            for (; dv.getUint8(z1) && z1 >= 0; z1 -= 1);
+            if (z0 >= z1) {
+                throw new Error('invalid centroid data');
+            }
+            let json = new Uint8Array(z0 + dv.byteLength - z1 - 1);
+            json.set(new Uint8Array(resp.slice(0, z0)), 0);
+            json.set(new Uint8Array(resp.slice(z1 + 1)), z0);
+            let result = JSON.parse(decodeURIComponent(escape(String.fromCharCode.apply(null, json))));
+            let defaults = {
+                default: {
+                    fillColor: {r: 1, g: 120 / 255, b: 0},
+                    fillOpacity: 0.8,
+                    strokeColor: {r: 0, g: 0, b: 0},
+                    strokeOpacity: 1,
+                    strokeWidth: 1
+                },
+                rectangle: {
+                    fillColor: {r: 176 / 255, g: 222 / 255, b: 92 / 255},
+                    strokeColor: {r: 153 / 255, g: 153 / 255, b: 153 / 255},
+                    strokeWidth: 2
+                },
+                polyline: {
+                    strokeColor: {r: 1, g: 120 / 255, b: 0},
+                    strokeOpacity: 0.5,
+                    strokeWidth: 4
+                },
+                polyline_closed: {
+                    fillColor: {r: 176 / 255, g: 222 / 255, b: 92 / 255},
+                    strokeColor: {r: 153 / 255, g: 153 / 255, b: 153 / 255},
+                    strokeWidth: 2
+                }
+            };
+            result.props = result._elementQuery.props.map((props) => {
+                let propsdict = {};
+                result._elementQuery.propskeys.forEach((key, i) => {
+                    propsdict[key] = props[i];
+                });
+                Object.assign(propsdict, style(propsdict));
+                let type = propsdict.type + (propsdict.closed ? '_closed' : '');
+                ['fillColor', 'strokeColor', 'strokeWidth', 'fillOpacity', 'strokeOpacity'].forEach((key) => {
+                    if (propsdict[key] === undefined) {
+                        propsdict[key] = (defaults[type] || defaults.default)[key];
+                    }
+                    if (propsdict[key] === undefined) {
+                        propsdict[key] = defaults.default[key];
+                    }
+                });
+                return propsdict;
+            });
+            dv = new DataView(resp, z0 + 1, z1 - z0 - 1);
+            if (dv.byteLength !== result._elementQuery.count * 28) {
+                throw new Error('invalid centroid data size');
+            }
+            let centroids = {
+                id: new Array(result._elementQuery.count),
+                x: new Float32Array(result._elementQuery.count),
+                y: new Float32Array(result._elementQuery.count),
+                r: new Float32Array(result._elementQuery.count),
+                s: new Uint32Array(result._elementQuery.count)
+            };
+            let i, s;
+            for (i = s = 0; s < dv.byteLength; i += 1, s += 28) {
+                centroids.id[i] =
+                    ('0000000' + dv.getUint32(s, false).toString(16)).substr(-8) +
+                    ('0000000' + dv.getUint32(s + 4, false).toString(16)).substr(-8) +
+                    ('0000000' + dv.getUint32(s + 8, false).toString(16)).substr(-8);
+                centroids.x[i] = dv.getFloat32(s + 12, true);
+                centroids.y[i] = dv.getFloat32(s + 16, true);
+                centroids.r[i] = dv.getFloat32(s + 20, true);
+                centroids.s[i] = dv.getUint32(s + 24, true);
+            }
+            result.centroids = centroids;
+            result.data = {length: result._elementQuery.count};
+
+            this._centroids = result;
+            return result;
+        });
+    },
+
+    /**
      * Fetch a single resource from the server. Triggers g:fetched on success,
      * or g:error on error.
      * To ignore the default error handler, pass
@@ -64,7 +163,7 @@ export default AccessControlledModel.extend({
         opts = opts || {};
         var restOpts = {
             url: (this.altUrl || this.resourceName) + '/' + this.get('_id'),
-            /* Add out region request into the query */
+            /* Add our region request into the query */
             data: this._region
         };
         if (opts.extraPath) {
@@ -74,6 +173,11 @@ export default AccessControlledModel.extend({
             restOpts.error = null;
         }
         this._inFetch = true;
+        if (this._refresh) {
+            delete this._pageElements;
+            delete this._centroids;
+            this._refresh = false;
+        }
         return restRequest(restOpts).done((resp) => {
             const annotation = resp.annotation || {};
             const elements = annotation.elements || [];
@@ -81,22 +185,45 @@ export default AccessControlledModel.extend({
             this.set(resp);
             if (this._pageElements === undefined && resp._elementQuery) {
                 this._pageElements = resp._elementQuery.count > resp._elementQuery.returned;
+                if (this._pageElements) {
+                    this._inFetch = 'centroids';
+                    this.fetchCentroids().then(() => {
+                        this._inFetch = true;
+                        if (opts.extraPath) {
+                            this.trigger('g:fetched.' + opts.extraPath);
+                        } else {
+                            this.trigger('g:fetched');
+                        }
+                        return null;
+                    }).always(() => {
+                        this._inFetch = false;
+                        if (this._nextFetch) {
+                            var nextFetch = this._nextFetch;
+                            this._nextFetch = null;
+                            nextFetch();
+                        }
+                        return null;
+                    });
+                }
             }
-            if (opts.extraPath) {
-                this.trigger('g:fetched.' + opts.extraPath);
-            } else {
-                this.trigger('g:fetched');
+            if (this._inFetch !== 'centroids') {
+                if (opts.extraPath) {
+                    this.trigger('g:fetched.' + opts.extraPath);
+                } else {
+                    this.trigger('g:fetched');
+                }
             }
-
             this._elements.reset(elements, _.extend({sync: true}, opts));
         }).fail((err) => {
             this.trigger('g:error', err);
         }).always(() => {
-            this._inFetch = false;
-            if (this._nextFetch) {
-                var nextFetch = this._nextFetch;
-                this._nextFetch = null;
-                nextFetch();
+            if (this._inFetch !== 'centroids') {
+                this._inFetch = false;
+                if (this._nextFetch) {
+                    var nextFetch = this._nextFetch;
+                    this._nextFetch = null;
+                    nextFetch();
+                }
             }
         });
     },
@@ -225,8 +352,10 @@ export default AccessControlledModel.extend({
      * @param {number} maxZoom the maximum zoom factor.
      * @param {boolean} noFetch Truthy to not perform a fetch if the view
      *  changes.
+     * @param {number} sizeX the maximum width to query.
+     * @param {number} sizeY the maximum height to query.
      */
-    setView(bounds, zoom, maxZoom, noFetch) {
+    setView(bounds, zoom, maxZoom, noFetch, sizeX, sizeY) {
         if (this._pageElements === false || this.isNew()) {
             return;
         }
@@ -245,14 +374,18 @@ export default AccessControlledModel.extend({
         if (canskip && !this._inFetch) {
             return;
         }
-        this._region.left = bounds.left - xoverlap;
-        this._region.top = bounds.top - yoverlap;
-        this._region.right = bounds.right + xoverlap;
-        this._region.bottom = bounds.bottom + yoverlap;
-        /* ask for items that will be at least 0.5 pixels, minus a bit */
+        var lastRegion = Object.assign({}, this._region);
+        this._region.left = Math.max(0, bounds.left - xoverlap);
+        this._region.top = Math.max(0, bounds.top - yoverlap);
+        this._region.right = Math.min(sizeX || 1e6, bounds.right + xoverlap);
+        this._region.bottom = Math.min(sizeY || 1e6, bounds.bottom + yoverlap);
         this._lastZoom = zoom;
-        this._region.minimumSize = Math.pow(2, maxZoom - zoom - 1) - 1;
+        /* Don't ask for a minimum size; we show centroids if the data is
+         * incomplete. */
         if (noFetch) {
+            return;
+        }
+        if (['left', 'top', 'right', 'bottom', 'minumumSize'].every((key) => this._region[key] === lastRegion[key])) {
             return;
         }
         if (!this._nextFetch) {


### PR DESCRIPTION
When there are too many elements to load all of them due to complexity, this loads all element centroids (actually the center of their bounding boxes) along with the element size (the diagonal of the bounding box).  If an element has not been loaded, a circle is shown at the centroid with an adjusted diameter that is related to the bounding box size.

This doesn't actually load *all* element centroids, just the first 2,000,000.  This number should be empirically determined based on GPU memory (something like half the memory divided by (16 or 17) * 4 * vpf would be appropriate).

Other improvements would be to (a) add hover events for centroid elements -- we know the ID and the center position, but not much else, (b) determine if any point's radius would be bigger than the webgl maximum point size, and, if so, render using a different primitive shape; otherwise, very large points render incorrectly, (c) if zoomed-out fully there seems to be an extra fetch of data on initial load, (d) compute a better centroid and size that the bounding box center and diagonal; this could be done on ingest.

This PR will benefit from a GeoJS release -- small points are rendered poorly in master.

When annotation centroids are retrieved, the response is a json-like object with a binary payload in the center.  If there are a large number of distinct styles in the annotation, this can become inefficient (for instance, if every element has a distinct fill and stroke color).

This has been developed on the 2.x-maintenance branch.  Tests will be added on the master branch version.