### PR TITLE
Better release bioformats resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Improvements
+- Better release bioformats resources (#502)
+
 ## Version 1.3.2
 
 ### Improvements


### PR DESCRIPTION
Before this change, from the repl, issuing commands like:
```
import large_image
ts = large_image.getTileSource('/some/bioformats/file')
```
and then exiting would hang because the local reference to the tile source would still contain a reference to the unclosed bioformats resource.