### PR TITLE
Change the default tile size.

### DIFF
--- a/test/test_source_nd2.py
+++ b/test/test_source_nd2.py
@@ -12,11 +12,11 @@ def testTilesFromND2():
     source = large_image_source_nd2.ND2FileTileSource(imagePath)
     tileMetadata = source.getMetadata()
 
-    assert tileMetadata['tileWidth'] == 256
-    assert tileMetadata['tileHeight'] == 256
+    assert tileMetadata['tileWidth'] == 1024
+    assert tileMetadata['tileHeight'] == 1022
     assert tileMetadata['sizeX'] == 1024
     assert tileMetadata['sizeY'] == 1022
-    assert tileMetadata['levels'] == 3
+    assert tileMetadata['levels'] == 1
     assert tileMetadata['magnification'] == pytest.approx(47, 1)
     assert len(tileMetadata['frames']) == 232
     assert tileMetadata['frames'][201]['Frame'] == 201


### PR DESCRIPTION
All of the example nd2 files that I've seen don't actually store the data in a pyramidal format.  As such, larger tiles are more efficient.