### PR TITLE
Unpin pytest-cov.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ flake8-bugbear; python_version >= '3.5'
 flake8-docstrings
 flake8-quotes
 pytest>=3.6
-pytest-cov==2.5
+pytest-cov>=2.6
 pytest-girder>=3.0.3
 pytest-xdist
 mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,14 +21,17 @@ cache_dir = build/pytest_cache
 testpaths = test girder/test_girder girder_annotation/test_annotation
 
 [coverage:paths]
+# As of pytest-cov 2.6, all but the first source line is relative to the first
+# source line.  The first line is relative to the local path.  Prior to 2.6,
+# all lines were relative to the local path.
 source =
     large_image/
-    girder/girder_large_image
-    girder_annotation/girder_large_image_annotation
-    sources/
-    tasks/
-    examples/
-    build/tox/*/lib/*/site-packages/large_image/
+    ../girder/girder_large_image
+    ../girder_annotation/girder_large_image_annotation
+    ../sources/
+    ../tasks/
+    ../examples/
+    ../build/tox/*/lib/*/site-packages/large_image/
 
 [coverage:run]
 data_file = build/coverage/.coverage


### PR DESCRIPTION
The format for how source files are mentioned changed between version 2.5.x and 2.6; follow along.