### PR TITLE
Speed up item list annotation counts.

### DIFF
--- a/girder_annotation/girder_large_image_annotation/web_client/views/itemList.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/itemList.js
@@ -12,29 +12,18 @@ import '../stylesheets/itemList.styl';
 wrap(ItemListWidget, 'render', function (render) {
     render.apply(this, _.rest(arguments));
 
-    function addLargeImageAnnotationBadge(item, parent) {
-        restRequest({
-            type: 'GET',
-            url: 'annotation',
-            data: {
-                itemId: item.id,
-                limit: -1
-            },
-            error: null
-        }).done((result, status, jqxhr) => {
-            const numAnnotations = +jqxhr.getResponseHeader('Girder-Total-Count') || 0;
-            const thumbnail = $('a[g-item-cid="' + item.cid + '"] .large_image_thumbnail', parent).first();
+    function addLargeImageAnnotationBadge(item, parent, numAnnotations) {
+        const thumbnail = $('a[g-item-cid="' + item.cid + '"] .large_image_thumbnail', parent).first();
 
-            let badge = thumbnail.find('.large_image_annotation_badge');
-            if (badge.length === 0) {
-                badge = $(`<div class="large_image_annotation_badge"></div>`).appendTo(thumbnail);
-            }
-            // update badge
-            badge
-                .attr('title', `${numAnnotations} annotation${numAnnotations === 1 ? '' : 's'}`)
-                .text(numAnnotations)
-                .toggleClass('hidden', numAnnotations === 0);
-        });
+        let badge = thumbnail.find('.large_image_annotation_badge');
+        if (badge.length === 0) {
+            badge = $(`<div class="large_image_annotation_badge hidden"></div>`).appendTo(thumbnail);
+        }
+        // update badge
+        badge
+            .attr('title', `${numAnnotations} annotation${numAnnotations === 1 ? '' : 's'}`)
+            .text(numAnnotations)
+            .toggleClass('hidden', !numAnnotations);
     }
 
     largeImageAnnotationConfig.getSettings((settings) => {
@@ -50,12 +39,35 @@ wrap(ItemListWidget, 'render', function (render) {
             return;
         }
 
-        _.each(items, (item) => {
-            if (item.get('largeImage')) {
-                item.getAccessLevel(function () {
-                    addLargeImageAnnotationBadge(item, parent);
+        const needCounts = items.filter((item) => item._annotationCount === undefined && item.has('largeImage')).map((item) => {
+            item._annotationCount = null; // pending
+            return item.id;
+        });
+        let promise;
+        if (!needCounts.length) {
+            promise = $.Deferred().resolve({});
+        } else {
+            promise = restRequest({
+                type: 'POST',
+                url: 'annotation/counts',
+                data: {
+                    items: needCounts.join(',')
+                },
+                headers: { 'X-HTTP-Method-Override': 'GET' },
+                error: null
+            }).done((resp) => {
+                Object.entries(resp).forEach(([id, count]) => {
+                    this.collection.get(id)._annotationCount = count;
                 });
-            }
+            });
+        }
+        promise.then(() => {
+            this.collection.forEach((item) => {
+                if (item._annotationCount !== undefined) {
+                    addLargeImageAnnotationBadge(item, parent, item._annotationCount);
+                }
+            });
+            return null;
         });
     });
 });


### PR DESCRIPTION
When we show an item list in Girder with annotations, we show a badge on each thumbnail indicating how many annotations are on that large image.  Before, this made one REST request per call without any sort of throttling, which could effectively block navigation until enough of the calls were resolved.  This gets all needed values in a single REST request.