### PR TITLE
Don't delete the task output file.

### DIFF
--- a/girder/girder_large_image/models/image_item.py
+++ b/girder/girder_large_image/models/image_item.py
@@ -114,7 +114,7 @@ class ImageItem(Item):
             outputName=outputName,
             outputDir=TemporaryDirectory(),
             girder_result_hooks=[
-                GirderUploadToItem(str(item['_id']), True),
+                GirderUploadToItem(str(item['_id']), False),
             ]
         )
         return job.job


### PR DESCRIPTION
Since the output directory is removed, removing the file can result in a failure in girder_worker_utils.