### PR TITLE
Work around a file descriptor issue in cheroot.

### DIFF
--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -39,6 +39,10 @@ if resource:
         SoftNoFile, HardNoFile = resource.getrlimit(resource.RLIMIT_NOFILE)
         resource.setrlimit(resource.RLIMIT_NOFILE, (HardNoFile, HardNoFile))
         SoftNoFile, HardNoFile = resource.getrlimit(resource.RLIMIT_NOFILE)
+        # When run under cheroot, cheroot can fail if the file descriptor is
+        # greater than 1024 (see github.com/cherrypy/cheroot/issues/249), so
+        # limit this further
+        SoftNoFile = min(SoftNoFile, 1024)
         # Reserve some file handles for general use, and expect that tile
         # sources could use many handles each.  This is conservative, since
         # running out of file handles breaks the program in general.


### PR DESCRIPTION
There is an issue that was introduced in 8.1.0 that throws an error when file descriptor numbers are large (see https://github.com/cherrypy/cheroot/issues/249).  We can't pin cheroot to an older version, as that breaks support for modern python versions.