### PR TITLE
Increase the priority level of the PIL tile source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Reduce gdal warning about projection strings (#559)
 - Don't report needless frame information for some single frame files (#558)
 
+### Changes
+- The PIL tilesource priority is slightly higher than other fallback sources (#560)
+
 ### Bug Fixes
 - Fix compositing when using different frame numbers and partial tiles (#557)
 

--- a/large_image/constants.py
+++ b/large_image/constants.py
@@ -23,8 +23,9 @@ class SourcePriority:
     MEDIUM = 4
     LOW = 5
     LOWER = 6
-    FALLBACK = 7
-    MANUAL = 8   # Will never be selected automatically
+    FALLBACK_HIGH = 7
+    FALLBACK = 8
+    MANUAL = 9   # Will never be selected automatically
 
 
 TILE_FORMAT_IMAGE = 'image'

--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -145,7 +145,7 @@ class BioformatsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             raise TileSourceException(
                 'File cannot be opened via bioformats because it has no '
                 'extension to specify the file type (%s).' % largeImagePath)
-        if ext.lower() in ('.jpg', '.jpeg', '.jpe', '.png', '.tif', '.tiff'):
+        if ext.lower() in ('.jpg', '.jpeg', '.jpe', '.png'):
             raise TileSourceException('File will not be opened by bioformats reader')
 
         if not _startJavabridge(self._logger):

--- a/sources/pil/large_image_source_pil/__init__.py
+++ b/sources/pil/large_image_source_pil/__init__.py
@@ -24,7 +24,7 @@ import PIL.Image
 
 from large_image import config
 from large_image.cache_util import LruCacheMetaclass, methodcache, strhash
-from large_image.constants import TILE_FORMAT_PIL
+from large_image.constants import TILE_FORMAT_PIL, SourcePriority
 from large_image.exceptions import TileSourceException
 from large_image.tilesource import FileTileSource
 
@@ -65,8 +65,15 @@ class PILFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
 
     cacheName = 'tilesource'
     name = 'pilfile'
-    # No extensions or mime types are explicitly added for the PIL tile source,
-    # as it should always be a fallback source
+
+    # Although PIL is always a fallback source, prefer it to other fallback
+    # sources
+    extensions = {
+        None: SourcePriority.FALLBACK_HIGH
+    }
+    mimeTypes = {
+        None: SourcePriority.FALLBACK_HIGH
+    }
 
     def __init__(self, path, maxSize=None, **kwargs):
         """


### PR DESCRIPTION
The PIL tilesource was a fallback source, but sources with the same priority level are used in an arbitrary order, and it was desired to make it higher priority than the bioformats source for small tiff files.  This introduces more resolution into the fallback priority ordering.