### PR TITLE
Follow girder 3.0.4 testing changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ node_modules/
 *.aux.xml
 
 .eslintcache
+test/externaldata

--- a/girder/girder_large_image/__init__.py
+++ b/girder/girder_large_image/__init__.py
@@ -276,12 +276,19 @@ SettingDefault.defaults.update({
 })
 
 
+def unbindGirderEventsByHandlerName(handlerName):
+    for eventName in events._mapping:
+        events.unbind(eventName, handlerName)
+
+
 class LargeImagePlugin(GirderPlugin):
     DISPLAY_NAME = 'Large Image'
     CLIENT_SOURCE_PATH = 'web_client'
 
     def load(self, info):
         getPlugin('worker').load(info)
+
+        unbindGirderEventsByHandlerName('large_image')
 
         ModelImporter.registerModel('image_item', ImageItem, 'large_image')
         large_image.config.setConfig('logger', girder.logger)

--- a/girder/setup.py
+++ b/girder/setup.py
@@ -42,7 +42,7 @@ setup(
     install_requires=[
         'enum34>=1.1.6;python_version<"3.4"',
         'futures;python_version<"3.4"',
-        'girder>=3.0.3',
+        'girder>=3.0.4',
         'girder-jobs>=3.0.3',
         'girder-worker[girder]>=0.6.0',
         'large_image>=1.0.0',

--- a/girder/test_girder/test_large_image.py
+++ b/girder/test_girder/test_large_image.py
@@ -19,7 +19,7 @@ from girder_large_image import constants
 from girder_large_image.models.image_item import ImageItem
 
 from . import girder_utilities as utilities
-from .girder_utilities import unavailableWorker  # noqa
+from .girder_utilities import unavailableWorker, unbindLargeImage  # noqa
 
 
 def _waitForJobToBeRunning(job):
@@ -56,6 +56,7 @@ def _createThumbnails(server, admin, spec, cancel=False):
         time.sleep(0.1)
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testSettings(server):
     for key in (constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
@@ -104,6 +105,7 @@ def testSettings(server):
     assert settings[constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE] == 1024
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testThumbnailFileJob(server, admin, user, fsAssetstore):
     file = utilities.uploadExternalFile('data/sample_image.ptif.sha512', admin, fsAssetstore)
@@ -213,6 +215,7 @@ def testThumbnailFileJob(server, admin, user, fsAssetstore):
     assert present < 3 + len(slowList)
 
 
+@pytest.mark.usefixtures('unbindLargeImage')  # noqa
 @pytest.mark.usefixtures('unavailableWorker')  # noqa
 @pytest.mark.plugin('large_image')
 def testDeleteIncompleteTile(server, admin, user, fsAssetstore, unavailableWorker):  # noqa
@@ -270,6 +273,7 @@ def testDeleteIncompleteTile(server, admin, user, fsAssetstore, unavailableWorke
     assert results['removed'] == 1
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testCaches(server, admin):
     resp = server.request(path='/large_image/cache', user=admin)
@@ -282,6 +286,7 @@ def testCaches(server, admin):
     assert 'cacheCleared' in results
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testAssociateImageCaching(server, admin, user, fsAssetstore):
     file = utilities.uploadExternalFile('data/sample_image.ptif.sha512', admin, fsAssetstore)

--- a/girder/test_girder/test_tiles_rest.py
+++ b/girder/test_girder/test_tiles_rest.py
@@ -27,7 +27,7 @@ from girder_large_image import getGirderTileSource
 from girder_large_image import loadmodelcache
 
 from . import girder_utilities as utilities
-from .girder_utilities import girderWorker  # noqa
+from .girder_utilities import girderWorker, unbindLargeImage  # noqa
 
 
 def _testTilesZXY(server, admin, itemId, metadata, tileParams=None,
@@ -192,6 +192,7 @@ def _postTileViaHttp(server, admin, itemId, fileId, jobAction=None):
     return resp.json
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesFromPTIF(server, admin, fsAssetstore):
     file = utilities.uploadExternalFile(
@@ -309,6 +310,7 @@ def testTilesFromPTIF(server, admin, fsAssetstore):
     assert utilities.respStatus(resp) == 200
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesFromTest(server, admin, fsAssetstore):
     publicFolder = utilities.namedFolder(admin, 'Public')
@@ -387,6 +389,7 @@ def testTilesFromTest(server, admin, fsAssetstore):
         _createTestTiles(server, admin, {key: badParams[key]}, error=err)
 
 
+@pytest.mark.usefixtures('unbindLargeImage')  # noqa
 @pytest.mark.usefixtures('girderWorker')  # noqa
 @pytest.mark.plugin('large_image')
 def testTilesFromPNG(boundServer, admin, fsAssetstore, girderWorker):  # noqa
@@ -460,6 +463,7 @@ def testTilesFromPNG(boundServer, admin, fsAssetstore, girderWorker):  # noqa
     assert tileMetadata['levels'] == 7
 
 
+@pytest.mark.usefixtures('unbindLargeImage')  # noqa
 @pytest.mark.usefixtures('girderWorker')  # noqa
 @pytest.mark.plugin('large_image')
 def testTilesFromGreyscale(boundServer, admin, fsAssetstore, girderWorker):  # noqa
@@ -478,6 +482,7 @@ def testTilesFromGreyscale(boundServer, admin, fsAssetstore, girderWorker):  # n
     _testTilesZXY(boundServer, admin, itemId, tileMetadata)
 
 
+@pytest.mark.usefixtures('unbindLargeImage')  # noqa
 @pytest.mark.usefixtures('girderWorker')  # noqa
 @pytest.mark.plugin('large_image')
 def testTilesFromUnicodeName(boundServer, admin, fsAssetstore, girderWorker):  # noqa
@@ -507,6 +512,7 @@ def testTilesFromUnicodeName(boundServer, admin, fsAssetstore, girderWorker):  #
     _testTilesZXY(boundServer, admin, itemId, tileMetadata)
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesWithUnicodeName(server, admin, fsAssetstore):
     # Unicode file names shouldn't cause problems when accessing ptifs.
@@ -528,6 +534,7 @@ def testTilesWithUnicodeName(server, admin, fsAssetstore):
     assert tileMetadata['sizeY'] == 12288
 
 
+@pytest.mark.usefixtures('unbindLargeImage')  # noqa
 @pytest.mark.usefixtures('girderWorker')  # noqa
 @pytest.mark.plugin('large_image')
 def testTilesFromBadFiles(boundServer, admin, fsAssetstore, girderWorker):  # noqa
@@ -548,6 +555,7 @@ def testTilesFromBadFiles(boundServer, admin, fsAssetstore, girderWorker):  # no
     assert resp.json['deleted'] is False
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testThumbnails(server, admin, fsAssetstore):
     file = utilities.uploadExternalFile(
@@ -646,6 +654,7 @@ def testThumbnails(server, admin, fsAssetstore):
     assert present == 0
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testContentDisposition(server, admin, fsAssetstore):
     file = utilities.uploadExternalFile(
@@ -682,6 +691,7 @@ def testContentDisposition(server, admin, fsAssetstore):
         'largeImageThumbnail' in resp.headers['Content-Disposition'])
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testRegions(server, admin, fsAssetstore):
     file = utilities.uploadExternalFile(
@@ -765,6 +775,7 @@ def testRegions(server, admin, fsAssetstore):
     assert height == 375
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testPixel(server, admin, fsAssetstore):
     file = utilities.uploadExternalFile(
@@ -799,6 +810,7 @@ def testPixel(server, admin, fsAssetstore):
     assert resp.json == {}
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testGetTileSource(server, admin, fsAssetstore):
     file = utilities.uploadExternalFile(
@@ -824,6 +836,7 @@ def testGetTileSource(server, admin, fsAssetstore):
     assert height == 100
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesLoadModelCache(server, admin, fsAssetstore):
     loadmodelcache.invalidateLoadModelCache()
@@ -841,6 +854,7 @@ def testTilesLoadModelCache(server, admin, fsAssetstore):
     assert six.next(six.itervalues(loadmodelcache.LoadModelCache))['hits'] > 70
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesModelLookupCache(server, user, admin, fsAssetstore):
     User().load = mock.Mock(wraps=User().load)
@@ -860,6 +874,7 @@ def testTilesModelLookupCache(server, user, admin, fsAssetstore):
     assert User().load.call_count == lastCount
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesDZIEndpoints(server, admin, fsAssetstore):
     file = utilities.uploadExternalFile(
@@ -1012,6 +1027,7 @@ def testTilesAutoSetOption(server, admin, fsAssetstore):
     assert utilities.respStatus(resp) == 200
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesAssociatedImages(server, admin, fsAssetstore):
     file = utilities.uploadExternalFile(
@@ -1059,6 +1075,7 @@ def testTilesAssociatedImages(server, admin, fsAssetstore):
     assert image == b''
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesWithFrameNumbers(server, admin, fsAssetstore):
     file = utilities.uploadExternalFile(

--- a/girder/test_girder/test_web_client.py
+++ b/girder/test_girder/test_web_client.py
@@ -2,9 +2,10 @@ import os
 import pytest
 from pytest_girder.web_client import runWebClientTest
 
-from .girder_utilities import girderWorker  # noqa
+from .girder_utilities import girderWorker, unbindLargeImage  # noqa
 
 
+@pytest.mark.usefixtures('unbindLargeImage')  # noqa
 @pytest.mark.usefixtures('girderWorker')  # noqa
 @pytest.mark.plugin('large_image')
 @pytest.mark.parametrize('spec', (

--- a/girder_annotation/test_annotation/girder_utilities.py
+++ b/girder_annotation/test_annotation/girder_utilities.py
@@ -1,10 +1,16 @@
 # -*- coding: utf-8 -*-
 
 import os
+import pytest
 import six
+import subprocess
 
+from girder import events
 from girder.models.folder import Folder
+from girder.models.setting import Setting
 from girder.models.upload import Upload
+
+from girder_worker.girder_plugin.constants import PluginSettings as WorkerSettings
 
 from test.utilities import externaldata
 
@@ -59,3 +65,41 @@ def getBody(response, text=True):
         data += chunk
 
     return data
+
+
+@pytest.fixture
+def girderWorker(db):
+    """
+    Run an instance of Girder worker, connected to rabbitmq.  The rabbitmq
+    service must be running.
+    """
+    broker = 'amqp://guest@127.0.0.1'
+    Setting().set(WorkerSettings.BROKER, broker)
+    Setting().set(WorkerSettings.BACKEND, broker)
+    env = os.environ.copy()
+    env['C_FORCE_ROOT'] = 'true'
+    proc = subprocess.Popen([
+        'celery', '-A', 'girder_worker.app', 'worker', '--broker', broker, '--concurrency=1'],
+        close_fds=True, env=env)
+    yield True
+    proc.terminate()
+    proc.wait()
+    Setting().unset(WorkerSettings.BROKER)
+    Setting().unset(WorkerSettings.BACKEND)
+
+
+def unbindGirderEventsByHandlerName(handlerName):
+    for eventName in events._mapping:
+        events.unbind(eventName, handlerName)
+
+
+@pytest.fixture
+def unbindLargeImage(db):
+    yield True
+    unbindGirderEventsByHandlerName('large_image')
+
+
+@pytest.fixture
+def unbindAnnotation(db):
+    yield True
+    unbindGirderEventsByHandlerName('large_image_annotation')

--- a/girder_annotation/test_annotation/test_annotations_rest.py
+++ b/girder_annotation/test_annotation/test_annotations_rest.py
@@ -14,9 +14,11 @@ from girder_large_image_annotation.models.annotation import Annotation
 from girder_large_image import constants
 
 from . import girder_utilities as utilities
+from .girder_utilities import unbindLargeImage, unbindAnnotation  # noqa
 from .test_annotations import sampleAnnotationEmpty, sampleAnnotation, makeLargeSampleAnnotation
 
 
+@pytest.mark.usefixtures('unbindLargeImage', 'unbindAnnotation')
 @pytest.mark.plugin('large_image_annotation')
 class TestLargeImageAnnotationRest(object):
     def testGetAnnotationSchema(self, server):

--- a/girder_annotation/test_annotation/test_web_client.py
+++ b/girder_annotation/test_annotation/test_web_client.py
@@ -5,18 +5,23 @@ from pytest_girder.web_client import runWebClientTest
 from girder.models.folder import Folder
 from girder.models.item import Item
 
+from .girder_utilities import girderWorker, unbindLargeImage, unbindAnnotation  # noqa
 
+
+@pytest.mark.usefixtures('unbindLargeImage', 'unbindAnnotation')  # noqa
+@pytest.mark.usefixtures('girderWorker')  # noqa
 @pytest.mark.plugin('large_image_annotation')
 @pytest.mark.parametrize('spec', (
     'annotationListSpec.js',
     'geojsAnnotationSpec.js',
     'geojsSpec.js',
 ))
-def testWebClientWithAnnotation(boundServer, fsAssetstore, db, spec):
+def testWebClientWithAnnotation(boundServer, fsAssetstore, db, spec, girderWorker):  # noqa
     spec = os.path.join(os.path.dirname(__file__), 'web_client_specs', spec)
     runWebClientTest(boundServer, spec, 15000)
 
 
+@pytest.mark.usefixtures('unbindLargeImage', 'unbindAnnotation')
 @pytest.mark.plugin('large_image_annotation')
 def testWebClientAnnotationSpec(boundServer, fsAssetstore, db, admin):
     # Create an item in the Public folder

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Top level dependencies
-girder>=3.0.3
+girder>=3.0.4
 girder-jobs>=3.0.3
 -e sources/dummy
 -e sources/mapnik
@@ -25,7 +25,7 @@ flake8-docstrings
 flake8-quotes
 pytest>=3.6
 pytest-cov>=2.6
-pytest-girder>=3.0.3
+pytest-girder>=3.0.4
 pytest-xdist
 mock
 tox


### PR DESCRIPTION
Because the Girder pytest plugin fixture reinstantiates singletons, it is necessary to unbind and rebind events from models.