### PR TITLE
Add functions and endpoints to remove old annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Features
+- Added endpoints to remove old annotations (#432)
+
 ### Improvements
 - Migrate some database values on start to allow better annotation count reporting (#431)
 

--- a/girder_annotation/girder_large_image_annotation/models/annotationelement.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotationelement.py
@@ -61,6 +61,10 @@ class Annotationelement(Model):
                 ('_version', SortDir.DESCENDING),
                 ('element.group', SortDir.ASCENDING),
             ], {}),
+            ([
+                ('created', SortDir.ASCENDING),
+                ('_version', SortDir.ASCENDING),
+            ], {}),
         ])
 
         self.exposeFields(AccessType.READ, (
@@ -83,8 +87,13 @@ class Annotationelement(Model):
             versionObject = self.collection.find_one(
                 {'annotationId': 'version_sequence'})
             if versionObject is None:
+                startingId = self.collection.find_one({}, sort=[('_version', SortDir.DESCENDING)])
+                if startingId:
+                    startingId = startingId['_version'] + 1
+                else:
+                    startingId = 0
                 self.versionId = self.collection.insert_one(
-                    {'annotationId': 'version_sequence', '_version': 0}
+                    {'annotationId': 'version_sequence', '_version': startingId}
                 ).inserted_id
             else:
                 self.versionId = versionObject['_id']

--- a/girder_annotation/girder_large_image_annotation/rest/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/rest/annotation.py
@@ -55,9 +55,11 @@ class AnnotationResource(Resource):
         self.route('DELETE', (':id',), self.deleteAnnotation)
         self.route('GET', (':id', 'access'), self.getAnnotationAccess)
         self.route('PUT', (':id', 'access'), self.updateAnnotationAccess)
-        self.route('GET', ('item', ':id',), self.getItemAnnotations)
-        self.route('POST', ('item', ':id',), self.createItemAnnotations)
-        self.route('DELETE', ('item', ':id',), self.deleteItemAnnotations)
+        self.route('GET', ('item', ':id'), self.getItemAnnotations)
+        self.route('POST', ('item', ':id'), self.createItemAnnotations)
+        self.route('DELETE', ('item', ':id'), self.deleteItemAnnotations)
+        self.route('GET', ('old',), self.getOldAnnotations)
+        self.route('DELETE', ('old',), self.deleteOldAnnotations)
 
     @describeRoute(
         Description('Search for annotations.')
@@ -537,3 +539,29 @@ class AnnotationResource(Resource):
                 Annotation().remove(annot)
                 count += 1
         return count
+
+    @autoDescribeRoute(
+        Description('Report on old annotations.')
+        .param('age', 'The minimum age in days.', required=False,
+               dataType='int', default=30)
+        .param('versions', 'Keep at least this many history entries for each '
+               'annotation.', required=False, dataType='int', default=10)
+        .errorResponse()
+    )
+    @access.admin
+    def getOldAnnotations(self, age, versions):
+        setResponseTimeLimit(86400)
+        return Annotation().removeOldAnnotations(False, age, versions)
+
+    @autoDescribeRoute(
+        Description('Delete old annotations.')
+        .param('age', 'The minimum age in days.', required=False,
+               dataType='int', default=30)
+        .param('versions', 'Keep at least this many history entries for each '
+               'annotation.', required=False, dataType='int', default=10)
+        .errorResponse()
+    )
+    @access.admin
+    def deleteOldAnnotations(self, age, versions):
+        setResponseTimeLimit(86400)
+        return Annotation().removeOldAnnotations(True, age, versions)

--- a/girder_annotation/test_annotation/test_annotations_rest.py
+++ b/girder_annotation/test_annotation/test_annotations_rest.py
@@ -537,6 +537,19 @@ class TestLargeImageAnnotationRest(object):
         loaded = Annotation().load(annot['_id'], user=admin)
         assert len(loaded['annotation']['elements']) == 4
 
+        # Test old
+        resp = server.request('/annotation/old', method='GET', user=user)
+        assert utilities.respStatus(resp) == 403
+        resp = server.request('/annotation/old', method='GET', user=admin)
+        assert utilities.respStatus(resp) == 200
+        assert resp.json['abandonedVersions'] == 0
+        resp = server.request('/annotation/old', method='DELETE', user=admin)
+        assert utilities.respStatus(resp) == 200
+        assert resp.json['abandonedVersions'] == 0
+        resp = server.request('/annotation/old', method='DELETE', user=admin, params={'age': 6})
+        assert utilities.respStatus(resp) == 400
+        assert 'minAgeInDays' in resp.json['message']
+
     def testAnnotationsAfterCopyItem(self, server, admin):
         publicFolder = utilities.namedFolder(admin, 'Public')
         item = Item().createItem('sample', admin, publicFolder)


### PR DESCRIPTION
If you are tracking history, annotations can build up excessively.  This provides an informational endpoint and a delete endpoint to show how many old annotations there are and to remove them and compact the database.