### PR TITLE
Ensure all packages have python_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
     license='Apache Software License 2.0',
     long_description=readme,
     packages=find_packages(exclude=['test', 'test.*', 'girder']),
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     url='https://github.com/girder/large_image',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     zip_safe=False,
 )

--- a/sources/dummy/setup.py
+++ b/sources/dummy/setup.py
@@ -48,6 +48,7 @@ setup(
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),
     url='https://github.com/girder/large_image',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     entry_points={
         'large_image.source': [
             'dummy = large_image_source_dummy:DummyTileSource'

--- a/sources/gdal/setup.py
+++ b/sources/gdal/setup.py
@@ -54,6 +54,7 @@ setup(
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),
     url='https://github.com/girder/large_image',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     entry_points={
         'large_image.source': [
             'gdal = large_image_source_gdal:GDALFileTileSource'

--- a/sources/mapnik/setup.py
+++ b/sources/mapnik/setup.py
@@ -53,6 +53,7 @@ setup(
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),
     url='https://github.com/girder/large_image',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     entry_points={
         'large_image.source': [
             'mapnik = large_image_source_mapnik:MapnikFileTileSource'

--- a/sources/nd2/setup.py
+++ b/sources/nd2/setup.py
@@ -52,6 +52,7 @@ setup(
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),
     url='https://github.com/girder/large_image',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     entry_points={
         'large_image.source': [
             'nd2 = large_image_source_nd2:ND2FileTileSource'

--- a/sources/ometiff/setup.py
+++ b/sources/ometiff/setup.py
@@ -52,6 +52,7 @@ setup(
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),
     url='https://github.com/girder/large_image',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     entry_points={
         'large_image.source': [
             'ometiff = large_image_source_ometiff:OMETiffFileTileSource'

--- a/sources/openjpeg/setup.py
+++ b/sources/openjpeg/setup.py
@@ -53,6 +53,7 @@ setup(
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),
     url='https://github.com/girder/large_image',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     entry_points={
         'large_image.source': [
             'openjpeg = large_image_source_openjpeg:OpenjpegFileTileSource'

--- a/sources/openslide/setup.py
+++ b/sources/openslide/setup.py
@@ -52,6 +52,7 @@ setup(
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),
     url='https://github.com/girder/large_image',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     entry_points={
         'large_image.source': [
             'openslide = large_image_source_openslide:OpenslideFileTileSource'

--- a/sources/pil/setup.py
+++ b/sources/pil/setup.py
@@ -51,6 +51,7 @@ setup(
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),
     url='https://github.com/girder/large_image',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     entry_points={
         'large_image.source': [
             'pil = large_image_source_pil:PILFileTileSource'

--- a/sources/test/setup.py
+++ b/sources/test/setup.py
@@ -48,6 +48,7 @@ setup(
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),
     url='https://github.com/girder/large_image',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     entry_points={
         'large_image.source': [
             'test = large_image_source_test:TestTileSource'

--- a/sources/tiff/setup.py
+++ b/sources/tiff/setup.py
@@ -52,6 +52,7 @@ setup(
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),
     url='https://github.com/girder/large_image',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     entry_points={
         'large_image.source': [
             'tiff = large_image_source_tiff:TiffFileTileSource'

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -61,6 +61,7 @@ setup(
             'pyvips',
         ]
     },
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     entry_points={
         'girder_worker_plugins': [
             'large_image_tasks = large_image_tasks:LargeImageTasks',


### PR DESCRIPTION
This will be needed when support of specific python versions is dropped.