### PR TITLE
Harden updating the item view after making a large image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Better release bioformats resources (#502)
 - Better handling of tiff files with JPEG compression and RGB colorspace (#503)
 
+### Bug Fixes
+- Harden updates of the item view after making a large image
+
 ## Version 1.3.2
 
 ### Improvements
@@ -144,10 +147,10 @@
 
 ## Version 1.0.0
 
-This is a substantial refactor from preliminary versions.  Now that setuptools_scm is used for versioning, all merges to master are automatically published to pypi as development versions.  
+This is a substantial refactor from preliminary versions.  Now that setuptools_scm is used for versioning, all merges to master are automatically published to pypi as development versions.
 
 Tile sources are now fully modular and are installed via pip.  File extensions and mime type are now used as part of the order that tile sources are checked, giving more control over which tile source is used by default.
 
-The Girder plugin has been divided into the parts requiring annotations and the parts that are only necessary for large images.  
+The Girder plugin has been divided into the parts requiring annotations and the parts that are only necessary for large images.
 
 Python 3.4 support was dropped.

--- a/girder/girder_large_image/web_client/views/imageViewerSelectWidget.js
+++ b/girder/girder_large_image/web_client/views/imageViewerSelectWidget.js
@@ -139,6 +139,7 @@ var ImageViewerSelectWidget = View.extend({
 
 wrap(ItemView, 'initialize', function (initialize) {
     this.listenTo(eventStream, 'g:event.large_image.finished_image_item', () => {
+        this.model.unset('largeImage');
         this.model.fetch();
     });
     initialize.apply(this, _.rest(arguments));

--- a/girder/test_girder/web_client_specs/imageViewerSpec.js
+++ b/girder/test_girder/web_client_specs/imageViewerSpec.js
@@ -77,6 +77,9 @@ $(function () {
             girderTest.waitForLoad();
         });
         it('remake a large image and then remove the image file', function () {
+            waitsFor(function () {
+                return $('.g-large-image-create').length > 0;
+            }, 'make large image button to appear');
             runs(function () {
                 $('.g-large-image-create').click();
             });
@@ -111,6 +114,9 @@ $(function () {
             girderTest.waitForLoad();
         });
         it('navigate to item and make a large image', function () {
+            waitsFor(function () {
+                return $('a.g-item-list-link').length > 0;
+            }, 'link to appear');
             runs(function () {
                 $('a.g-item-list-link').click();
             });
@@ -124,7 +130,7 @@ $(function () {
             girderTest.waitForLoad();
             // wait for job to complete
             waitsFor(function () {
-                return $('.g-item-image-viewer-select').length !== 0;
+                return $('.g-item-image-viewer-select').length > 0 && $('.g-large-image-remove').length > 0;
             }, 15000);
             girderTest.waitForLoad();
         });


### PR DESCRIPTION
This is one of the causes of transient test failures, but shows a user interface bug.  Occasionally, when making a large image that requires converting via a job, the page would update after the job completed but before the image was marked as updated.  This would result in the page refreshing and still showing that the job was pending.

This substantially reduces transient test failures in one test environment.