### PR TITLE
Guard against GDAL throwing a runtime error on open.

### DIFF
--- a/sources/mapnik/large_image_source_mapnik/__init__.py
+++ b/sources/mapnik/large_image_source_mapnik/__init__.py
@@ -90,7 +90,7 @@ class MapnikFileTileSource(FileTileSource):
         'image/x-tiff': SourcePriority.LOW,
     }
 
-    def __init__(self, path, projection=None, style=None, unitsPerPixel=None, **kwargs):
+    def __init__(self, path, projection=None, style=None, unitsPerPixel=None, **kwargs):  # noqa
         """
         Initialize the tile class.  See the base class for other available
         parameters.
@@ -154,7 +154,10 @@ class MapnikFileTileSource(FileTileSource):
         super(MapnikFileTileSource, self).__init__(path, **kwargs)
         self._bounds = {}
         self._path = self._getLargeImagePath()
-        self.dataset = gdal.Open(self._path, gdalconst.GA_ReadOnly)
+        try:
+            self.dataset = gdal.Open(self._path, gdalconst.GA_ReadOnly)
+        except RuntimeError:
+            raise TileSourceException('File cannot be opened via GDAL')
         self._getDatasetLock = threading.RLock()
         self.tileSize = 256
         self.tileWidth = self.tileSize


### PR DESCRIPTION
gdal reports "not recognized as a supported file format", but this is done by raising a RuntimeError.