### PR TITLE
Improve handling imported formats with adjacent files.

### DIFF
--- a/girder/girder_large_image/girder_tilesource.py
+++ b/girder/girder_large_image/girder_tilesource.py
@@ -58,34 +58,45 @@ class GirderTileSource(tilesource.FileTileSource):
             self.edge,
             self._jsonstyle)
 
+    def mayHaveAdjacentFiles(self, largeImageFile):
+        if not hasattr(self, '_mayHaveAdjacentFiles'):
+            largeImageFileId = self.item['largeImage']['fileId']
+            # The item has adjacent files if there are any files that are not
+            # the large image file or an original file it was derived from.
+            # This is always the case if there are 3 or more files.
+            fileIds = [str(file['_id']) for file in Item().childFiles(self.item, limit=3)]
+            knownIds = [str(largeImageFileId)]
+            if 'originalId' in self.item['largeImage']:
+                knownIds.append(str(self.item['largeImage']['originalId']))
+            self._mayHaveAdjacentFiles = (
+                len(fileIds) >= 3 or
+                fileIds[0] not in knownIds or
+                fileIds[-1] not in knownIds)
+            if (any(ext in KnownExtensionsWithAdjacentFiles for ext in largeImageFile['exts']) or
+                    largeImageFile.get('mimeType') in KnownMimeTypesWithAdjacentFiles):
+                self._mayHaveAdjacentFiles = True
+        return self._mayHaveAdjacentFiles
+
     def _getLargeImagePath(self):
         # If self.mayHaveAdjacentFiles is True, we try to use the girder
         # mount where companion files appear next to each other.
+        largeImageFileId = self.item['largeImage']['fileId']
+        largeImageFile = File().load(largeImageFileId, force=True)
         try:
-            largeImageFileId = self.item['largeImage']['fileId']
-            if not hasattr(self, 'mayHaveAdjacentFiles'):
-                # The item has adjacent files if there are any files that
-                # are not the large image file or an original file it
-                # was derived from.  This is always the case if there are 3
-                # or more files.
-                fileIds = [str(file['_id']) for file in Item().childFiles(self.item, limit=3)]
-                knownIds = [str(largeImageFileId)]
-                if 'originalId' in self.item['largeImage']:
-                    knownIds.append(str(self.item['largeImage']['originalId']))
-                self.mayHaveAdjacentFiles = (
-                    len(fileIds) >= 3 or
-                    fileIds[0] not in knownIds or
-                    fileIds[-1] not in knownIds)
-            largeImageFile = File().load(largeImageFileId, force=True)
-            if (any(ext in KnownExtensionsWithAdjacentFiles for ext in largeImageFile['exts']) or
-                    largeImageFile.get('mimeType') in KnownMimeTypesWithAdjacentFiles):
-                self.mayHaveAdjacentFiles = True
             largeImagePath = None
-            if self.mayHaveAdjacentFiles and hasattr(File(), 'getGirderMountFilePath'):
+            if (self.mayHaveAdjacentFiles(largeImageFile) and
+                    hasattr(File(), 'getGirderMountFilePath')):
                 try:
-                    largeImagePath = File().getGirderMountFilePath(largeImageFile)
-                except FilePathException:
+                    if (largeImageFile.get('imported') and
+                            File().getLocalFilePath(largeImageFile) == largeImageFile['path']):
+                        largeImagePath = largeImageFile['path']
+                except Exception:
                     pass
+                if not largeImagePath:
+                    try:
+                        largeImagePath = File().getGirderMountFilePath(largeImageFile)
+                    except FilePathException:
+                        pass
             if not largeImagePath:
                 try:
                     largeImagePath = File().getLocalFilePath(largeImageFile)


### PR DESCRIPTION
When handling paths of file formats with adjacent files that have been imported, use the local path in preference to the mounted path.