### PR TITLE
Do a migration of database values on start.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Improvements
+- Migrate some database values on start to allow better annotation count reporting (#431)
+
 ## Version 1.1.0
 
 ### Features

--- a/girder_annotation/girder_large_image_annotation/__init__.py
+++ b/girder_annotation/girder_large_image_annotation/__init__.py
@@ -58,7 +58,8 @@ class LargeImageAnnotationPlugin(GirderPlugin):
         ModelImporter.registerModel('annotation', Annotation, 'large_image')
         info['apiRoot'].annotation = AnnotationResource()
         # Ask for some models to make sure their singletons are initialized.
-        Annotation()
+        # Also migrate the database as a one-time action.
+        Annotation()._migrateDatabase()
 
         # add copyAnnotations option to POST resource/copy, POST item/{id}/copy
         # and POST folder/{id}/copy

--- a/girder_annotation/girder_large_image_annotation/rest/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/rest/annotation.py
@@ -96,12 +96,9 @@ class AnnotationResource(Resource):
             (
                 'annotation.name', 'annotation.description', 'access', 'groups', '_version'
             ) + Annotation().baseFields)
-        annotations = list(Annotation().filterResultsByPermission(
-            cursor=Annotation().find(query, sort=sort, fields=fields),
-            user=self.getCurrentUser(), level=AccessType.READ, limit=limit, offset=offset
-        ))
-        for annotation in annotations:
-            Annotation().injectAnnotationGroupSet(annotation)
+        annotations = Annotation().findWithPermissions(
+            query, sort=sort, fields=fields, user=self.getCurrentUser(),
+            level=AccessType.READ, limit=limit, offset=offset)
         return annotations
 
     @describeRoute(

--- a/girder_annotation/girder_large_image_annotation/web_client/views/itemList.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/itemList.js
@@ -1,11 +1,11 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
+import { restRequest } from '@girder/core/rest';
 import { wrap } from '@girder/core/utilities/PluginUtils';
 import ItemListWidget from '@girder/core/views/widgets/ItemListWidget';
 
 import largeImageAnnotationConfig from './configView';
-import AnnotationCollection from '../collections/AnnotationCollection';
 
 import '../stylesheets/itemList.styl';
 
@@ -13,10 +13,16 @@ wrap(ItemListWidget, 'render', function (render) {
     render.apply(this, _.rest(arguments));
 
     function addLargeImageAnnotationBadge(item, parent) {
-        const collection = new AnnotationCollection([]);
-        collection.fetch({
-            itemId: item.id
-        }).done(() => {
+        restRequest({
+            type: 'GET',
+            url: 'annotation',
+            data: {
+                itemId: item.id,
+                limit: -1
+            },
+            error: null
+        }).done((result, status, jqxhr) => {
+            const numAnnotations = +jqxhr.getResponseHeader('Girder-Total-Count') || 0;
             const thumbnail = $('a[g-item-cid="' + item.cid + '"] .large_image_thumbnail', parent).first();
 
             let badge = thumbnail.find('.large_image_annotation_badge');
@@ -24,9 +30,8 @@ wrap(ItemListWidget, 'render', function (render) {
                 badge = $(`<div class="large_image_annotation_badge"></div>`).appendTo(thumbnail);
             }
             // update badge
-            const numAnnotations = collection.length;
             badge
-                .attr('title', `${numAnnotations} Annotation${numAnnotations === 1 ? '' : 's'}`)
+                .attr('title', `${numAnnotations} annotation${numAnnotations === 1 ? '' : 's'}`)
                 .text(numAnnotations)
                 .toggleClass('hidden', numAnnotations === 0);
         });

--- a/girder_annotation/test_annotation/test_annotations.py
+++ b/girder_annotation/test_annotation/test_annotations.py
@@ -541,6 +541,8 @@ class TestLargeImageAnnotationAccessMigration(object):
         del annot['public']
         Annotation().save(annot)
 
+        Annotation()._migrateDatabase()
+
         # load the annotation and assert access properties were added
         annot = Annotation().load(annot['_id'], force=True)
 
@@ -565,9 +567,9 @@ class TestLargeImageAnnotationAccessMigration(object):
 
         Annotation().save(annot)
         with mock.patch('girder_large_image_annotation.models.annotation.logger') as logger:
-            annot = Annotation().load(annot['_id'], force=True)
+            Annotation()._migrateDatabase()
             logger.warning.assert_called_once()
-
+        annot = Annotation().load(annot['_id'], force=True)
         assert 'access' not in annot
 
     def testMigrateAnnotationAccessControlNoFolderError(self, user, admin):
@@ -584,11 +586,10 @@ class TestLargeImageAnnotationAccessMigration(object):
         # save an invalid folder id to the item
         item['folderId'] = ObjectId()
         Item().save(item)
-
         with mock.patch('girder_large_image_annotation.models.annotation.logger') as logger:
-            annot = Annotation().load(annot['_id'], force=True)
+            Annotation()._migrateDatabase()
             logger.warning.assert_called_once()
-
+        annot = Annotation().load(annot['_id'], force=True)
         assert 'access' not in annot
 
     def testMigrateAnnotationAccessControlNoUserError(self, user, admin):
@@ -602,9 +603,8 @@ class TestLargeImageAnnotationAccessMigration(object):
         del annot['public']
         annot['creatorId'] = ObjectId()
         Annotation().save(annot)
-
         with mock.patch('girder_large_image_annotation.models.annotation.logger') as logger:
-            annot = Annotation().load(annot['_id'], force=True)
+            Annotation()._migrateDatabase()
             logger.warning.assert_called_once()
-
+        annot = Annotation().load(annot['_id'], force=True)
         assert 'access' not in annot

--- a/girder_annotation/test_annotation/test_annotations_rest.py
+++ b/girder_annotation/test_annotation/test_annotations_rest.py
@@ -655,6 +655,7 @@ class TestLargeImageAnnotationElementGroups(object):
                 }]
             }
         )
+        annotationModel._migrateDatabase()
 
     def testFindAnnotations(self, server, admin):
         self.makeAnnot(admin)


### PR DESCRIPTION
We were doing on-demand migrations to have ACLs and groups in annotation models, since originally we didn't have these.  Not having them prevents certain optimizations, like getting count of total number of annotations as a header when listing annotations.  Although there could be a slow one-time response to this, and, without appropriate indices, the initial start-up will be slower, the benefits outweigh this cost.

As a benefit of this, for instance, the query to display the number of annotations in the image list can return much less data, since it can get the number of annotations from the header.