### PR TITLE
When scaling, adjust reported mm_x/y.

### DIFF
--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -282,6 +282,8 @@ class LazyTileDict(dict):
             self['tile_height'] = self.get('tile_width', self.height)
             if self.get('magnification', None):
                 self['tile_magnification'] = self.get('tile_magnification', self['magnification'])
+            self['tile_mm_x'] = self.get('mm_x')
+            self['tile_mm_y'] = self.get('mm_y')
             self['x'] = float(self['tile_x'])
             self['y'] = float(self['tile_y'])
             # Add provisional width and height
@@ -292,6 +294,10 @@ class LazyTileDict(dict):
                     self['tile_height'] / self.requestedScale))
                 if self.get('tile_magnification', None):
                     self['magnification'] = self['tile_magnification'] / self.requestedScale
+                if self.get('tile_mm_x', None):
+                    self['mm_x'] = self['tile_mm_x'] * self.requestedScale
+                if self.get('tile_mm_y', None):
+                    self['mm_y'] = self['tile_mm_y'] * self.requestedScale
             # If we can resample the tile, many parameters may change once the
             # image is loaded.  Don't include width and height in this list;
             # the provisional values are sufficient.
@@ -1832,8 +1838,10 @@ class TileSource(object):
         if rounding:
             level = int(math.ceil(level) if rounding == 'ceil' else
                         round(level))
+        open('/tmp/junk.txt', 'a').write('ratio E: %r\n' % [exact, level, mag, rounding])  # ##DWM::
         if (exact and (level > mag['level'] or level < 0) or
                 (rounding == 'ceil' and level > mag['level'])):
+            open('/tmp/junk.txt', 'a').write('ratio G: %r\n' % [])  # ##DWM::
             return None
         if rounding is not None:
             level = max(0, min(mag['level'], level))
@@ -1897,6 +1905,8 @@ class TileSource(object):
                     scaling.
                 tile_magnification: magnification of the current tile before
                     scaling.
+                tile_mm_x, tile_mm_y: size of a pixel in a tile in millimeters
+                    before scaling.
             Note that scipy.misc.imresize uses PIL internally.
         :param region: a dictionary of optional values which specify the part
                 of the image to process.

--- a/test/test_source_tiff.py
+++ b/test/test_source_tiff.py
@@ -620,3 +620,29 @@ def testHistogram():
                             density=True, resample=False)
     assert hist['histogram'][0]['samples'] == 2801664
     assert hist['histogram'][0]['hist'][128] == pytest.approx(6.39e-5, 0.01)
+
+
+def testSingleTileIteratorResample():
+    imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
+    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    tile = source.getSingleTile()
+    assert tile['mm_x'] == 0.00025
+    assert tile['width'] == 256
+    tile = source.getSingleTile(
+        tile_size={'width': 255, 'height': 255}, scale={'mm_x': 0.5e-3})
+    assert tile['mm_x'] == 0.0005
+    assert tile['width'] == 255
+    tile = source.getSingleTile(
+        tile_size={'width': 255, 'height': 255}, scale={'mm_x': 0.6e-3}, resample=False)
+    assert tile['mm_x'] == 0.0005
+    assert tile['width'] == 255
+    assert tile['magnification'] == 20.0
+    assert 'tile_mm_x' not in tile
+    assert 'tile_magnification' not in tile
+    tile = source.getSingleTile(
+        tile_size={'width': 255, 'height': 255}, scale={'mm_x': 0.6e-3}, resample=True)
+    assert tile['mm_x'] == pytest.approx(0.0006, 1e-3)
+    assert tile['magnification'] == pytest.approx(16.667, 1e-3)
+    assert tile['width'] == 255
+    assert tile['tile_mm_x'] == 0.0005
+    assert tile['tile_magnification'] == 20.0


### PR DESCRIPTION
Set tile_mm_x/y to the unscaled values and mm_x/y to the scaled values.

Fixes #439.