### PR TITLE
Increase the response time limit.

### DIFF
--- a/girder_annotation/girder_large_image_annotation/rest/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/rest/annotation.py
@@ -31,6 +31,7 @@ from girder.exceptions import ValidationException, RestException, AccessExceptio
 from girder.models.item import Item
 from girder.models.user import User
 from girder.utility import JsonEncoder
+from girder.utility.progress import setResponseTimeLimit
 from ..models.annotation import AnnotationSchema, Annotation
 from ..models.annotationelement import Annotationelement
 
@@ -163,6 +164,8 @@ class AnnotationResource(Resource):
         :param params: paging and region parameters for the annotation.
         :returns: a function that will return a generator.
         """
+        # Set the response time limit to a very long value
+        setResponseTimeLimit(86400)
         annotation = Annotation().load(
             id, region=params, user=user, level=AccessType.READ, getElements=False)
         if annotation is None:
@@ -298,6 +301,8 @@ class AnnotationResource(Resource):
     @loadmodel(model='annotation', plugin='large_image', level=AccessType.WRITE)
     @filtermodel(model='annotation', plugin='large_image')
     def updateAnnotation(self, annotation, params):
+        # Set the response time limit to a very long value
+        setResponseTimeLimit(86400)
         user = self.getCurrentUser()
         item = Item().load(annotation.get('itemId'), force=True)
         if item is not None:


### PR DESCRIPTION
When the database is slow, getting and putting annotations can time out.  This increase the time limit.  It would be better to speed up the database, but until that is done, this at least allows it to function.

Forward port of #388.