### PR TITLE
Show additional associated image for some openslides.

### DIFF
--- a/sources/openslide/setup.py
+++ b/sources/openslide/setup.py
@@ -44,6 +44,7 @@ setup(
     install_requires=[
         'large-image>=1.0.0',
         'openslide-python>=1.1.0',
+        'tifftools;python_version>="3.6"',
     ],
     extras_require={
         'girder': 'girder-large-image>=1.0.0',


### PR DESCRIPTION
Openslide only exposes associated images from Aperio if they have an ImageDescription with their name.  For Python>3.6, if you also have appropriate tiff libraries installed (for instance, from the tiff tile source), this will expose label and macro images based on other indicators.

For Hamamatsu files, only the macro image is exposed.  There is another image that can be present, but this is the non-empty region map.