### PR TITLE
Convert from large_image sources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Features
 - Added a `canRead` method to the core module (#512)
 - Image conversion supports JPEG 2000 (jp2k) compression (#522)
+- Image conversion can now convert images readable by large_image sources but not by vips (#529)
 
 ### Improvements
 - Better release bioformats resources (#502)

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -151,7 +151,15 @@ def testConvertJp2kCompression(tmpdir):
     large_image_converter.convert(imagePath, outputPath3, compression='jp2k', cr=100)
     assert os.path.getsize(outputPath3) < os.path.getsize(outputPath)
     assert os.path.getsize(outputPath3) != os.path.getsize(outputPath2)
-    # ##DWM::
+
+
+def testConvertFromLargeImage(tmpdir):
+    imagePath = utilities.externaldata('data/sample_image.jp2.sha512')
+    outputPath = os.path.join(tmpdir, 'out.tiff')
+    large_image_converter.convert(imagePath, outputPath)
+    source = large_image_source_tiff.TiffFileTileSource(outputPath)
+    metadata = source.getMetadata()
+    assert metadata['levels'] == 6
 
 
 def testConverterMain(tmpdir):


### PR DESCRIPTION
Allow conversion from files that can be read by large image but not by vips.  This permits reencoding inefficient files to a preferred format.