### PR TITLE
Fix an issue with non-integer GDAL sources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## Unreleased
 
 ### Improvements
-- In Girder, prefer geospatial sources for geospatial data
+- In Girder, prefer geospatial sources for geospatial data (#564)
+
+### Bug Fixes
+- The GDAL source failed when getting band ranges on non-integer data (#565)
 
 ## Version 1.4.2
 


### PR DESCRIPTION
If a GDAL source had non-integer data, the band maxim/min calculation would fail.  Specifically, we were adding the maximum range of the integer type as a value at the end of the list of data for that frame's bands.  If the dtype is not an integer type, this fails.