### PR TITLE
Guard against GDAL throwing a runtime error on open.

### DIFF
--- a/plugin_tests/source_mapnik_test.py
+++ b/plugin_tests/source_mapnik_test.py
@@ -379,7 +379,7 @@ class LargeImageSourceMapnikTest(common.LargeImageCommonTest):
             MapnikTileSource(filepath, 'EPSG:4326')
         filepath = os.path.join(
             os.path.dirname(__file__), 'test_files', 'zero_gi.tif')
-        with six.assertRaisesRegex(self, TileSourceException, 'cannot be opened via Mapnik'):
+        with six.assertRaisesRegex(self, TileSourceException, 'cannot be opened via'):
             MapnikTileSource(filepath)
         filepath = os.path.join(
             os.path.dirname(__file__), 'test_files', 'yb10kx5k.png')

--- a/server/tilesource/mapniksource.py
+++ b/server/tilesource/mapniksource.py
@@ -64,7 +64,7 @@ class MapnikTileSource(FileTileSource):
         'tiff': SourcePriority.LOW,
     }
 
-    def __init__(self, path, projection=None, style=None, unitsPerPixel=None, **kwargs):
+    def __init__(self, path, projection=None, style=None, unitsPerPixel=None, **kwargs):  # noqa
         """
         Initialize the tile class.  See the base class for other available
         parameters.
@@ -126,7 +126,10 @@ class MapnikTileSource(FileTileSource):
         super(MapnikTileSource, self).__init__(path, **kwargs)
         self._bounds = {}
         self._path = self._getLargeImagePath()
-        self.dataset = gdal.Open(self._path)
+        try:
+            self.dataset = gdal.Open(self._path)
+        except RuntimeError:
+            raise TileSourceException('File cannot be opened via GDAL')
         self._getDatasetLock = threading.RLock()
         self.tileSize = 256
         self.tileWidth = self.tileSize


### PR DESCRIPTION
Backport of #375 to 2.x branch.