### PR TITLE
Add an open method to each source module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Added a `canRead` method to the core module (#512)
 - Image conversion supports JPEG 2000 (jp2k) compression (#522)
 - Image conversion can now convert images readable by large_image sources but not by vips (#529)
+- Added an `open` method to the core module as an alias to `getTileSource` (#550)
+- Added an `open` method to each file source module (#550)
+- Numerous improvement to image converversion (#533, #535, #537, #541, #544, #545, #546, #549)
 
 ### Improvements
 - Better release bioformats resources (#502)
@@ -16,10 +19,13 @@
 - The openjpeg tile source can decode with parallelism (#511)
 - Geospatial tile sources are preferred for geospatial files (#512)
 - Support decoding JP2k compressed tiles in the tiff tile source (#514)
+- Hardened tests against transient timing issues (#532, #536)
 
 ### Bug Fixes
 - Harden updates of the item view after making a large image (#508, #515)
 - Tiles in an unexpected color mode weren't consistently adjusted (#510)
+- Harden trying to add an annotation before the viewer is ready (#547)
+- Correctly report the tile size after resampling in the tileIterator (#538)
 
 ## Version 1.3.2
 

--- a/large_image/__init__.py
+++ b/large_image/__init__.py
@@ -17,7 +17,7 @@
 from pkg_resources import DistributionNotFound, get_distribution
 
 from . import tilesource  # noqa
-from .tilesource import canRead, getTileSource  # noqa
+from .tilesource import canRead, getTileSource, open  # noqa
 
 
 try:

--- a/large_image/tilesource/__init__.py
+++ b/large_image/tilesource/__init__.py
@@ -123,6 +123,18 @@ def getTileSource(*args, **kwargs):
     return getTileSourceFromDict(AvailableTileSources, *args, **kwargs)
 
 
+def open(*args, **kwargs):
+    """
+    Alternate name of getTileSource.
+
+    Get a tilesource using the known sources.  If tile sources have not yet
+    been loaded, load them.
+
+    :returns: A tilesource for the passed arguments.
+    """
+    return getTileSource(*args, **kwargs)
+
+
 def canRead(*args, **kwargs):
     """
     Check if large_image can read a path or uri.

--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -538,3 +538,17 @@ class BioformatsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 if javabridge.get_env():
                     javabridge.detach()
         return large_image.tilesource.base._imageToPIL(image)
+
+
+def open(*args, **kwargs):
+    """
+    Create an instance of the module class.
+    """
+    return BioformatsFileTileSource(*args, **kwargs)
+
+
+def canRead(*args, **kwargs):
+    """
+    Check if an input can be read by the module class.
+    """
+    return BioformatsFileTileSource.canRead(*args, **kwargs)

--- a/sources/dummy/large_image_source_dummy/__init__.py
+++ b/sources/dummy/large_image_source_dummy/__init__.py
@@ -47,3 +47,17 @@ class DummyTileSource(TileSource):
 
     def getTile(self, x, y, z, **kwargs):
         return b''
+
+
+def open(*args, **kwargs):
+    """
+    Create an instance of the module class.
+    """
+    return DummyTileSource(*args, **kwargs)
+
+
+def canRead(*args, **kwargs):
+    """
+    Check if an input can be read by the module class.
+    """
+    return DummyTileSource.canRead(*args, **kwargs)

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -940,3 +940,17 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                         except RuntimeError:
                             pass
         return pixel
+
+
+def open(*args, **kwargs):
+    """
+    Create an instance of the module class.
+    """
+    return GDALFileTileSource(*args, **kwargs)
+
+
+def canRead(*args, **kwargs):
+    """
+    Check if an input can be read by the module class.
+    """
+    return GDALFileTileSource.canRead(*args, **kwargs)

--- a/sources/mapnik/large_image_source_mapnik/__init__.py
+++ b/sources/mapnik/large_image_source_mapnik/__init__.py
@@ -414,3 +414,17 @@ class MapnikFileTileSource(GDALFileTileSource, metaclass=LruCacheMetaclass):
         if overscan:
             pilimg = pilimg.crop((1, 1, pilimg.width - overscan, pilimg.height - overscan))
         return self._outputTile(pilimg, TILE_FORMAT_PIL, x, y, z, applyStyle=False, **kwargs)
+
+
+def open(*args, **kwargs):
+    """
+    Create an instance of the module class.
+    """
+    return MapnikFileTileSource(*args, **kwargs)
+
+
+def canRead(*args, **kwargs):
+    """
+    Check if an input can be read by the module class.
+    """
+    return MapnikFileTileSource.canRead(*args, **kwargs)

--- a/sources/nd2/large_image_source_nd2/__init__.py
+++ b/sources/nd2/large_image_source_nd2/__init__.py
@@ -318,3 +318,17 @@ class ND2FileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             tile = tileframe[y0:y1:step, x0:x1:step].copy()
         return self._outputTile(tile, TILE_FORMAT_NUMPY, x, y, z,
                                 pilImageAllowed, numpyAllowed, **kwargs)
+
+
+def open(*args, **kwargs):
+    """
+    Create an instance of the module class.
+    """
+    return ND2FileTileSource(*args, **kwargs)
+
+
+def canRead(*args, **kwargs):
+    """
+    Check if an input can be read by the module class.
+    """
+    return ND2FileTileSource.canRead(*args, **kwargs)

--- a/sources/ometiff/large_image_source_ometiff/__init__.py
+++ b/sources/ometiff/large_image_source_ometiff/__init__.py
@@ -353,3 +353,17 @@ class OMETiffFileTileSource(TiffFileTileSource, metaclass=LruCacheMetaclass):
         while level - baselevel > self._maxSkippedLevels:
             level -= self._maxSkippedLevels
         return level
+
+
+def open(*args, **kwargs):
+    """
+    Create an instance of the module class.
+    """
+    return OMETiffFileTileSource(*args, **kwargs)
+
+
+def canRead(*args, **kwargs):
+    """
+    Check if an input can be read by the module class.
+    """
+    return OMETiffFileTileSource.canRead(*args, **kwargs)

--- a/sources/openjpeg/large_image_source_openjpeg/__init__.py
+++ b/sources/openjpeg/large_image_source_openjpeg/__init__.py
@@ -14,6 +14,7 @@
 #  limitations under the License.
 ##############################################################################
 
+import builtins
 import glymur
 import io
 import math
@@ -203,7 +204,7 @@ class OpenjpegFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         if box.length > 16 * 1024 * 1024:
             return
         try:
-            fp = open(self._largeImagePath, 'rb')
+            fp = builtins.open(self._largeImagePath, 'rb')
             headerLength = 16
             fp.seek(box.offset + headerLength)
             data = fp.read(box.length - headerLength)
@@ -255,3 +256,17 @@ class OpenjpegFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             tile = tile[::scale, ::scale]
         return self._outputTile(tile, TILE_FORMAT_NUMPY, x, y, z,
                                 pilImageAllowed, numpyAllowed, **kwargs)
+
+
+def open(*args, **kwargs):
+    """
+    Create an instance of the module class.
+    """
+    return OpenjpegFileTileSource(*args, **kwargs)
+
+
+def canRead(*args, **kwargs):
+    """
+    Check if an input can be read by the module class.
+    """
+    return OpenjpegFileTileSource.canRead(*args, **kwargs)

--- a/sources/openslide/large_image_source_openslide/__init__.py
+++ b/sources/openslide/large_image_source_openslide/__init__.py
@@ -370,3 +370,17 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         _tiffFile.SetDirectory(images[imageKey])
         img = _tiffFile.read_image()
         return PIL.Image.fromarray(img)
+
+
+def open(*args, **kwargs):
+    """
+    Create an instance of the module class.
+    """
+    return OpenslideFileTileSource(*args, **kwargs)
+
+
+def canRead(*args, **kwargs):
+    """
+    Check if an input can be read by the module class.
+    """
+    return OpenslideFileTileSource.canRead(*args, **kwargs)

--- a/sources/pil/large_image_source_pil/__init__.py
+++ b/sources/pil/large_image_source_pil/__init__.py
@@ -170,3 +170,17 @@ class PILFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             raise TileSourceException('y is outside layer')
         return self._outputTile(self._pilImage, TILE_FORMAT_PIL, x, y, z,
                                 pilImageAllowed, numpyAllowed, **kwargs)
+
+
+def open(*args, **kwargs):
+    """
+    Create an instance of the module class.
+    """
+    return PILFileTileSource(*args, **kwargs)
+
+
+def canRead(*args, **kwargs):
+    """
+    Check if an input can be read by the module class.
+    """
+    return PILFileTileSource.canRead(*args, **kwargs)

--- a/sources/test/large_image_source_test/__init__.py
+++ b/sources/test/large_image_source_test/__init__.py
@@ -178,3 +178,17 @@ class TestTileSource(TileSource, metaclass=LruCacheMetaclass):
         return 'test %r %r %r %r %r %r' % (
             super().getState(), self.minLevel,
             self.maxLevel, self.tileWidth, self.tileHeight, self.fractal)
+
+
+def open(*args, **kwargs):
+    """
+    Create an instance of the module class.
+    """
+    return TestTileSource(*args, **kwargs)
+
+
+def canRead(*args, **kwargs):
+    """
+    Check if an input can be read by the module class.
+    """
+    return TestTileSource.canRead(*args, **kwargs)

--- a/sources/tiff/large_image_source_tiff/__init__.py
+++ b/sources/tiff/large_image_source_tiff/__init__.py
@@ -647,3 +647,17 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         if imageKey in self._associatedImages:
             return PIL.Image.fromarray(self._associatedImages[imageKey])
         return None
+
+
+def open(*args, **kwargs):
+    """
+    Create an instance of the module class.
+    """
+    return TiffFileTileSource(*args, **kwargs)
+
+
+def canRead(*args, **kwargs):
+    """
+    Check if an input can be read by the module class.
+    """
+    return TiffFileTileSource.canRead(*args, **kwargs)

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -141,7 +141,7 @@ def testConvertJp2kCompression(tmpdir):
     info = tifftools.read_tiff(outputPath)
     assert (info['ifds'][0]['tags'][tifftools.Tag.Compression.value]['data'][0] ==
             tifftools.constants.Compression.JP2000.value)
-    source = large_image_source_tiff.TiffFileTileSource(outputPath)
+    source = large_image_source_tiff.open(outputPath)
     image, _ = source.getRegion(
         output={'maxWidth': 200, 'maxHeight': 200}, format=constants.TILE_FORMAT_NUMPY)
     assert (image[12][167] == [215, 135, 172]).all()
@@ -160,7 +160,7 @@ def testConvertFromLargeImage(tmpdir):
     imagePath = utilities.externaldata('data/sample_image.jp2.sha512')
     outputPath = os.path.join(tmpdir, 'out.tiff')
     large_image_converter.convert(imagePath, outputPath)
-    source = large_image_source_tiff.TiffFileTileSource(outputPath)
+    source = large_image_source_tiff.open(outputPath)
     metadata = source.getMetadata()
     assert metadata['levels'] == 6
 
@@ -169,7 +169,7 @@ def testConvertFromMultiframeImage(tmpdir):
     imagePath = utilities.externaldata('data/sample.ome.tif.sha512')
     outputPath = os.path.join(tmpdir, 'out.tiff')
     large_image_converter.convert(imagePath, outputPath)
-    source = large_image_source_tiff.TiffFileTileSource(outputPath)
+    source = large_image_source_tiff.open(outputPath)
     metadata = source.getMetadata()
     assert metadata['levels'] == 5
     assert len(metadata['frames']) == 3
@@ -181,7 +181,7 @@ def testConvertFromMultiframeImageNoSubIFDS(tmpdir):
     imagePath = utilities.externaldata('data/sample.ome.tif.sha512')
     outputPath = os.path.join(tmpdir, 'out.tiff')
     large_image_converter.convert(imagePath, outputPath, subifds=False)
-    source = large_image_source_tiff.TiffFileTileSource(outputPath)
+    source = large_image_source_tiff.open(outputPath)
     metadata = source.getMetadata()
     assert metadata['levels'] == 5
     assert len(metadata['frames']) == 3

--- a/test/test_source_bioformats.py
+++ b/test/test_source_bioformats.py
@@ -9,7 +9,7 @@ def testTilesFromBioformats():
     import large_image_source_bioformats
 
     imagePath = utilities.externaldata('data/HENormalN801.czi.sha512')
-    source = large_image_source_bioformats.BioformatsFileTileSource(imagePath)
+    source = large_image_source_bioformats.open(imagePath)
     tileMetadata = source.getMetadata()
 
     assert tileMetadata['tileWidth'] == 1024
@@ -28,7 +28,7 @@ def testInternalMetadata():
     import large_image_source_bioformats
 
     imagePath = utilities.externaldata('data/HENormalN801.czi.sha512')
-    source = large_image_source_bioformats.BioformatsFileTileSource(imagePath)
+    source = large_image_source_bioformats.open(imagePath)
     metadata = source.getInternalMetadata()
     assert 'sizeColorPlanes' in metadata
 

--- a/test/test_source_dummy.py
+++ b/test/test_source_dummy.py
@@ -1,9 +1,9 @@
-from large_image import getTileSource
+import large_image
 import large_image_source_dummy
 
 
 def testDummyTileSource():
-    source = large_image_source_dummy.DummyTileSource()
+    source = large_image_source_dummy.open()
     tileMetadata = source.getMetadata()
     assert tileMetadata['tileWidth'] == 0
     assert tileMetadata['tileHeight'] == 0
@@ -17,5 +17,5 @@ def testDummyTileSource():
 
 
 def testGetDummyTileSource():
-    source = getTileSource('large_image://dummy')
+    source = large_image.open('large_image://dummy')
     assert isinstance(source, large_image_source_dummy.DummyTileSource)

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -47,7 +47,7 @@ def _assertImageMatches(image, testRootName, saveTestImageFailurePath='/tmp'):
 def testTileFromGeotiffs():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
-    source = large_image_source_gdal.GDALFileTileSource(imagePath)
+    source = large_image_source_gdal.open(imagePath)
     tileMetadata = source.getMetadata()
 
     assert tileMetadata['tileWidth'] == 256
@@ -69,7 +69,7 @@ def testTileFromGeotiffs():
     assert tileMetadata['bands'][2]['min'] == 0.0
 
     # Getting the metadata with a specified projection will be different
-    source = large_image_source_gdal.GDALFileTileSource(
+    source = large_image_source_gdal.open(
         imagePath, projection='EPSG:3857')
     tileMetadata = source.getMetadata()
 
@@ -85,7 +85,7 @@ def testTileFromGeotiffs():
     assert tileMetadata['bounds']['srs'] == '+init=epsg:3857'
     assert tileMetadata['geospatial']
 
-    source = large_image_source_gdal.GDALFileTileSource(
+    source = large_image_source_gdal.open(
         imagePath, projection='EPSG:3857', style=json.dumps({'band': -1}), encoding='PNG')
     image = source.getTile(89, 207, 9)
     _assertImageMatches(image, 'geotiff_9_89_207')
@@ -97,7 +97,7 @@ def testTileLinearStyleFromGeotiffs():
     style = json.dumps({'band': 1, 'min': 0, 'max': 100,
                         'palette': 'matplotlib.Plasma_6',
                         'scheme': 'linear'})
-    source = large_image_source_gdal.GDALFileTileSource(
+    source = large_image_source_gdal.open(
         imagePath, projection='EPSG:3857', style=style, encoding='PNG')
     image = source.getTile(22, 51, 7)
     _assertImageMatches(image, 'geotiff_style_linear_7_22_51')
@@ -106,7 +106,7 @@ def testTileLinearStyleFromGeotiffs():
 def testTileStyleBadInput():
     def _assertStyleResponse(imagePath, style, message):
         with pytest.raises(TileSourceException, match=message):
-            source = large_image_source_gdal.GDALFileTileSource(
+            source = large_image_source_gdal.open(
                 imagePath, projection='EPSG:3857', style=json.dumps(style), encoding='PNG')
             source.getTile(22, 51, 7)
 
@@ -133,12 +133,12 @@ def testTileStyleBadInput():
 def testThumbnailFromGeotiffs():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
-    source = large_image_source_gdal.GDALFileTileSource(imagePath)
+    source = large_image_source_gdal.open(imagePath)
     # We get a thumbnail without a projection
     image, mimeType = source.getThumbnail(encoding='PNG')
     assert image[:len(utilities.PNGHeader)] == utilities.PNGHeader
     # We get a different thumbnail with a projection
-    source = large_image_source_gdal.GDALFileTileSource(imagePath, projection='EPSG:3857')
+    source = large_image_source_gdal.open(imagePath, projection='EPSG:3857')
     image2, mimeType = source.getThumbnail(encoding='PNG')
     assert image2[:len(utilities.PNGHeader)] == utilities.PNGHeader
     assert image != image2
@@ -149,7 +149,7 @@ def testPixel():
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
 
     # Test in pixel coordinates
-    source = large_image_source_gdal.GDALFileTileSource(imagePath)
+    source = large_image_source_gdal.open(imagePath)
     pixel = source.getPixel(region={'left': 212, 'top': 198})
     assert pixel == {
         'r': 76, 'g': 78, 'b': 77, 'a': 255, 'bands': {1: 62.0, 2: 65.0, 3: 66.0}}
@@ -157,7 +157,7 @@ def testPixel():
     assert pixel == {}
 
     # Test with a projection
-    source = large_image_source_gdal.GDALFileTileSource(imagePath, projection='EPSG:3857')
+    source = large_image_source_gdal.open(imagePath, projection='EPSG:3857')
     pixel = source.getPixel(region={'left': -13132910, 'top': 4010586, 'units': 'projection'})
     assert pixel == {
         'r': 94, 'g': 98, 'b': 99, 'a': 255, 'bands': {1: 77.0, 2: 82.0, 3: 84.0}}
@@ -165,7 +165,7 @@ def testPixel():
     # Test with styles
     style = json.dumps({'band': 1, 'min': 0, 'max': 100,
                         'palette': 'matplotlib.Plasma_6'})
-    source = large_image_source_gdal.GDALFileTileSource(
+    source = large_image_source_gdal.open(
         imagePath, projection='EPSG:3857', style=style)
     pixel = source.getPixel(region={'left': -13132910, 'top': 4010586, 'units': 'projection'})
     assert pixel == {
@@ -174,14 +174,14 @@ def testPixel():
     # Test with palette as an array of colors
     style = json.dumps({'band': 1, 'min': 0, 'max': 100,
                         'palette': ['#0000ff', '#00ff00', '#ff0000']})
-    source = large_image_source_gdal.GDALFileTileSource(
+    source = large_image_source_gdal.open(
         imagePath, projection='EPSG:3857', style=style)
     pixel = source.getPixel(region={'left': -13132910, 'top': 4010586, 'units': 'projection'})
     assert pixel == {
         'r': 137, 'g': 117, 'b': 0, 'a': 255, 'bands': {1: 77.0, 2: 82.0, 3: 84.0}}
 
     # Test with projection units
-    source = large_image_source_gdal.GDALFileTileSource(imagePath, projection='EPSG:3857')
+    source = large_image_source_gdal.open(imagePath, projection='EPSG:3857')
     pixel = source.getPixel(region={'left': -13132910, 'top': 4010586, 'units': 'EPSG:3857'})
     assert pixel == {
         'r': 94, 'g': 98, 'b': 99, 'a': 255, 'bands': {1: 77.0, 2: 82.0, 3: 84.0}}
@@ -190,7 +190,7 @@ def testPixel():
         'r': 94, 'g': 98, 'b': 99, 'a': 255, 'bands': {1: 77.0, 2: 82.0, 3: 84.0}}
     # When the tile has a different projection, the pixel is the same as
     # the band values.
-    source = large_image_source_gdal.GDALFileTileSource(imagePath)
+    source = large_image_source_gdal.open(imagePath)
     pixel = source.getPixel(region={'left': -13132910, 'top': 4010586, 'units': 'EPSG:3857'})
     assert pixel == {
         'r': 94, 'g': 98, 'b': 99, 'a': 255, 'bands': {1: 77.0, 2: 82.0, 3: 84.0}}
@@ -200,13 +200,13 @@ def testSourceErrors():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
     with pytest.raises(TileSourceException, match='must not be geographic'):
-        large_image_source_gdal.GDALFileTileSource(imagePath, 'EPSG:4326')
+        large_image_source_gdal.open(imagePath, 'EPSG:4326')
     imagePath = os.path.join(testDir, 'test_files', 'zero_gi.tif')
     with pytest.raises(TileSourceException, match='cannot be opened via'):
-        large_image_source_gdal.GDALFileTileSource(imagePath)
+        large_image_source_gdal.open(imagePath)
     imagePath = os.path.join(testDir, 'test_files', 'yb10kx5k.png')
     with pytest.raises(TileSourceException, match='does not have a projected scale'):
-        large_image_source_gdal.GDALFileTileSource(imagePath)
+        large_image_source_gdal.open(imagePath)
 
 
 def testStereographicProjection():
@@ -215,9 +215,9 @@ def testStereographicProjection():
     # We will fail if we ask for a stereographic projection and don't
     # specify unitsPerPixel
     with pytest.raises(TileSourceException, match='unitsPerPixel must be specified'):
-        large_image_source_gdal.GDALFileTileSource(imagePath, 'EPSG:3411')
+        large_image_source_gdal.open(imagePath, 'EPSG:3411')
     # But will pass if unitsPerPixel is specified
-    large_image_source_gdal.GDALFileTileSource(imagePath, 'EPSG:3411', unitsPerPixel=150000)
+    large_image_source_gdal.open(imagePath, 'EPSG:3411', unitsPerPixel=150000)
 
 
 def testProj4Proj():
@@ -233,7 +233,7 @@ def testProj4Proj():
 def testConvertProjectionUnits():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
-    tsNoProj = large_image_source_gdal.GDALFileTileSource(imagePath)
+    tsNoProj = large_image_source_gdal.open(imagePath)
 
     result = tsNoProj._convertProjectionUnits(
         -13024380, 3895303, None, None, None, None, 'EPSG:3857')
@@ -268,7 +268,7 @@ def testConvertProjectionUnits():
         tsNoProj._convertProjectionUnits(
             -117.5, None, -117, None, None, None, 'EPSG:4326')
 
-    tsProj = large_image_source_gdal.GDALFileTileSource(imagePath, projection='EPSG:3857')
+    tsProj = large_image_source_gdal.open(imagePath, projection='EPSG:3857')
     result = tsProj._convertProjectionUnits(
         -13024380, 3895303, None, None, None, None, 'EPSG:3857')
     assert result[0] == pytest.approx(-13024380, 1)
@@ -279,7 +279,7 @@ def testConvertProjectionUnits():
 def testGuardAgainstBadLatLong():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'global_dem.tif')
-    source = large_image_source_gdal.GDALFileTileSource(imagePath)
+    source = large_image_source_gdal.open(imagePath)
     bounds = source.getBounds(srs='EPSG:4326')
 
     assert bounds['xmin'] == -180.00416667
@@ -290,7 +290,7 @@ def testGuardAgainstBadLatLong():
 
 def testPalettizedGeotiff():
     imagePath = utilities.externaldata('data/landcover_sample_1000.tif.sha512')
-    source = large_image_source_gdal.GDALFileTileSource(imagePath)
+    source = large_image_source_gdal.open(imagePath)
     tileMetadata = source.getMetadata()
     assert tileMetadata['tileWidth'] == 256
     assert tileMetadata['tileHeight'] == 256
@@ -303,7 +303,7 @@ def testPalettizedGeotiff():
     assert len(tileMetadata['bands']) == 1
     assert tileMetadata['bands'][1]['interpretation'] == 'palette'
     # Getting the metadata with a specified projection will be different
-    source = large_image_source_gdal.GDALFileTileSource(
+    source = large_image_source_gdal.open(
         imagePath, projection='EPSG:3857', encoding='PNG')
     tileMetadata = source.getMetadata()
     assert tileMetadata['tileWidth'] == 256
@@ -326,7 +326,7 @@ def testPalettizedGeotiff():
 
 def testRetileProjection():
     imagePath = utilities.externaldata('data/landcover_sample_1000.tif.sha512')
-    ts = large_image_source_gdal.GDALFileTileSource(imagePath, projection='EPSG:3857')
+    ts = large_image_source_gdal.open(imagePath, projection='EPSG:3857')
     ti = ts.getSingleTile(tile_size=dict(width=1000, height=1000), tile_position=1000)
     assert ti['tile'].size == 3000000
     tile = ts.getTile(1178, 1507, 12)
@@ -336,14 +336,14 @@ def testRetileProjection():
 def testInternalMetadata():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
-    source = large_image_source_gdal.GDALFileTileSource(imagePath)
+    source = large_image_source_gdal.open(imagePath)
     metadata = source.getInternalMetadata()
     assert metadata['driverShortName'] == 'GTiff'
 
 
 def testGetRegionWithProjection():
     imagePath = utilities.externaldata('data/landcover_sample_1000.tif.sha512')
-    ts = large_image_source_gdal.GDALFileTileSource(imagePath, projection='EPSG:3857')
+    ts = large_image_source_gdal.open(imagePath, projection='EPSG:3857')
     region, _ = ts.getRegion(output=dict(maxWidth=1024, maxHeight=1024),
                              format=constants.TILE_FORMAT_NUMPY)
     assert region.shape == (1024, 1024, 4)

--- a/test/test_source_nd2.py
+++ b/test/test_source_nd2.py
@@ -7,7 +7,7 @@ from . import utilities
 
 def testTilesFromND2():
     imagePath = utilities.externaldata('data/ITGA3Hi_export_crop2.nd2.sha512')
-    source = large_image_source_nd2.ND2FileTileSource(imagePath)
+    source = large_image_source_nd2.open(imagePath)
     tileMetadata = source.getMetadata()
 
     assert tileMetadata['tileWidth'] == 1024
@@ -29,6 +29,6 @@ def testTilesFromND2():
 
 def testInternalMetadata():
     imagePath = utilities.externaldata('data/ITGA3Hi_export_crop2.nd2.sha512')
-    source = large_image_source_nd2.ND2FileTileSource(imagePath)
+    source = large_image_source_nd2.open(imagePath)
     metadata = source.getInternalMetadata()
     assert 'nd2' in metadata

--- a/test/test_source_ometiff.py
+++ b/test/test_source_ometiff.py
@@ -11,7 +11,7 @@ from . import utilities
 
 def testTilesFromOMETiff():
     imagePath = utilities.externaldata('data/sample.ome.tif.sha512')
-    source = large_image_source_ometiff.OMETiffFileTileSource(imagePath)
+    source = large_image_source_ometiff.open(imagePath)
     tileMetadata = source.getMetadata()
 
     assert tileMetadata['tileWidth'] == 1024
@@ -29,7 +29,7 @@ def testTilesFromOMETiff():
 
 def testTilesFromOMETiffWithSubIFD():
     imagePath = utilities.externaldata('data/sample.subifd.ome.tif.sha512')
-    source = large_image_source_ometiff.OMETiffFileTileSource(imagePath, frame=1)
+    source = large_image_source_ometiff.open(imagePath, frame=1)
     tileMetadata = source.getMetadata()
 
     assert tileMetadata['tileWidth'] == 256
@@ -47,7 +47,7 @@ def testTilesFromOMETiffWithSubIFD():
 
 def testTilesFromStripOMETiff():
     imagePath = utilities.externaldata('data/DDX58_AXL_EGFR_well2_XY01.ome.tif.sha512')
-    source = large_image_source_ometiff.OMETiffFileTileSource(imagePath)
+    source = large_image_source_ometiff.open(imagePath)
     tileMetadata = source.getMetadata()
 
     assert tileMetadata['tileWidth'] == 1024
@@ -67,7 +67,7 @@ def testTilesFromStripOMETiff():
 
 def testOMETiffAre16Bit():
     imagePath = utilities.externaldata('data/DDX58_AXL_EGFR_well2_XY01.ome.tif.sha512')
-    source = large_image_source_ometiff.OMETiffFileTileSource(imagePath)
+    source = large_image_source_ometiff.open(imagePath)
     tile = next(source.tileIterator(format=TILE_FORMAT_NUMPY))['tile']
     assert tile.dtype == numpy.uint16
     assert tile[15][15][0] == 17852
@@ -79,10 +79,10 @@ def testOMETiffAre16Bit():
 
 def testStyleAutoMinMax():
     imagePath = utilities.externaldata('data/DDX58_AXL_EGFR_well2_XY01.ome.tif.sha512')
-    source = large_image_source_ometiff.OMETiffFileTileSource(imagePath)
+    source = large_image_source_ometiff.open(imagePath)
     image, _ = source.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=TILE_FORMAT_NUMPY, frame=1)
-    sourceB = large_image_source_ometiff.OMETiffFileTileSource(
+    sourceB = large_image_source_ometiff.open(
         imagePath, style=json.dumps({'min': 'auto', 'max': 'auto'}))
     imageB, _ = sourceB.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=TILE_FORMAT_NUMPY, frame=1)
@@ -96,7 +96,7 @@ def testStyleAutoMinMax():
 
 def testInternalMetadata():
     imagePath = utilities.externaldata('data/sample.ome.tif.sha512')
-    source = large_image_source_ometiff.OMETiffFileTileSource(imagePath)
+    source = large_image_source_ometiff.open(imagePath)
     metadata = source.getInternalMetadata()
     assert 'omeinfo' in metadata
 
@@ -115,7 +115,7 @@ def testXMLParsing():
     }]
     # Create a source so we can use internal functions for testing
     imagePath = utilities.externaldata('data/sample.ome.tif.sha512')
-    source = large_image_source_ometiff.OMETiffFileTileSource(imagePath)
+    source = large_image_source_ometiff.open(imagePath)
     for sample in samples:
         xml = ElementTree.fromstring(sample['xml'])
         info = etreeToDict(xml)

--- a/test/test_source_openjpeg.py
+++ b/test/test_source_openjpeg.py
@@ -5,7 +5,7 @@ from . import utilities
 
 def testTilesFromOpenJPEG():
     imagePath = utilities.externaldata('data/sample_image.jp2.sha512')
-    source = large_image_source_openjpeg.OpenjpegFileTileSource(imagePath)
+    source = large_image_source_openjpeg.open(imagePath)
     tileMetadata = source.getMetadata()
 
     assert tileMetadata['tileWidth'] == 256
@@ -19,7 +19,7 @@ def testTilesFromOpenJPEG():
 
 def testAssociatedImagesFromOpenJPEG():
     imagePath = utilities.externaldata('data/JK-kidney_B-gal_H3_4C_1-500sec.jp2.sha512')
-    source = large_image_source_openjpeg.OpenjpegFileTileSource(imagePath)
+    source = large_image_source_openjpeg.open(imagePath)
 
     imageList = source.getAssociatedImagesList()
     assert imageList == ['label', 'macro']
@@ -39,7 +39,7 @@ def testBelowLevelTilesFromOpenJPEG():
     large_image_source_openjpeg.OpenjpegFileTileSource._maxTileSize = 64
     # Clear the cache to make sure we use our required max tile size.
     cachesClear()
-    source = large_image_source_openjpeg.OpenjpegFileTileSource(imagePath)
+    source = large_image_source_openjpeg.open(imagePath)
     tileMetadata = source.getMetadata()
 
     assert tileMetadata['tileWidth'] == 64
@@ -56,6 +56,6 @@ def testBelowLevelTilesFromOpenJPEG():
 
 def testInternalMetadata():
     imagePath = utilities.externaldata('data/sample_image.jp2.sha512')
-    source = large_image_source_openjpeg.OpenjpegFileTileSource(imagePath)
+    source = large_image_source_openjpeg.open(imagePath)
     metadata = source.getInternalMetadata()
     assert 'ScanInfo' in metadata['xml']

--- a/test/test_source_openslide.py
+++ b/test/test_source_openslide.py
@@ -13,13 +13,13 @@ from . import utilities
 def testTilesFromSVS():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'yb10kx5k.png')
-    assert large_image_source_openslide.OpenslideFileTileSource.canRead(imagePath) is False
+    assert large_image_source_openslide.canRead(imagePath) is False
 
     imagePath = utilities.externaldata(
         'data/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-'
         'af6f-14fefbbdf7bd.svs.sha512')
-    assert large_image_source_openslide.OpenslideFileTileSource.canRead(imagePath) is True
-    source = large_image_source_openslide.OpenslideFileTileSource(imagePath)
+    assert large_image_source_openslide.canRead(imagePath) is True
+    source = large_image_source_openslide.open(imagePath)
     tileMetadata = source.getMetadata()
     assert tileMetadata['tileWidth'] == 240
     assert tileMetadata['tileHeight'] == 240
@@ -33,7 +33,7 @@ def testMagnification():
     imagePath = utilities.externaldata(
         'data/sample_jp2k_33003_TCGA-CV-7242-11A-01-TS1.1838afb1-9eee-'
         '4a70-9ae3-50e3ab45e242.svs.sha512')
-    source = large_image_source_openslide.OpenslideFileTileSource(imagePath)
+    source = large_image_source_openslide.open(imagePath)
     # tileMetadata = source.getMetadata()
     mag = source.getNativeMagnification()
     assert mag['magnification'] == 40.0
@@ -79,7 +79,7 @@ def testTileIterator():
     imagePath = utilities.externaldata(
         'data/sample_jp2k_33003_TCGA-CV-7242-11A-01-TS1.1838afb1-9eee-'
         '4a70-9ae3-50e3ab45e242.svs.sha512')
-    source = large_image_source_openslide.OpenslideFileTileSource(imagePath)
+    source = large_image_source_openslide.open(imagePath)
     tileCount = 0
     visited = {}
     for tile in source.tileIterator(
@@ -181,7 +181,7 @@ def testGetRegion():
     imagePath = utilities.externaldata(
         'data/sample_jp2k_33003_TCGA-CV-7242-11A-01-TS1.1838afb1-9eee-'
         '4a70-9ae3-50e3ab45e242.svs.sha512')
-    source = large_image_source_openslide.OpenslideFileTileSource(imagePath)
+    source = large_image_source_openslide.open(imagePath)
     # By default, getRegion gets an image
     image, mimeType = source.getRegion(scale={'magnification': 2.5})
     assert mimeType == 'image/jpeg'
@@ -213,7 +213,7 @@ def testConvertRegionScale():
     imagePath = utilities.externaldata(
         'data/sample_jp2k_33003_TCGA-CV-7242-11A-01-TS1.1838afb1-9eee-'
         '4a70-9ae3-50e3ab45e242.svs.sha512')
-    source = large_image_source_openslide.OpenslideFileTileSource(imagePath)
+    source = large_image_source_openslide.open(imagePath)
     # If we aren't using pixels as our units and don't specify a target
     # unit, this should do nothing.  This source image is 23021 x 23162
     sourceRegion = {'width': 0.8, 'height': 0.7, 'units': 'fraction'}
@@ -300,7 +300,7 @@ def testConvertPointScale():
     imagePath = utilities.externaldata(
         'data/sample_jp2k_33003_TCGA-CV-7242-11A-01-TS1.1838afb1-9eee-'
         '4a70-9ae3-50e3ab45e242.svs.sha512')
-    source = large_image_source_openslide.OpenslideFileTileSource(imagePath)
+    source = large_image_source_openslide.open(imagePath)
     point = source.getPointAtAnotherScale((500, 800), {'magnification': 5}, 'mag_pixels')
     assert point == (4000.0, 6400.0)
     point = source.getPointAtAnotherScale(
@@ -316,7 +316,7 @@ def testGetPixel():
     imagePath = utilities.externaldata(
         'data/sample_jp2k_33003_TCGA-CV-7242-11A-01-TS1.1838afb1-9eee-'
         '4a70-9ae3-50e3ab45e242.svs.sha512')
-    source = large_image_source_openslide.OpenslideFileTileSource(imagePath)
+    source = large_image_source_openslide.open(imagePath)
 
     pixel = source.getPixel(region={'left': 12125, 'top': 10640})
     assert pixel == {'r': 156, 'g': 98, 'b': 138, 'a': 255}
@@ -336,7 +336,7 @@ def testGetPixel():
 
 def testTilesFromPowerOf3Tiles():
     imagePath = utilities.externaldata('data/G10-3_pelvis_crop-powers-of-3.tif.sha512')
-    source = large_image_source_openslide.OpenslideFileTileSource(imagePath)
+    source = large_image_source_openslide.open(imagePath)
     tileMetadata = source.getMetadata()
     assert tileMetadata['tileWidth'] == 128
     assert tileMetadata['tileHeight'] == 128
@@ -350,7 +350,7 @@ def testRegionsWithMagnification():
     imagePath = utilities.externaldata(
         'data/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-'
         'af6f-14fefbbdf7bd.svs.sha512')
-    source = large_image_source_openslide.OpenslideFileTileSource(imagePath)
+    source = large_image_source_openslide.open(imagePath)
     params = {'region': {'width': 2000, 'height': 1500},
               'output': {'maxWidth': 1000, 'maxHeight': 1000},
               'encoding': 'PNG'}
@@ -391,7 +391,7 @@ def testTilesAssociatedImages():
     imagePath = utilities.externaldata(
         'data/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-'
         'af6f-14fefbbdf7bd.svs.sha512')
-    source = large_image_source_openslide.OpenslideFileTileSource(imagePath)
+    source = large_image_source_openslide.open(imagePath)
     imageList = source.getAssociatedImagesList()
     assert imageList == ['label', 'macro', 'thumbnail']
     image, mimeType = source.getAssociatedImage('macro')
@@ -404,7 +404,7 @@ def testTilesFromSmallFile():
     testDir = os.path.dirname(os.path.realpath(__file__))
     # Using a two-channel luminance-alpha tiff should work
     imagePath = os.path.join(testDir, 'test_files', 'small_la.tiff')
-    source = large_image_source_openslide.OpenslideFileTileSource(imagePath)
+    source = large_image_source_openslide.open(imagePath)
     tileMetadata = source.getMetadata()
     assert tileMetadata['tileWidth'] == 2
     assert tileMetadata['tileHeight'] == 1
@@ -418,21 +418,21 @@ def testEdgeOptions():
     imagePath = utilities.externaldata(
         'data/sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-'
         'af6f-14fefbbdf7bd.svs.sha512')
-    image = large_image_source_openslide.OpenslideFileTileSource(
+    image = large_image_source_openslide.open(
         imagePath, format=constants.TILE_FORMAT_IMAGE, encoding='PNG',
         edge='crop').getTile(0, 0, 0)
     assert image[:len(utilities.PNGHeader)] == utilities.PNGHeader
     (width, height) = struct.unpack('!LL', image[16:24])
     assert width == 124
     assert height == 54
-    image = large_image_source_openslide.OpenslideFileTileSource(
+    image = large_image_source_openslide.open(
         imagePath, format=constants.TILE_FORMAT_IMAGE, encoding='PNG',
         edge='#DDD').getTile(0, 0, 0)
     assert image[:len(utilities.PNGHeader)] == utilities.PNGHeader
     (width, height) = struct.unpack('!LL', image[16:24])
     assert width == 240
     assert height == 240
-    imageB = large_image_source_openslide.OpenslideFileTileSource(
+    imageB = large_image_source_openslide.open(
         imagePath, format=constants.TILE_FORMAT_IMAGE, encoding='PNG',
         edge='yellow').getTile(0, 0, 0)
     assert imageB[:len(utilities.PNGHeader)] == utilities.PNGHeader
@@ -446,6 +446,6 @@ def testInternalMetadata():
     imagePath = utilities.externaldata(
         'data/sample_jp2k_33003_TCGA-CV-7242-11A-01-TS1.1838afb1-9eee-'
         '4a70-9ae3-50e3ab45e242.svs.sha512')
-    source = large_image_source_openslide.OpenslideFileTileSource(imagePath)
+    source = large_image_source_openslide.open(imagePath)
     metadata = source.getInternalMetadata()
     assert 'openslide' in metadata

--- a/test/test_source_pil.py
+++ b/test/test_source_pil.py
@@ -16,12 +16,12 @@ def testTilesFromPIL():
     imagePath = utilities.externaldata('data/sample_Easy1.png.sha512')
     # Test with different max size options.
     config.setConfig('max_small_image_size', 100)
-    assert large_image_source_pil.PILFileTileSource.canRead(imagePath) is False
+    assert large_image_source_pil.canRead(imagePath) is False
 
     # Allow images bigger than our test
     config.setConfig('max_small_image_size', 2048)
-    assert large_image_source_pil.PILFileTileSource.canRead(imagePath) is True
-    source = large_image_source_pil.PILFileTileSource(imagePath)
+    assert large_image_source_pil.canRead(imagePath) is True
+    source = large_image_source_pil.open(imagePath)
     tileMetadata = source.getMetadata()
     assert tileMetadata['tileWidth'] == 1790
     assert tileMetadata['tileHeight'] == 1046
@@ -38,20 +38,20 @@ def testTileRedirects():
     # Test redirects, use a JPEG
     imagePath = utilities.externaldata('data/sample_Easy1.jpeg.sha512')
     rawimage = open(imagePath, 'rb').read()
-    source = large_image_source_pil.PILFileTileSource(imagePath)
+    source = large_image_source_pil.open(imagePath)
     # No encoding or redirect should just get a JPEG
     image = source.getTile(0, 0, 0)
     assert image == rawimage
     # quality 75 should work
-    source = large_image_source_pil.PILFileTileSource(imagePath, jpegQuality=95)
+    source = large_image_source_pil.open(imagePath, jpegQuality=95)
     image = source.getTile(0, 0, 0)
     assert image == rawimage
     # redirect with a different quality shouldn't
-    source = large_image_source_pil.PILFileTileSource(imagePath, jpegQuality=75)
+    source = large_image_source_pil.open(imagePath, jpegQuality=75)
     image = source.getTile(0, 0, 0)
     assert image != rawimage
     # redirect with a different encoding shouldn't
-    source = large_image_source_pil.PILFileTileSource(imagePath, encoding='PNG')
+    source = large_image_source_pil.open(imagePath, encoding='PNG')
     image = source.getTile(0, 0, 0)
     assert image != rawimage
 
@@ -62,11 +62,11 @@ def testReadingVariousColorFormats():
              if re.match(r'&test_.*\.png$', name)]
     for name in files:
         imagePath = os.path.join(testDir, 'test_files', name)
-        assert large_image_source_pil.PILFileTileSource.canRead(imagePath) is True
+        assert large_image_source_pil.canRead(imagePath) is True
 
 
 def testInternalMetadata():
     imagePath = utilities.externaldata('data/sample_Easy1.png.sha512')
-    source = large_image_source_pil.PILFileTileSource(imagePath)
+    source = large_image_source_pil.open(imagePath)
     metadata = source.getInternalMetadata()
     assert 'pil' in metadata

--- a/test/test_source_tiff.py
+++ b/test/test_source_tiff.py
@@ -24,11 +24,11 @@ def nestedUpdate(value, nvalue):
 def testTilesFromPTIF():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'yb10kx5k.png')
-    assert large_image_source_tiff.TiffFileTileSource.canRead(imagePath) is False
+    assert large_image_source_tiff.canRead(imagePath) is False
 
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    assert large_image_source_tiff.TiffFileTileSource.canRead(imagePath) is True
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    assert large_image_source_tiff.canRead(imagePath) is True
+    source = large_image_source_tiff.open(imagePath)
     tileMetadata = source.getMetadata()
     assert tileMetadata['tileWidth'] == 256
     assert tileMetadata['tileHeight'] == 256
@@ -41,7 +41,7 @@ def testTilesFromPTIF():
 
 def testTileIterator():
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
 
     # Ask for JPEGS
     tileCount = 0
@@ -74,7 +74,7 @@ def testTileIterator():
 
 def testTileIteratorRetiling():
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
 
     # Test retiling to 500 x 400
     tileCount = 0
@@ -157,7 +157,7 @@ def testTileIteratorRetiling():
 
 def testTileIteratorSingleTile():
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
 
     # Test getting a single tile
     sourceRegion = {
@@ -206,7 +206,7 @@ def testTileIteratorSingleTile():
 
 def testGetSingleTile():
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
 
     sourceRegion = {
         'width': 0.7, 'height': 0.6,
@@ -247,7 +247,7 @@ def testGetSingleTile():
 
 def testTilesFromPTIFJpeg2K():
     imagePath = utilities.externaldata('data/huron.image2_jpeg2k.tif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
     tileMetadata = source.getMetadata()
     assert tileMetadata['tileWidth'] == 256
     assert tileMetadata['tileHeight'] == 256
@@ -260,7 +260,7 @@ def testTilesFromPTIFJpeg2K():
 
 def testThumbnails():
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
     tileMetadata = source.getMetadata()
     # Now we should be able to get a thumbnail
     image, mimeType = source.getThumbnail()
@@ -338,7 +338,7 @@ def testThumbnails():
 
 def testRegions():
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
     tileMetadata = source.getMetadata()
 
     # Test bad parameters
@@ -454,7 +454,7 @@ def testRegions():
 
 def testPixel():
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
 
     # Test bad parameters
     badParams = [
@@ -476,7 +476,7 @@ def testPixel():
 
 def testTilesAssociatedImages():
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
 
     imageList = source.getAssociatedImagesList()
     assert imageList == ['label', 'macro']
@@ -492,7 +492,7 @@ def testTilesAssociatedImages():
 
 def testTilesFromSCN():
     imagePath = utilities.externaldata('data/sample_leica.scn.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
     tileMetadata = source.getMetadata()
     assert tileMetadata['tileWidth'] == 512
     assert tileMetadata['tileHeight'] == 512
@@ -518,7 +518,7 @@ def testOrientations():
     }
     for orient in range(9):
         imagePath = os.path.join(testDir, 'test_files', 'test_orient%d.tif' % orient)
-        source = large_image_source_tiff.TiffFileTileSource(imagePath)
+        source = large_image_source_tiff.open(imagePath)
         image, _ = source.getRegion(
             output={'maxWidth': 100, 'maxHeight': 100}, format=constants.TILE_FORMAT_NUMPY)
         assert image.shape == testResults[orient]['shape']
@@ -532,7 +532,7 @@ def testOrientations():
 
 def testTilesFromMultipleTiledTIF():
     imagePath = utilities.externaldata('data/JK-kidney_H3_4C_1-500sec.tif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
     tileMetadata = source.getMetadata()
     assert tileMetadata['tileWidth'] == 256
     assert tileMetadata['tileHeight'] == 256
@@ -545,11 +545,11 @@ def testTilesFromMultipleTiledTIF():
 
 def testStyleSwapChannels():
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
     image, _ = source.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=constants.TILE_FORMAT_NUMPY)
     # swap the green and blue channels
-    sourceB = large_image_source_tiff.TiffFileTileSource(imagePath, style=json.dumps({'bands': [
+    sourceB = large_image_source_tiff.open(imagePath, style=json.dumps({'bands': [
         {'band': 'red', 'palette': ['#000', '#f00']},
         {'band': 'green', 'palette': ['#000', '#00f']},
         {'band': 'blue', 'palette': ['#000', '#0f0']},
@@ -566,11 +566,11 @@ def testStyleSwapChannels():
 
 def testStyleClamp():
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(
+    source = large_image_source_tiff.open(
         imagePath, style=json.dumps({'min': 100, 'max': 200, 'clamp': True}))
     image, _ = source.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=constants.TILE_FORMAT_NUMPY)
-    sourceB = large_image_source_tiff.TiffFileTileSource(
+    sourceB = large_image_source_tiff.open(
         imagePath, style=json.dumps({'min': 100, 'max': 200, 'clamp': False}))
     imageB, _ = sourceB.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=constants.TILE_FORMAT_NUMPY)
@@ -582,11 +582,11 @@ def testStyleClamp():
 
 def testStyleNoData():
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(
+    source = large_image_source_tiff.open(
         imagePath, style=json.dumps({'nodata': None}))
     image, _ = source.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=constants.TILE_FORMAT_NUMPY)
-    sourceB = large_image_source_tiff.TiffFileTileSource(
+    sourceB = large_image_source_tiff.open(
         imagePath, style=json.dumps({'nodata': 101}))
     imageB, _ = sourceB.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=constants.TILE_FORMAT_NUMPY)
@@ -598,7 +598,7 @@ def testStyleNoData():
 
 def testHistogram():
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
     hist = source.histogram(bins=8, output={'maxWidth': 1024}, resample=False)
     assert len(hist['histogram']) == 3
     assert hist['histogram'][0]['range'] == (0, 256)
@@ -622,7 +622,7 @@ def testHistogram():
 
 def testSingleTileIteratorResample():
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
     tile = source.getSingleTile()
     assert tile['mm_x'] == 0.00025
     assert tile['width'] == 256
@@ -648,7 +648,7 @@ def testSingleTileIteratorResample():
 
 def testInternalMetadata():
     imagePath = utilities.externaldata('data/sample_image.ptif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
     metadata = source.getInternalMetadata()
     assert 'xml' in metadata
 
@@ -656,14 +656,14 @@ def testInternalMetadata():
 def testFromTiffRGBJPEG():
     imagePath = utilities.externaldata(
         'data/TCGA-AA-A02O-11A-01-BS1.8b76f05c-4a8b-44ba-b581-6b8b4f437367.svs.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
     tile = source.getSingleTile()
     assert list(tile['tile'][0, 0]) == [243, 243, 243]
 
 
 def testTilesFromMultiFrameTiff():
     imagePath = utilities.externaldata('data/sample.ome.tif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath)
+    source = large_image_source_tiff.open(imagePath)
     tileMetadata = source.getMetadata()
 
     assert tileMetadata['tileWidth'] == 1024
@@ -681,7 +681,7 @@ def testTilesFromMultiFrameTiff():
 
 def testTilesFromMultiFrameTiffWithSubIFD():
     imagePath = utilities.externaldata('data/sample.subifd.ome.tif.sha512')
-    source = large_image_source_tiff.TiffFileTileSource(imagePath, frame=1)
+    source = large_image_source_tiff.open(imagePath, frame=1)
     tileMetadata = source.getMetadata()
 
     assert tileMetadata['tileWidth'] == 256

--- a/utilities/converter/large_image_converter/__main__.py
+++ b/utilities/converter/large_image_converter/__main__.py
@@ -118,9 +118,9 @@ def compute_error_metrics(original, altered, results, converterOpts=None):
     with TemporaryDirectory() as tempDir:
         tempPath = os.path.join(tempDir, os.path.basename(original) + '.tiff')
         orig = large_image_converter.convert(original, tempPath, compression='lzw')
-        tsOrig = large_image_source_tiff.TiffFileTileSource(orig)
+        tsOrig = large_image_source_tiff.open(orig)
         numFrames = len(tsOrig.getMetadata().get('frames', [0]))
-        tsAlt = large_image_source_tiff.TiffFileTileSource(altered)
+        tsAlt = large_image_source_tiff.open(altered)
         mse = 0
         ssim = 0
         ssim_count = 0


### PR DESCRIPTION
This also adds a canRead method to each source module and an open method to the primary module.

Before, to open a file with a specific file source, you needed to do something like ``large_image_source_tiff.TiffFileTileSource(path)``, where the name of the tile source's class had to be used.  Now, you can do ``large_image_source_tiff.open(path)``, which maps to the same thing.  The old way still works.  Similarly, ``canRead`` required something like ``large_image_source_tiff.TiffFileTileSource.canRead(path)`` and now ``large_image_source_tiff.canRead(path)`` works as well.

``open`` is now also a synonym for ``getTileSource``, so generically, ``large_image.getTileSource(path)`` can be written as ``large_image.open(path)``. 

There is no requirement that tile source modules expose the ``open`` and ``canRead`` methods directly; it is more a convenience for developers.