### PR TITLE
Remove PIL version check.

### DIFF
--- a/server/tilesource/base.py
+++ b/server/tilesource/base.py
@@ -51,9 +51,6 @@ except ImportError:
 try:
     import PIL
 
-    if int(PIL.PILLOW_VERSION.split('.')[0]) < 3:
-        logger.warning('Error: Pillow v3.0 or later is required')
-        PIL = None
     import PIL.Image
     import PIL.ImageColor
     import PIL.ImageDraw

--- a/server/tilesource/test.py
+++ b/server/tilesource/test.py
@@ -23,10 +23,7 @@ from .base import TileSource, TileSourceException
 from ..cache_util import strhash, methodcache, LruCacheMetaclass
 from ..constants import SourcePriority
 
-import PIL
 from PIL import Image, ImageDraw, ImageFont
-if int(PIL.PILLOW_VERSION.split('.')[0]) < 3:
-    raise ImportError('Pillow v3.0 or later is required')
 
 
 # Used in testing


### PR DESCRIPTION
Otherwise, PIL 7 fails.

This only applies to the 2.x-maintenance branch.