### PR TITLE
Standardize frame metadata.

### DIFF
--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1454,6 +1454,28 @@ class TileSource(object):
         return False
 
     def getMetadata(self):
+        """
+        Return metadata about this tile source.  In addition to the keys that
+        are listed in this template function, tile sources that expose multiple
+        frames will also contain:
+        - frames: a list of frames.  Each frame entry is a dictionary with
+          - Frame: a 0-values frame index (the location in the list)
+          - Channel (optional): the name of the channel, if known
+          - IndexC (optional if unique): a 0-based index into the channel list
+          - IndexT (optional if unique): a 0-based index for time values
+          - IndexZ (optional if unique): a 0-based index for z values
+          - IndexXY (optional if unique): a 0-based index for view (xy) values
+          - Index: a 0-based index of non-channel unique sets.  If the frames
+              vary only by channel and are adjacent, they will have the same
+              index.
+        - IndexRange: a dictionary of the number of unique index values from
+            frames if greater than 1 (e.g., if an entry like IndexXY is not
+            present, then all frames either do not have that value or have a
+            value of 0).
+        - channels (optional): if known, a list of channel names
+        - channelmap (optional): if known, a dictionary of channel names with
+            their offset into the channel list.
+        """
         mag = self.getNativeMagnification()
         return {
             'levels': self.levels,

--- a/test/test_source_nd2.py
+++ b/test/test_source_nd2.py
@@ -19,4 +19,11 @@ def testTilesFromND2():
     assert tileMetadata['levels'] == 3
     assert tileMetadata['magnification'] == pytest.approx(47, 1)
     assert len(tileMetadata['frames']) == 232
+    assert tileMetadata['frames'][201]['Frame'] == 201
+    assert tileMetadata['frames'][201]['Index'] == 50
+    assert tileMetadata['frames'][201]['IndexC'] == 1
+    assert tileMetadata['frames'][201]['IndexXY'] == 1
+    assert tileMetadata['frames'][201]['IndexZ'] == 21
+    assert tileMetadata['channels'] == ['Brightfield', 'YFP', 'A594', 'DAPI']
+    assert tileMetadata['IndexRange'] == {'IndexC': 4, 'IndexXY': 2, 'IndexZ': 29}
     utilities.checkTilesZXY(source, tileMetadata)

--- a/test/test_source_ometiff.py
+++ b/test/test_source_ometiff.py
@@ -20,6 +20,10 @@ def testTilesFromOMETiff():
     assert tileMetadata['sizeY'] == 2016
     assert tileMetadata['levels'] == 3
     assert len(tileMetadata['frames']) == 3
+    assert tileMetadata['frames'][1]['Frame'] == 1
+    assert tileMetadata['frames'][1]['Index'] == 0
+    assert tileMetadata['frames'][1]['IndexC'] == 1
+    assert tileMetadata['IndexRange'] == {'IndexC': 3}
     utilities.checkTilesZXY(source, tileMetadata)
 
 
@@ -34,6 +38,12 @@ def testTilesFromStripOMETiff():
     assert tileMetadata['sizeY'] == 1022
     assert tileMetadata['levels'] == 3
     assert len(tileMetadata['frames']) == 145
+    assert tileMetadata['frames'][101]['Frame'] == 101
+    assert tileMetadata['frames'][101]['Index'] == 20
+    assert tileMetadata['frames'][101]['IndexC'] == 1
+    assert tileMetadata['frames'][101]['IndexZ'] == 20
+    assert tileMetadata['channels'] == ['Brightfield', 'CY3', 'A594', 'CY5', 'DAPI']
+    assert tileMetadata['IndexRange'] == {'IndexC': 5, 'IndexZ': 29}
     utilities.checkTilesZXY(source, tileMetadata)
 
 


### PR DESCRIPTION
Any tile source that exposes frames will have a frames list.  This list now will always contain Frame and Index values, and, where appropriate IndexC, IndexT, IndexZ, IndexXY values.  The top-level metadata will always have IndexRange and IndexStride entries.  When known, the top-level metadata will have channels and channelmap entries with channel names.