### PR TITLE
Harden updating after making a large image

### DIFF
--- a/girder/girder_large_image/__init__.py
+++ b/girder/girder_large_image/__init__.py
@@ -104,6 +104,8 @@ def _updateJob(event):
         # don't clear the expected status on success.
         if status != JobStatus.SUCCESS:
             del item['largeImage']['expected']
+        else:
+            return
     notify = item.get('largeImage', {}).get('notify')
     msg = None
     if notify:


### PR DESCRIPTION
There was a condition where the image conversion job sent a completion message before the upload was finalized.