### PR TITLE
Store the large image path to avoid rerequesting it.

### DIFF
--- a/sources/ometiff/large_image_source_ometiff/__init__.py
+++ b/sources/ometiff/large_image_source_ometiff/__init__.py
@@ -92,6 +92,7 @@ class OMETiffFileTileSource(TiffFileTileSource):
         super(TiffFileTileSource, self).__init__(path, **kwargs)
 
         largeImagePath = self._getLargeImagePath()
+        self._largeImagePath = largeImagePath
 
         try:
             base = TiledTiffDirectory(largeImagePath, 0, mustBeTiled=None)

--- a/sources/openslide/large_image_source_openslide/__init__.py
+++ b/sources/openslide/large_image_source_openslide/__init__.py
@@ -157,6 +157,7 @@ class OpenslideFileTileSource(FileTileSource):
                 'svslevel': bestlevel,
                 'scale': scale
             })
+        self._largeImagePath = largeImagePath
 
     def _getTileSize(self):
         """
@@ -371,7 +372,7 @@ class OpenslideFileTileSource(FileTileSource):
                 return self._openslide.associated_images[imageKey]
             except openslide.lowlevel.OpenSlideError:
                 return None
-        bytePath = self._getLargeImagePath()
+        bytePath = self._largeImagePath
         if not isinstance(bytePath, six.binary_type):
             bytePath = bytePath.encode('utf8')
         _tiffFile = libtiff_ctypes.TIFF.open(bytePath)

--- a/sources/tiff/large_image_source_tiff/__init__.py
+++ b/sources/tiff/large_image_source_tiff/__init__.py
@@ -83,6 +83,7 @@ class TiffFileTileSource(FileTileSource):
         super(TiffFileTileSource, self).__init__(path, **kwargs)
 
         largeImagePath = self._getLargeImagePath()
+        self._largeImagePath = largeImagePath
         try:
             alldir = self._scanDirectories()
         except (ValidationTiffException, TiffException) as exc:
@@ -134,7 +135,7 @@ class TiffFileTileSource(FileTileSource):
         self.sizeY = highest.imageHeight
 
     def _scanDirectories(self):
-        largeImagePath = self._getLargeImagePath()
+        largeImagePath = self._largeImagePath
         lastException = None
         # Associated images are smallish TIFF images that have an image
         # description and are not tiled.  They have their own TIFF directory.
@@ -382,7 +383,7 @@ class TiffFileTileSource(FileTileSource):
                 self._directoryCache = {}
             try:
                 result = TiledTiffDirectory(
-                    self._getLargeImagePath(), dirnum, mustBeTiled=None, subDirectoryNum=subdir)
+                    self._largeImagePath, dirnum, mustBeTiled=None, subDirectoryNum=subdir)
             except IOTiffException:
                 result = None
             self._directoryCache[key] = result


### PR DESCRIPTION
This should very slightly reduce database access in Girder.