### PR TITLE
Improve annotation conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Improvements
 - Reduce caching associated images when the parent item changes (#491)
 - Test with Python 3.9 (#493)
+- Add a hideAnnotation function in the client (#490)
+
+### Changes
+- Include the annotationType to the annotation conversion method in the client (#490)
 
 ## Version 1.3.1
 

--- a/girder_annotation/girder_large_image_annotation/web_client/annotations/convert.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/annotations/convert.js
@@ -11,11 +11,12 @@ function convertOne(properties) {
         if (!_.has(geometry, type)) {
             return;
         }
+        const geom = geometry[type](annotation);
         return {
             type: 'Feature',
             id: annotation.id,
-            geometry: geometry[type](annotation),
-            properties: _.extend({element: annotation}, properties, style(annotation))
+            geometry: { type: geom.type, coordinates: geom.coordinates },
+            properties: _.extend({element: annotation, annotationType: geom.annotationType}, properties, style(annotation))
         };
     };
 }

--- a/girder_annotation/girder_large_image_annotation/web_client/annotations/convert.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/annotations/convert.js
@@ -5,7 +5,10 @@ import * as defaults from './defaults';
 import style from './style';
 
 function convertOne(properties) {
-    return function (annotation) {
+    return function (annotation, key) {
+        if (('' + key).startsWith('_')) {
+            return;
+        }
         const type = annotation.type;
         annotation = _.defaults({}, annotation, defaults[type] || {});
         if (!_.has(geometry, type)) {
@@ -23,7 +26,7 @@ function convertOne(properties) {
 
 export default function convert(json, properties = {}) {
     const features = _.chain(json)
-        .map(convertOne(properties))
+        .mapObject(convertOne(properties))
         .compact()
         .value();
 

--- a/girder_annotation/girder_large_image_annotation/web_client/annotations/geometry/point.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/annotations/geometry/point.js
@@ -3,6 +3,7 @@ import _ from 'underscore';
 export default function point(json) {
     return {
         type: 'Point',
-        coordinates: _.first(json.center, 2)
+        coordinates: _.first(json.center, 2),
+        annotationType: 'point'
     };
 }

--- a/girder_annotation/girder_large_image_annotation/web_client/annotations/geometry/polyline.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/annotations/geometry/polyline.js
@@ -4,18 +4,22 @@ export default function polyline(json) {
     const points = _.map(json.points, (p) => _.first(p, 2));
     var type;
     var coordinates;
+    var annotationType;
 
     if (json.closed) {
         type = 'Polygon';
         points.push(points[0]);
         coordinates = [points];
+        annotationType = 'polygon';
     } else {
         type = 'LineString';
         coordinates = points;
+        annotationType = 'line';
     }
 
     return {
         type,
-        coordinates
+        coordinates,
+        annotationType
     };
 }

--- a/girder_annotation/girder_large_image_annotation/web_client/annotations/geometry/rectangle.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/annotations/geometry/rectangle.js
@@ -23,6 +23,7 @@ export default function rectangle(json) {
             [right, bottom],
             [left, bottom],
             [left, top]
-        ], rotate(rotation, center))]
+        ], rotate(rotation, center))],
+        annotationType: 'rectangle'
     };
 }

--- a/girder_annotation/test_annotation/web_client_specs/annotationSpec.js
+++ b/girder_annotation/test_annotation/web_client_specs/annotationSpec.js
@@ -51,6 +51,7 @@ describe('Annotations', function () {
 
             expect(obj.type).toBe('Polygon');
             expect(obj.coordinates.length).toBe(1);
+            expect(obj.annotationType).toBe('rectangle');
             expectClose(
                 obj.coordinates[0], [
                     [7.5, 15], [12.5, 15], [12.5, 25], [7.5, 25], [7.5, 15]
@@ -68,6 +69,7 @@ describe('Annotations', function () {
 
             expect(obj.type).toBe('Polygon');
             expect(obj.coordinates.length).toBe(1);
+            expect(obj.annotationType).toBe('rectangle');
             expectClose(
                 obj.coordinates[0], [
                     [10, 9], [11, 10], [10, 11], [9, 10], [10, 9]
@@ -88,6 +90,7 @@ describe('Annotations', function () {
 
             expect(obj.type).toBe('LineString');
             expect(obj.coordinates.length).toBe(2);
+            expect(obj.annotationType).toBe('line');
             expectClose(
                 obj.coordinates, [
                     [0, 1], [1, 0]
@@ -110,6 +113,7 @@ describe('Annotations', function () {
             expect(obj.type).toBe('Polygon');
             expect(obj.coordinates.length).toBe(1);
             expect(obj.coordinates[0].length).toBe(4);
+            expect(obj.annotationType).toBe('polygon');
             expectClose(
                 obj.coordinates[0], [
                     [0, 1], [1, 0], [1, 1], [0, 1]
@@ -124,6 +128,7 @@ describe('Annotations', function () {
                 center: [1, 2, 0]
             });
             expect(obj.type).toBe('Point');
+            expect(obj.annotationType).toBe('point');
             expect(obj.coordinates).toEqual([1, 2]);
         });
     });

--- a/girder_annotation/test_annotation/web_client_specs/geojsAnnotationSpec.js
+++ b/girder_annotation/test_annotation/web_client_specs/geojsAnnotationSpec.js
@@ -4,7 +4,7 @@
 girderTest.importPlugin('large_image', 'large_image_annotation');
 
 describe('geojs-annotations', function () {
-    var large_image_annotation, geojs;
+    var large_image_annotation, geojs, convert;
     var fillColor = 'rgba(0,0,0,0)';
     var lineColor = 'rgb(0,0,0)';
     var lineWidth = 2;
@@ -12,9 +12,10 @@ describe('geojs-annotations', function () {
     beforeEach(function () {
         large_image_annotation = girder.plugins.large_image_annotation;
         geojs = large_image_annotation.annotations.geojs;
+        convert = large_image_annotation.annotations.convert;
     });
 
-    it('convert', function () {
+    it('convert from', function () {
         var type;
         var coordinates;
 
@@ -42,6 +43,20 @@ describe('geojs-annotations', function () {
             lineColor: lineColor,
             lineWidth: lineWidth
         });
+    });
+
+    it('convert to', function () {
+        var result;
+
+        result = convert({attributes: {type: 'point', center: [0, 0, 0]}});
+        expect(result.type).toBe('FeatureCollection');
+        expect(result.features.length).toBe(1);
+        result = convert({attributes: {type: 'point', center: [0, 0, 0]}, attributes2: {type: 'point', center: [0, 0, 0]}});
+        expect(result.type).toBe('FeatureCollection');
+        expect(result.features.length).toBe(2);
+        result = convert({attributes: {type: 'point', center: [0, 0, 0]}, _attributes: {type: 'point', center: [0, 0, 0]}});
+        expect(result.type).toBe('FeatureCollection');
+        expect(result.features.length).toBe(1);
     });
 
     describe('coordinates', function () {

--- a/girder_annotation/test_annotation/web_client_specs/geojsSpec.js
+++ b/girder_annotation/test_annotation/web_client_specs/geojsSpec.js
@@ -580,7 +580,7 @@ $(function () {
             });
         });
 
-        describe('highlight annotations', function () {
+        describe('highlight and hide annotations', function () {
             var annotation1, annotation2;
             var element11 = '111111111111111111111111';
             var element12 = '222222222222222222222222';
@@ -691,6 +691,25 @@ $(function () {
 
             it('reset opacities', function () {
                 viewer.highlightAnnotation();
+
+                checkFeatureOpacity(annotation1.id, 0.5, 1);
+                checkFeatureOpacity(annotation2.id, 0.5, 1);
+            });
+
+            it('hide an element', function () {
+                viewer.hideAnnotation(annotation2.id, element21);
+
+                checkFeatureOpacity(annotation1.id, 0.5, 1);
+                checkFeatureOpacity(annotation2.id, 0.5, 1, function (data) {
+                    return data.id !== element21;
+                });
+                checkFeatureOpacity(annotation2.id, 0, 0, function (data) {
+                    return data.id === element21;
+                });
+            });
+
+            it('reset opacities', function () {
+                viewer.hideAnnotation();
 
                 checkFeatureOpacity(annotation1.id, 0.5, 1);
                 checkFeatureOpacity(annotation2.id, 0.5, 1);


### PR DESCRIPTION
This adds the annotationType to the result so it can be directly passed to the annotation layer's geojson method.

Add hideAnnotation function.  This hides a single annotation efficiently.  It useful when editing annotations.