### PR TITLE
Fix a threading issue with multiple styled tiles

### DIFF
--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -353,12 +353,12 @@ class LazyTileDict(dict):
                     self.x, self.y, self.level,
                     pilImageAllowed=True, numpyAllowed=True,
                     sparseFallback=True, frame=self.frame)
+                if self.crop:
+                    tileData, _ = _imageToNumpy(tileData)
+                    tileData = tileData[self.crop[1]:self.crop[3], self.crop[0]:self.crop[2]]
             else:
                 tileData = self._retileTile()
 
-            if self.crop and not self.retile:
-                tileData, _ = _imageToNumpy(tileData)
-                tileData = tileData[self.crop[1]:self.crop[3], self.crop[0]:self.crop[2]]
             pilData = _imageToPIL(tileData)
 
             # resample if needed
@@ -1140,7 +1140,7 @@ class TileSource(object):
         :param onlyMinMax: if True, only return the minimum and maximum value
             of the region.
         :param bins: the number of bins in the histogram.  This is passed to
-            numpy.histogram, but needs to produce teh same set of edges for
+            numpy.histogram, but needs to produce the same set of edges for
             each tile.
         :param density: if True, scale the results based on the number of
             samples.
@@ -1216,7 +1216,7 @@ class TileSource(object):
         self._skipStyle = True
         # Divert the tile cache while querying unstyled tiles
         classkey = self._classkey
-        self._classkey = 'nocache' + str(random.random)
+        self._classkey = 'nocache' + str(random.random())
         try:
             self._bandRanges[frame] = self.histogram(
                 dtype=dtype,

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -298,9 +298,8 @@ def testPalettizedGeotiff():
     assert tileMetadata['sizeX'] == 687
     assert tileMetadata['sizeY'] == 509
     assert tileMetadata['levels'] == 3
-    assert (tileMetadata['bounds']['srs'].strip() ==
-            '+proj=aea +lat_0=23 +lon_0=-96 +lat_1=29.5 +lat_2=45.5 +x_0=0 '
-            '+y_0=0 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs')
+    assert tileMetadata['bounds']['srs'].strip().startswith(
+        '+proj=aea +lat_0=23 +lon_0=-96 +lat_1=29.5 +lat_2=45.5 +x_0=0 +y_0=0')
     assert tileMetadata['geospatial']
     assert len(tileMetadata['bands']) == 1
     assert tileMetadata['bands'][1]['interpretation'] == 'palette'


### PR DESCRIPTION
Due to a typo, if multiple styled tiles were requested concurrently, the wrong tile could be obtained from cache.