### PR TITLE
Run pytest in forked mode in Circle-ci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
           name: Run tests via tox
           # Piping through cat does less buffering of the output but can
           # consume the exit code
-          command: tox -e << parameters.env >> | cat; test ${PIPESTATUS[0]} -eq 0
+          command: PYTEST_ADDOPTS=--forked tox -e << parameters.env >> | cat; test ${PIPESTATUS[0]} -eq 0
   coverage:
     description: "Upload coverage"
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ python =
   3.8: py38
 
 [testenv]
+passenv = PYTEST_*
 install_command = pip install --upgrade --upgrade-strategy eager --find-links https://girder.github.io/large_image_wheels {opts} .[memcached] {packages}
 deps =
   -rrequirements-dev.txt


### PR DESCRIPTION
This might reduce the memory footprint in Circle-CI.