### PR TITLE
Reduce warnings.

### DIFF
--- a/girder/test_girder/conftest.py
+++ b/girder/test_girder/conftest.py
@@ -29,10 +29,12 @@ def unavailableWorker(db):
 @pytest.fixture(scope='session')
 def girderWorkerProcess():
     broker = 'amqp://guest@127.0.0.1'
+    backend = 'rpc://guest@127.0.0.1'
     env = os.environ.copy()
     env['C_FORCE_ROOT'] = 'true'
     proc = subprocess.Popen([
-        'celery', '-A', 'girder_worker.app', 'worker', '--broker', broker, '--concurrency=1'],
+        'celery', '-A', 'girder_worker.app', 'worker', '--broker', broker,
+        '--result-backend', backend, '--concurrency=1'],
         close_fds=True, env=env)
     yield True
     proc.terminate()
@@ -46,8 +48,9 @@ def girderWorker(db, girderWorkerProcess):
     service must be running.
     """
     broker = 'amqp://guest@127.0.0.1'
+    backend = 'rpc://guest@127.0.0.1'
     Setting().set(WorkerSettings.BROKER, broker)
-    Setting().set(WorkerSettings.BACKEND, broker)
+    Setting().set(WorkerSettings.BACKEND, backend)
     yield True
     Setting().unset(WorkerSettings.BROKER)
     Setting().unset(WorkerSettings.BACKEND)

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ exclude =
 ignore = D100,D101,D102,D103,D104,D105,D106,D107,D200,D205,D400,D401,E741,W504
 
 [tool:pytest]
-addopts = --verbose --strict --showlocals --cov-report="term" --cov-report="xml" --cov
+addopts = --verbose --strict-markers --showlocals --cov-report="term" --cov-report="xml" --cov
 cache_dir = build/pytest_cache
 testpaths = test girder/test_girder girder_annotation/test_annotation
 

--- a/test/test_source_bioformats.py
+++ b/test/test_source_bioformats.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-import sys
 
 from large_image.cache_util import cachesClear
 
 from . import utilities
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason='only python >=3.5')
 def testTilesFromBioformats():
     import large_image_source_bioformats
 
@@ -28,7 +26,6 @@ def testTilesFromBioformats():
     cachesClear()
 
 
-@pytest.mark.skipif(sys.version_info < (3, 5), reason='only python >=3.5')
 def testInternalMetadata():
     import large_image_source_bioformats
 

--- a/test/test_source_pil.py
+++ b/test/test_source_pil.py
@@ -6,10 +6,15 @@ import re
 from large_image import config
 import large_image_source_pil
 
+from large_image.cache_util import cachesClear
+
 from . import utilities
 
 
 def testTilesFromPIL():
+    # Ensure this test can run in any order
+    cachesClear()
+
     imagePath = utilities.externaldata('data/sample_Easy1.png.sha512')
     # Test with different max size options.
     config.setConfig('max_small_image_size', 100)

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,7 @@ setenv =
   NPM_CONFIG_LOGLEVEL=warn
   NPM_CONFIG_PROGRESS=false
   NPM_CONFIG_PREFER_OFFLINE=true
+  GDAL_PAM_ENABLED=no
 
 [testenv:flake8]
 skipsdist = true


### PR DESCRIPTION
This reduces warnings on

- celery backend

- pytest strict mode

- pyproj transform

This also hardens test order to some degree.  Ideally, we could run tests in a random order, but when that is done, sometimes java doesn't stop and restart as cleanly as it should.

Also, stop writing GDAL PAM (aux.xml) files when running tox.