### PR TITLE
Prefer geospatial sources for geospatial data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Improvements
+- In Girder, prefer geospatial sources for geospatial data
+
 ## Version 1.4.2
 
 ### Features


### PR DESCRIPTION
Apply the same logic to prefer geospatial sources in Girder as we do in core.