### PR TITLE
Reduce severity of bioformats warnings.

### DIFF
--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -114,7 +114,7 @@ class BioformatsFileTileSource(FileTileSource):
     _tileSize = 512
     _associatedImageMaxSize = 8192
 
-    def __init__(self, path, **kwargs):
+    def __init__(self, path, **kwargs):  # noqa
         """
         Initialize the tile class.  See the base class for other available
         parameters.
@@ -145,7 +145,11 @@ class BioformatsFileTileSource(FileTileSource):
 
         try:
             javabridge.attach()
-            self._bioimage = bioformats.ImageReader(largeImagePath)
+            try:
+                self._bioimage = bioformats.ImageReader(largeImagePath)
+            except AttributeError as exc:
+                self._logger.debug('File cannot be opened via Bioformats. (%r)' % exc)
+                raise TileSourceException('File cannot be opened via Bioformats. (%r)' % exc)
 
             rdr = self._bioimage.rdr
             # Bind additional functions not done by bioformats module.

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ python =
 
 [testenv]
 passenv = PYTEST_*
-install_command = pip install --upgrade --upgrade-strategy eager --find-links https://girder.github.io/large_image_wheels {opts} .[memcached] {packages}
+install_command = pip install --find-links https://girder.github.io/large_image_wheels {opts} {packages}
 deps =
   -rrequirements-dev.txt
   coverage
@@ -31,6 +31,8 @@ deps =
   pytest-xdist
   celery!=4.4.4,<5
   urllib3<1.26
+extras =
+  memcached
 # celery 4.4.4 is broken; avoid it until a new version is released
 whitelist_externals =
   rm


### PR DESCRIPTION
If a file cannot be read by bioformats, only log to debug level.