### PR TITLE
Don't report frame information for one frame.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Bug Fixes
+- Fix compositing when using different frame numbers and partial tiles (#557)
+
 ## Version 1.4.1
 
 ### Features

--- a/girder/girder_large_image/rest/tiles.py
+++ b/girder/girder_large_image/rest/tiles.py
@@ -264,7 +264,7 @@ class TilesItemResource(ItemResource):
         If requested, set the content disposition and a suggested file name.
 
         :param item: an item that includes a name.
-        :param contentDisposition: either 'inline' or 'attachemnt', otherwise
+        :param contentDisposition: either 'inline' or 'attachment', otherwise
             no header is added.
         :param mime: the mimetype of the output image.  Used for the filename
             suffix.

--- a/sources/tiff/large_image_source_tiff/__init__.py
+++ b/sources/tiff/large_image_source_tiff/__init__.py
@@ -447,7 +447,7 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         :returns: metadata dictonary.
         """
         result = super().getMetadata()
-        if hasattr(self, '_frames'):
+        if hasattr(self, '_frames') and len(self._frames) > 1:
             result['frames'] = [frame.get('frame', {}) for frame in self._frames]
             self._addMetadataFrameInformation(result, self._frames[0].get('channels', None))
         return result


### PR DESCRIPTION
Fix a typo in a docstring.