### PR TITLE
Improve documentation on style.

### DIFF
--- a/docs/source/tilesource_options.rst
+++ b/docs/source/tilesource_options.rst
@@ -51,7 +51,7 @@ A band definition is an object which can contain the following keys:
 
 - ``composite``: either 'lighten' or 'multiply'.  Defaults to 'lighten' for all except the alpha band.
 
-- ``clamp``: either True to clamp values outside of the [min, max] to the ends of the palette or False to make outside values transparent.
+- ``clamp``: either True to clamp (also called clip or crop) values outside of the [min, max] to the ends of the palette or False to make outside values transparent.
 
 Note that some tile sources add additional options to the ``style`` parameter.
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -524,9 +524,9 @@ class TileSource:
                     not use a nodata value.
                 composite: either 'lighten' or 'multiply'.  Defaults to
                     'lighten' for all except the alpha band.
-                clamp: either True to clamp values outside of the [min, max]
-                    to the ends of the palette or False to make outside values
-                    transparent.
+                clamp: either True to clamp (also called clip or crop) values
+                    outside of the [min, max] to the ends of the palette or
+                    False to make outside values transparent.
             Alternately, the style object can contain a single key of 'bands',
             which has a value which is a list of style dictionaries as above,
             excepting that each must have a band that is not -1.  Bands are


### PR DESCRIPTION
This adds words users are likely to search for to the clamp option description.