### PR TITLE
Add functions and endpoints to remove old annotations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,8 @@ before_install:
   - sudo rm -f /etc/boto.cfg
 
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then export PY3="true"; else export PY2="true"; fi
-  - if [ -n "${PY3}" ]; then export MONGO_VERSION=3.6.2; export PY_COVG="OFF"; else export MONGO_VERSION=3.4.10; export PY_COVG="ON"; export DEPLOY=true; fi
+  - export MONGO_VERSION=3.6.2
+  - if [ -n "${PY3}" ]; then export PY_COVG="OFF"; else export PY_COVG="ON"; export DEPLOY=true; fi
   - GIRDER_VERSION=2.x-maintenance
   - GIRDER_WORKER_VERSION=v0.5.1
 

--- a/plugin_tests/annotations_test.py
+++ b/plugin_tests/annotations_test.py
@@ -1084,6 +1084,16 @@ class LargeImageAnnotationRestTest(common.LargeImageCommonTest):
         loaded = Annotation().load(annot['_id'], user=self.admin)
         self.assertEqual(len(loaded['annotation']['elements']), 4)
 
+        # Test old
+        resp = self.request('/annotation/old', method='GET', user=self.user)
+        self.assertStatus(resp, 403)
+        resp = self.request('/annotation/old', method='GET', user=self.admin)
+        self.assertStatus(resp, 200)
+        self.assertEqual(resp.json['abandonedVersions'], 0)
+        resp = self.request('/annotation/old', method='DELETE', user=self.admin)
+        self.assertStatus(resp, 200)
+        self.assertEqual(resp.json['abandonedVersions'], 0)
+
     #  Add tests for:
     # find
 

--- a/server/models/annotation.py
+++ b/server/models/annotation.py
@@ -18,7 +18,6 @@
 ##############################################################################
 
 from bson import ObjectId
-import bson
 import cherrypy
 import datetime
 import enum
@@ -1024,138 +1023,65 @@ class Annotation(AccessControlledModel):
         age = datetime.datetime.utcnow() + datetime.timedelta(-minAgeInDays)
         if keepInactiveVersions < 0:
             raise ValidationException('keepInactiveVersions mist be non-negative')
-        options = {
-            # By allowing disk use, large sorted queries will work.  If
-            # disallowed, they will fail.  Although this is slower than
-            # memory sorting, actual experiemnts show it to be acceptable
-            'allowDiskUse': True,
-            # Start with a 0-sized batch.  This avoids fetching data from
-            # the Mongo server if the query is never polled and starts
-            # streaming data faster than a fixed batch size.
-            'cursor': {'batchSize': 0},
-        }
-        report = {}
-        # elements without annotations
-        # This can be done via an aggregation, but it is very slow
-        """
-        abandonedElements = [
-            {'$match': {'created': {'$lt': age}}},
-            {'$group': {'_id': '$_version'}},
-            {'$lookup': {
-                'from': 'annotation',
-                'localField': '_id',
-                'foreignField': '_version',
-                'as': '__l'
-            }},
-            {'$match': {'__l': {'$eq': []}}}
-        ]
-        try:
-            logger.info('Checking old annotations, abandoned elements: %s',
-                        bson.json_util.dumps(abandonedElements))
-            report['abandonedVersions'] = next(iter(
-                Annotationelement().collection.aggregate(
-                    abandonedElements + [{'$count': 'count'}], **options)
-                ))['count']
-        except StopIteration:
-            report['abandonedVersions'] = 0
-        logger.info('Checking old annotations, abandoned elements: %r', report['abandonedVersions'])
-        """
-        # This will fail if there are too many versions.
-        logger.info('Checking old annotations, abandoned elements: using distinct')
-        elemversions = Annotationelement().collection.distinct(
+        report = {'fromDeletedItems': 0, 'oldVersions': 0}
+        if remove:
+            report['removedVersions'] = 0
+        itemIds = {}
+        processedIds = set()
+        annotVersions = set()
+        logger.info('Checking old annotations')
+        logtime = time.time()
+        for annot in self.collection.find().sort([('_id', SortDir.ASCENDING)]):
+            if time.time() - logtime > 10:
+                logger.info('Still checking old annotations, checked %d with %d versions, %r' % (
+                    len(processedIds), len(annotVersions), report))
+                logtime = time.time()
+            id = annot.get('_annotationId', annot['_id'])
+            version = annot.get('_version')
+            annotVersions.add(version)
+            if id in processedIds:
+                continue
+            itemId = annot.get('_itemId')
+            if itemId not in itemIds:
+                if len(itemIds) > 10000:
+                    itemIds = {}
+                itemIds[itemId] = Item().findOne({'_id': itemId}) is not None
+            keep = 0 if itemIds[itemId] else keepInactiveVersions
+            history = self.versionList(id, force=True)
+            for record in history:
+                if record.get('_active', True) and itemIds[itemId]:
+                    continue
+                if keep:
+                    keep -= 1
+                    continue
+                if max(record['created'], record['updated']) < age:
+                    if remove:
+                        self.collection.delete_one({'_id': record['_id']})
+                        Annotationelement().removeWithQuery({'_version': record['_version']})
+                        report['removedVersions'] += 1
+                    if itemIds[itemId] is None:
+                        report['fromDeletedItems'] += 1
+                    else:
+                        report['oldVersions'] += 1
+            processedIds.add(id)
+        logger.info('Getting distinct element versions')
+        elemVersions = Annotationelement().collection.distinct(
             '_version', filter={'created': {'$lt': age}})
-        docversions = self.collection.distinct('_version')
-        abandonedVersions = set(elemversions) - set(docversions)
+        logger.info('Got %d distinct element versions' % len(elemVersions))
+        logtime = time.time()
+        abandonedVersions = set(elemVersions) - set(annotVersions)
         report['abandonedVersions'] = len(abandonedVersions)
-        logger.info('Checking old annotations, abandoned elements: %r', report['abandonedVersions'])
-        # Annotations without items
-        fromDeletedItems = [
-            {'$match': {'updated': {'$lt': age}}},
-            {'$lookup': {
-                'from': 'item',
-                'localField': 'itemId',
-                'foreignField': '_id',
-                'as': '__l'
-            }},
-            {'$match': {'__l': {'$eq': []}}}
-        ]
-        try:
-            logger.info('Checking old annotations, from deleted items: %s',
-                        bson.json_util.dumps(fromDeletedItems))
-            report['fromDeletedItems'] = next(iter(
-                self.collection.aggregate(
-                    fromDeletedItems + [{'$count': 'count'}], **options)
-                ))['count']
-        except StopIteration:
-            report['fromDeletedItems'] = 0
-        logger.info('Checking old annotations, from deleted items: %r', report['fromDeletedItems'])
-        # Old versions
-        oldVersions = [
-            {'$match': {'_active': False}},
-            {'$addFields': {'_annotationId': {'$ifNull': ['$_annotationId', '$_id']}}},
-            {'$sort': {'_version': 1}},
-            {'$group': {'_id': '$_annotationId', 'versions': {'$push': '$_version'}}},
-            {'$match': {'$expr': {'$gt': [{'$size': '$versions'}, keepInactiveVersions]}}},
-            {'$addFields': {'versions': {'$slice': ['$versions', keepInactiveVersions, 1e9]}}},
-            {'$unwind': "$versions"},
-            {'$lookup': {
-                'from': 'annotation',
-                'localField': 'versions',
-                'foreignField': '_version',
-                'as': '__l'
-            }},
-            {'$unwind': "$__l"},
-            {'$replaceRoot': {'newRoot': '$__l'}},
-            # Repeating _active: False shouldn't be necessary
-            {'$match': {'updated': {'$lt': age}, '_active': False}}
-        ]
-        try:
-            logger.info('Checking old annotations: old versions: %s',
-                        bson.json_util.dumps(oldVersions))
-            report['oldVersions'] = next(iter(
-                self.collection.aggregate(
-                    oldVersions + [{'$count': 'count'}], **options)
-                ))['count']
-        except StopIteration:
-            report['oldVersions'] = 0
-        logger.info('Checking old annotations: old versions: %r', report['oldVersions'])
-        # Walk results and remove if required
-        if report['abandonedVersions']:
+        if remove:
             for version in abandonedVersions:
-                if remove:
-                    Annotationelement().removeWithQuery({'_version': version})
-                    report['removedAbandonedVersions'] = report.get(
-                        'removedAbandonedVersions', 0) + 1
-            logger.info('%s old annotations, abandoned elements: %r',
-                        'Checked' if not remove else 'Deleted',
-                        report['abandonedVersions'])
-        if report['fromDeletedItems']:
-            for annotation in self.collection.aggregate(
-                    fromDeletedItems, **options):
-                if remove:
-                    super(Annotation, self).remove(annotation)
-                    Annotationelement().removeWithQuery({'_version': annotation['_version']})
-                    report['removedFromDeletedItems'] = report.get(
-                        'removedFromDeletedItems', 0) + 1
-            logger.info('%s old annotations, from deleted items: %r',
-                        'Checked' if not remove else 'Deleted',
-                        report['fromDeletedItems'])
-        if report['oldVersions']:
-            for annotation in self.collection.aggregate(
-                    oldVersions, **options):
-                if remove:
-                    super(Annotation, self).remove(annotation)
-                    Annotationelement().removeWithQuery({'_version': annotation['_version']})
-                    report['removedOldVersions'] = report.get(
-                        'removedOldVersions', 0) + 1
-            logger.info('%s old annotations: old versions: %r',
-                        'Checked' if not remove else 'Deleted',
-                        report['oldVersions'])
-        if (remove and (report['abandonedVersions'] or report['fromDeletedItems'] or
-                        report['oldVersions'])):
+                if time.time() - logtime > 10:
+                    logger.info('Removing abandoned versions, %r' % report)
+                    logtime = time.time()
+                Annotationelement().removeWithQuery({'_version': version})
+                report['removedVersions'] += 1
             logger.info('Compacting annotation collection')
             self.collection.database.command('compact', self.name)
             logger.info('Compacting annotationelement collection')
             self.collection.database.command('compact', Annotationelement().name)
             logger.info('Done compacting collections')
+        logger.info('Finished checking old annotations, %r' % report)
         return report

--- a/server/models/annotationelement.py
+++ b/server/models/annotationelement.py
@@ -61,6 +61,10 @@ class Annotationelement(Model):
                 ('_version', SortDir.DESCENDING),
                 ('element.group', SortDir.ASCENDING),
             ], {}),
+            ([
+                ('created', SortDir.ASCENDING),
+                ('_version', SortDir.ASCENDING),
+            ], {}),
         ])
 
         self.exposeFields(AccessType.READ, (
@@ -83,8 +87,13 @@ class Annotationelement(Model):
             versionObject = self.collection.find_one(
                 {'annotationId': 'version_sequence'})
             if versionObject is None:
+                startingId = self.collection.find_one({}, sort=[('_version', SortDir.DESCENDING)])
+                if startingId:
+                    startingId = startingId['_version'] + 1
+                else:
+                    startingId = 0
                 self.versionId = self.collection.insert_one(
-                    {'annotationId': 'version_sequence', '_version': 0}
+                    {'annotationId': 'version_sequence', '_version': startingId}
                 ).inserted_id
             else:
                 self.versionId = versionObject['_id']

--- a/server/rest/annotation.py
+++ b/server/rest/annotation.py
@@ -56,9 +56,11 @@ class AnnotationResource(Resource):
         self.route('DELETE', (':id',), self.deleteAnnotation)
         self.route('GET', (':id', 'access'), self.getAnnotationAccess)
         self.route('PUT', (':id', 'access'), self.updateAnnotationAccess)
-        self.route('GET', ('item', ':id',), self.getItemAnnotations)
-        self.route('POST', ('item', ':id',), self.createItemAnnotations)
-        self.route('DELETE', ('item', ':id',), self.deleteItemAnnotations)
+        self.route('GET', ('item', ':id'), self.getItemAnnotations)
+        self.route('POST', ('item', ':id'), self.createItemAnnotations)
+        self.route('DELETE', ('item', ':id'), self.deleteItemAnnotations)
+        self.route('GET', ('old',), self.getOldAnnotations)
+        self.route('DELETE', ('old',), self.deleteOldAnnotations)
 
     @describeRoute(
         Description('Search for annotations.')
@@ -545,3 +547,29 @@ class AnnotationResource(Resource):
                 Annotation().remove(annot)
                 count += 1
         return count
+
+    @autoDescribeRoute(
+        Description('Report on old annotations.')
+        .param('age', 'The minimum age in days.', required=False,
+               dataType='int', default=30)
+        .param('versions', 'Keep at least this many history entries for each '
+               'annotation.', required=False, dataType='int', default=10)
+        .errorResponse()
+    )
+    @access.admin
+    def getOldAnnotations(self, age, versions):
+        setResponseTimeLimit(86400)
+        return Annotation().removeOldAnnotations(False, age, versions)
+
+    @autoDescribeRoute(
+        Description('Delete old annotations.')
+        .param('age', 'The minimum age in days.', required=False,
+               dataType='int', default=30)
+        .param('versions', 'Keep at least this many history entries for each '
+               'annotation.', required=False, dataType='int', default=10)
+        .errorResponse()
+    )
+    @access.admin
+    def deleteOldAnnotations(self, age, versions):
+        setResponseTimeLimit(86400)
+        return Annotation().removeOldAnnotations(True, age, versions)


### PR DESCRIPTION
If you are tracking history, annotations can build up excessively.  This provides an informational endpoint and a delete endpoint to show how many old annotations there are and to remove them and compact the database.