### PR TITLE
Add an option to try using all items as large images.

### DIFF
--- a/girder/girder_large_image/constants.py
+++ b/girder/girder_large_image/constants.py
@@ -29,3 +29,4 @@ class PluginSettings:
     LARGE_IMAGE_AUTO_SET = 'large_image.auto_set'
     LARGE_IMAGE_MAX_THUMBNAIL_FILES = 'large_image.max_thumbnail_files'
     LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE = 'large_image.max_small_image_size'
+    LARGE_IMAGE_AUTO_USE_ALL_FILES = 'large_image.auto_use_all_files'

--- a/girder/girder_large_image/web_client/templates/largeImageConfig.pug
+++ b/girder/girder_large_image/web_client/templates/largeImageConfig.pug
@@ -15,11 +15,14 @@ form#g-large-image-form(role="form")
       | Uploaded and imported items with files that have MIME-types or extensions that are typical of large images will be set as large image items if they can be used without running a conversion job.
     .g-large-image-auto-set-container
       label.radio-inline
-        input.g-large-image-auto-set-on(type="radio", name="g-large-image-auto-set", checked=settings['large_image.auto_set'] !== false ? 'checked': undefined)
+        input.g-large-image-auto-set-on(type="radio", name="g-large-image-auto-set", checked=settings['large_image.auto_set'] === true ? 'checked' : undefined)
         | Automatically use large images
       label.radio-inline
-        input.g-large-image-auto-set-off(type="radio", name="g-large-image-auto-set", checked=settings['large_image.auto_set'] !== false ? undefined : 'checked')
+        input.g-large-image-auto-set-off(type="radio", name="g-large-image-auto-set", checked=settings['large_image.auto_set'] === false ? 'checked' : undefined)
         | No automatic use
+      label.radio-inline
+        input.g-large-image-auto-set-all(type="radio", name="g-large-image-auto-set", checked=settings['large_image.auto_set'] === 'all' ? 'checked' : undefined)
+        | Automatically try to use all files as large images
   .form-group
     label
       | Maximum size of regular images to use without conversion

--- a/girder/girder_large_image/web_client/views/configView.js
+++ b/girder/girder_large_image/web_client/views/configView.js
@@ -27,7 +27,7 @@ var ConfigView = View.extend({
                 value: this.$('.g-large-image-default-viewer').val()
             }, {
                 key: 'large_image.auto_set',
-                value: this.$('.g-large-image-auto-set-on').prop('checked')
+                value: this.$('.g-large-image-auto-set-all').prop('checked') ? 'all' : this.$('.g-large-image-auto-set-on').prop('checked')
             }, {
                 key: 'large_image.max_thumbnail_files',
                 value: +this.$('.g-large-image-max-thumbnail-files').val()


### PR DESCRIPTION
The existing setting had two states: use items with likely names and mime types, or don't use anything.  This adds a third setting to try to use all items as large images.  It will slow down generic item ingestion but reduce the need to mark jpeg and png as large images.