### PR TITLE
Convert to svs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,6 @@ node_modules/
 .eslintcache
 test/externaldata
 
-docs/source
+docs/source/*
+!docs/source/*.py
+!docs/source/*.rst

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 - Allow converting a single frame of a multiframe image (#579)
 - Add a convert endpoint to the Girder plugin (#578)
+- Added support for creating Aperio svs files (#580)
 
 ### Improvements
 - More untiled tiff files are handles by the bioformats reader (#569)

--- a/docs/make_docs.sh
+++ b/docs/make_docs.sh
@@ -10,6 +10,8 @@ pip install -e . -r requirements-dev.txt --find-links https://girder.github.io/l
 popd
 # git clean -fxd .
 
+large_image_converter --help > source/large_image_converter.txt
+
 sphinx-apidoc -f -o source/large_image ../large_image
 sphinx-apidoc -f -o source/large_image_source_dummy ../sources/dummy/large_image_source_dummy
 sphinx-apidoc -f -o source/large_image_source_gdal ../sources/gdal/large_image_source_gdal

--- a/docs/source/image_conversion.rst
+++ b/docs/source/image_conversion.rst
@@ -1,0 +1,10 @@
+Image Conversion
+================
+
+The large_image library can read a variety of images with the various tile source modules.  Some image files that cannot be read directly can be converted into a format that can be read by the large_image library.  Additionally, some images that can be read are very slow to handle because they are stored inefficiently, and converting them will make a equivalent file that is more efficient.
+
+Installing the ``large-image-converter`` module adds a ``large_image_converter`` command to the local environment.  Running ``large_image_converter --help`` displays the various options.
+
+.. include:: large_image_converter.txt
+   :literal:
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ large_image also works as a Girder plugin with optional annotation support.
    :caption: Contents:
 
    tilesource_options
+   image_conversion
    large_image/modules
    large_image_source_dummy/modules
    large_image_source_gdal/modules

--- a/docs/source/tilesource_options.rst
+++ b/docs/source/tilesource_options.rst
@@ -39,7 +39,7 @@ A band definition is an object which can contain the following keys:
 
 - ``frame``: if specified, override the frame parameter used in the tile query for this band.  Note that it is more efficient to have at least one band not specify a frame parameter or use the same value as the basic query.  Defaults to the frame value of the core query.
 
-- ``frameidelta``: if specified, and ``frame`` is not specified, override the frame parameter used in the tile query for this band by adding the value to the current frame number.  If many different frames are being requested, all with the same ``framedelta``, this is more efficient than varying the ``frame`` within the style.
+- ``framedelta``: if specified, and ``frame`` is not specified, override the frame parameter used in the tile query for this band by adding the value to the current frame number.  If many different frames are being requested, all with the same ``framedelta``, this is more efficient than varying the ``frame`` within the style.
 
 - ``min``: the value to map to the first palette value.  Defaults to 0.  'auto' to use 0 if the reported minimum and maximum of the band are between [0, 255] or use the reported minimum otherwise.  'min' or 'max' to always uses the reported minimum or maximum.
 

--- a/girder/girder_large_image/rest/tiles.py
+++ b/girder/girder_large_image/rest/tiles.py
@@ -207,6 +207,8 @@ class TilesItemResource(ItemResource):
         .param('onlyFrame', 'Only convert a specific 0-based frame of a '
                'multiframe file.  If not specified, all frames are converted.',
                dataType='int', required=False)
+        .param('format', 'File format', required=False,
+               enum=['tiff', 'aperio'])
         .param('compression', 'Internal compression format', required=False,
                enum=['none', 'jpeg', 'deflate', 'lzw', 'zstd', 'packbits', 'webp', 'jp2k'])
         .param('quality', 'JPEG compression quality where 0 is small and 100 '

--- a/large_image/tilesource/__init__.py
+++ b/large_image/tilesource/__init__.py
@@ -16,7 +16,7 @@ def isGeospatial(path):
     """
     Check if a path is likely to be a geospatial file.
 
-    :params path: The path to the file
+    :param path: The path to the file
     :returns: True if geospatial.
     """
     try:

--- a/sources/openslide/large_image_source_openslide/__init__.py
+++ b/sources/openslide/large_image_source_openslide/__init__.py
@@ -360,6 +360,7 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             return None
         if images[imageKey] == 'openslide':
             try:
+                print('YYYYYYY')
                 return self._openslide.associated_images[imageKey]
             except openslide.lowlevel.OpenSlideError:
                 return None

--- a/sources/tiff/large_image_source_tiff/__init__.py
+++ b/sources/tiff/large_image_source_tiff/__init__.py
@@ -319,6 +319,36 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 'It will be inefficient to read lower resolution tiles.', maxMissing)
         return True
 
+    def _reorient_numpy_image(self, image, orientation):
+        """
+        Reorient a numpy image array based on a tiff orientation.
+
+        :param image: the numpy array to reorient.
+        :param orientation: one of the tiff orientation constants.
+        :returns: an image with top-left orientation.
+        """
+        if len(image.shape) == 2:
+            image = numpy.resize(image, (image.shape[0], image.shape[1], 1))
+        if orientation in {
+                tifftools.constants.Orientation.LeftTop.value,
+                tifftools.constants.Orientation.RightTop.value,
+                tifftools.constants.Orientation.LeftBottom.value,
+                tifftools.constants.Orientation.RightBottom.value}:
+            image = image.transpose(1, 0, 2)
+        if orientation in {
+                tifftools.constants.Orientation.BottomLeft.value,
+                tifftools.constants.Orientation.BottomRight.value,
+                tifftools.constants.Orientation.LeftBottom.value,
+                tifftools.constants.Orientation.RightBottom.value}:
+            image = image[::-1, ::, ::]
+        if orientation in {
+                tifftools.constants.Orientation.TopRight.value,
+                tifftools.constants.Orientation.BottomRight.value,
+                tifftools.constants.Orientation.RightTop.value,
+                tifftools.constants.Orientation.RightBottom.value}:
+            image = image[::, ::-1, ::]
+        return image
+
     def _addAssociatedImage(self, largeImagePath, directoryNum, mustBeTiled=False, topImage=None):
         """
         Check if the specified TIFF directory contains an image with a sensible
@@ -335,9 +365,11 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         try:
             associated = TiledTiffDirectory(largeImagePath, directoryNum, mustBeTiled)
             id = ''
-            if associated._tiffInfo.get('imagedescription'):
-                id = associated._tiffInfo.get(
-                    'imagedescription').strip().split(None, 1)[0].lower()
+            desc = associated._tiffInfo.get('imagedescription')
+            if desc:
+                id = desc.strip().split(None, 1)[0].lower()
+                if b'\n' in desc:
+                    id = desc.split(b'\n', 1)[1].strip().split(None, 1)[0].lower() or id
             elif mustBeTiled:
                 id = 'dir%d' % directoryNum
                 if not len(self._associatedImages):
@@ -357,6 +389,7 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 if image.tobytes()[:6] == b'<?xml ':
                     self._parseImageXml(image.tobytes().rsplit(b'>', 1)[0] + b'>', topImage)
                     return
+                image = self._reorient_numpy_image(image, associated._tiffInfo.get('orientation'))
                 self._associatedImages[id] = image
         except (TiffException, AttributeError):
             # If we can't validate or read an associated image or it has no

--- a/sources/tiff/large_image_source_tiff/__init__.py
+++ b/sources/tiff/large_image_source_tiff/__init__.py
@@ -407,8 +407,8 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         Parse metadata stored in arbitrary xml and associate it with a specific
         image.
 
-        :params xml: the xml as a string or bytes object.
-        :params topImage: the image to add metadata to.
+        :param xml: the xml as a string or bytes object.
+        :param topImage: the image to add metadata to.
         """
         if not topImage or topImage.pixelInfo.get('magnificaiton'):
             return

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -4,6 +4,7 @@ import pytest
 import shutil
 import tifftools
 
+import large_image
 from large_image import constants
 import large_image_source_tiff
 
@@ -198,6 +199,23 @@ def testConvertFromMultiframeImageOnlyOneFrame(tmpdir):
     assert metadata['levels'] == 5
     info = tifftools.read_tiff(outputPath)
     assert len(info['ifds']) == 5
+
+
+def testConvertToAperio(tmpdir):
+    imagePath = utilities.externaldata('data/huron.image2_jpeg2k.tif.sha512')
+    outputPath = os.path.join(tmpdir, 'out.svs')
+    large_image_converter.convert(imagePath, outputPath, format='aperio')
+    source = large_image.open(outputPath)
+    assert 'openslide' in source.name
+    assert 'label' in source.getAssociatedImagesList()
+
+
+def testConvertMultiframeToAperio(tmpdir):
+    imagePath = utilities.externaldata('data/sample.ome.tif.sha512')
+    outputPath = os.path.join(tmpdir, 'out.tiff')
+    large_image_converter.convert(imagePath, outputPath, format='aperio', compression='jp2k')
+    source = large_image.open(outputPath)
+    assert 'label' in source.getAssociatedImagesList()
 
 
 # Test main program

--- a/utilities/converter/large_image_converter/__init__.py
+++ b/utilities/converter/large_image_converter/__init__.py
@@ -80,12 +80,12 @@ def _generate_geotiff(inputPath, outputPath, **kwargs):
     Take a source input file, readable by gdal, and output a cloud-optimized
     geotiff file.  See https://gdal.org/drivers/raster/cog.html.
 
-    :params inputPath: the path to the input file or base file of a set.
-    :params outputPath: the path of the output file.
+    :param inputPath: the path to the input file or base file of a set.
+    :param outputPath: the path of the output file.
     Optional parameters that can be specified in kwargs:
-    :params tileSize: the horizontal and vertical tile size.
+    :param tileSize: the horizontal and vertical tile size.
     :param compression: one of 'jpeg', 'deflate' (zip), 'lzw', or 'zstd'.
-    :params quality: a jpeg quality passed to vips.  0 is small, 100 is high
+    :param quality: a jpeg quality passed to vips.  0 is small, 100 is high
         quality.  90 or above is recommended.
     :param level: compression level for zstd, 1-22 (default is 10).
     :param predictor: one of 'none', 'horizontal', 'float', or 'yes' used for
@@ -130,16 +130,16 @@ def _generate_multiframe_tiff(inputPath, outputPath, tempPath, lidata, **kwargs)
     Take a source input file with multiple frames and output a multi-pyramidal
     tiff file.
 
-    :params inputPath: the path to the input file or base file of a set.
-    :params outputPath: the path of the output file.
-    :params tempPath: a temporary file in a temporary directory.
-    :params lidata: data from a large_image tilesource including associated
+    :param inputPath: the path to the input file or base file of a set.
+    :param outputPath: the path of the output file.
+    :param tempPath: a temporary file in a temporary directory.
+    :param lidata: data from a large_image tilesource including associated
         images.
     Optional parameters that can be specified in kwargs:
-    :params tileSize: the horizontal and vertical tile size.
+    :param tileSize: the horizontal and vertical tile size.
     :param compression: one of 'jpeg', 'deflate' (zip), 'lzw', 'packbits',
         'zstd', or 'jp2k'.
-    :params quality: a jpeg quality passed to vips.  0 is small, 100 is high
+    :param quality: a jpeg quality passed to vips.  0 is small, 100 is high
         quality.  90 or above is recommended.
     :param level: compression level for zstd, 1-22 (default is 10).
     :param predictor: one of 'none', 'horizontal', or 'float' used for lzw and
@@ -205,16 +205,16 @@ def _generate_tiff(inputPath, outputPath, tempPath, lidata, **kwargs):
     Take a source input file, readable by vips, and output a pyramidal tiff
     file.
 
-    :params inputPath: the path to the input file or base file of a set.
-    :params outputPath: the path of the output file.
-    :params tempPath: a temporary file in a temporary directory.
-    :params lidata: data from a large_image tilesource including associated
+    :param inputPath: the path to the input file or base file of a set.
+    :param outputPath: the path of the output file.
+    :param tempPath: a temporary file in a temporary directory.
+    :param lidata: data from a large_image tilesource including associated
         images.
     Optional parameters that can be specified in kwargs:
-    :params tileSize: the horizontal and vertical tile size.
+    :param tileSize: the horizontal and vertical tile size.
     :param compression: one of 'jpeg', 'deflate' (zip), 'lzw', 'packbits',
         'zstd', or 'jp2k'.
-    :params quality: a jpeg quality passed to vips.  0 is small, 100 is high
+    :param quality: a jpeg quality passed to vips.  0 is small, 100 is high
         quality.  90 or above is recommended.
     :param level: compression level for zstd, 1-22 (default is 10).
     :param predictor: one of 'none', 'horizontal', or 'float' used for lzw and
@@ -490,7 +490,7 @@ def _convert_large_image_frame(frame, numFrames, ts, frameOutputPath, tempPath, 
     :param numFrames: the total number of frames; used for logging.
     :param ts: the open tile source.
     :param frameOutputPath: the destination name for the tiff file.
-    :params tempPath: a temporary file in a temporary directory.
+    :param tempPath: a temporary file in a temporary directory.
     """
     # The iterator tile size is a balance between memory use and fewer calls
     # and file handles.
@@ -515,10 +515,10 @@ def _convert_large_image(inputPath, outputPath, tempPath, lidata, **kwargs):
     Take a large_image source and convert it by resaving each tiles image with
     vips.
 
-    :params inputPath: the path to the input file or base file of a set.
-    :params outputPath: the path of the output file.
-    :params tempPath: a temporary file in a temporary directory.
-    :params lidata: data from a large_image tilesource including associated
+    :param inputPath: the path to the input file or base file of a set.
+    :param outputPath: the path of the output file.
+    :param tempPath: a temporary file in a temporary directory.
+    :param lidata: data from a large_image tilesource including associated
         images.
     """
     ts = lidata['tilesource']
@@ -550,7 +550,7 @@ def _output_tiff(inputs, outputPath, tempPath, lidata, extraImages=None, **kwarg
 
     :param inputs: a list of pyramidal input files.
     :param outputPath: the final destination.
-    :params tempPath: a temporary file in a temporary directory.
+    :param tempPath: a temporary file in a temporary directory.
     :param lidata: large_image data including metadata and associated images.
     :param extraImages: an optional dictionary of keys and paths to add as
         extra associated images.
@@ -666,8 +666,8 @@ def _is_eightbit(path, tiffinfo=None):
     Check if a path has an unsigned 8-bit per sample data size.  If any known
     channel is otherwise or this is unknown, this returns False.
 
-    :params path: The path to the file
-    :params tiffinfo: data extracted from tifftools.read_tiff(path).
+    :param path: The path to the file
+    :param tiffinfo: data extracted from tifftools.read_tiff(path).
     :returns: True if known to be 8 bits per sample.
     """
     if not tiffinfo:
@@ -691,8 +691,8 @@ def _is_lossy(path, tiffinfo=None):
     Check if a path uses lossy compression.  This imperfectly just checks if
     the file is a TIFF and stored in one of the JPEG formats.
 
-    :params path: The path to the file
-    :params tiffinfo: data extracted from tifftools.read_tiff(path).
+    :param path: The path to the file
+    :param tiffinfo: data extracted from tifftools.read_tiff(path).
     :returns: True if known to be lossy.
     """
     if not tiffinfo:
@@ -709,7 +709,7 @@ def _is_multiframe(path):
     """
     Check if a path is a multiframe file.
 
-    :params path: The path to the file
+    :param path: The path to the file
     :returns: True if multiframe.
     """
     _import_pyvips()
@@ -831,8 +831,10 @@ def _vips_parameters(forTiled=True, **kwargs):
 
     :param forTiled: True if this is for a tiled image.  False for an
         associated image.
+
     Optional parameters that can be specified in kwargs:
-    :params tileSize: the horizontal and vertical tile size.
+
+    :param tileSize: the horizontal and vertical tile size.
     :param compression: one of 'jpeg', 'deflate' (zip), 'lzw', 'packbits',
         'zstd', or 'none'.
     :param quality: a jpeg quality passed to vips.  0 is small, 100 is high
@@ -903,25 +905,40 @@ def convert(inputPath, outputPath=None, **kwargs):
     """
     Take a source input file and output a pyramidal tiff file.
 
-    :params inputPath: the path to the input file or base file of a set.
-    :params outputPath: the path of the output file.
+    :param inputPath: the path to the input file or base file of a set.
+    :param outputPath: the path of the output file.
+
     Optional parameters that can be specified in kwargs:
-    :params tileSize: the horizontal and vertical tile size.
+
+    :param tileSize: the horizontal and vertical tile size.
+    :param format: one of 'tiff' or 'aperio'.  Default is 'tiff'.
+    :param onlyFrame: None for all frames or the 0-based frame number to just
+        convert a single frame of the source.
     :param compression: one of 'jpeg', 'deflate' (zip), 'lzw', 'packbits',
         'zstd', or 'none'.
-    :params quality: a jpeg or webp quality passed to vips.  0 is small, 100 is
+    :param quality: a jpeg or webp quality passed to vips.  0 is small, 100 is
         high quality.  90 or above is recommended.  For webp, 0 is lossless.
     :param level: compression level for zstd, 1-22 (default is 10) and deflate,
         1-9.
-    :param predictor: one of 'none', 'horizontal', or 'float' used for lzw and
-        deflate.  Default is horizontal.
+    :param predictor: one of 'none', 'horizontal', 'float', or 'yes' used for
+        lzw and deflate.  Default is horizontal for non-geospatial data and yes
+        for geospatial.
     :param psnr: psnr value for jp2k, higher results in large files.  0 is
         lossless.
     :param cr: jp2k compression ratio.  1 is lossless, 100 will try to make
         a file 1% the size of the original, etc.
+    :param subifds: if True (the default), when creating a multi-frame file,
+        store lower resolution tiles in sub-ifds.  If False, store all data in
+        primary ifds.
+    :param overwrite: if not True, throw an exception if the output path
+        already exists.
+
     Additional optional parameters:
+
     :param geospatial: if not None, a boolean indicating if this file is
         geospatial.  If not specified or None, this will be checked.
+    :param _concurrency: the number of cpus to use during conversion.  None to
+        use the logical cpu count.
 
     :returns: outputPath if successful
     """
@@ -976,7 +993,7 @@ def is_geospatial(path):
     """
     Check if a path is likely to be a geospatial file.
 
-    :params path: The path to the file
+    :param path: The path to the file
     :returns: True if geospatial.
     """
     try:
@@ -999,7 +1016,7 @@ def is_vips(path):
     """
     Check if a path is readable by vips.
 
-    :params path: The path to the file
+    :param path: The path to the file
     :returns: True if readable by vips.
     """
     _import_pyvips()

--- a/utilities/converter/large_image_converter/__main__.py
+++ b/utilities/converter/large_image_converter/__main__.py
@@ -48,6 +48,15 @@ depth.
         help='When handling a multiframe file, only output a single frame.  '
         'This is the zero-based frame number.')
     parser.add_argument(
+        '--format', default=None,
+        choices=['tiff', 'aperio'],
+        help='Output format.  The default is a standardized pyramidal tiff or '
+        'COG geotiff.  Other formats may not be available for all input '
+        'options and will change some defaults.  '
+        'Aperio (svs) defaults to no-subifds.  If there is no label image, a '
+        'cropped square thumbnail is used in its place if the source image '
+        'can be read by anyt of the known tile sources.')
+    parser.add_argument(
         '--compression', '-c',
         choices=[
             '', 'jpeg', 'deflate', 'zip', 'lzw', 'zstd', 'packbits', 'jbig',

--- a/utilities/converter/large_image_converter/__main__.py
+++ b/utilities/converter/large_image_converter/__main__.py
@@ -54,8 +54,8 @@ depth.
         'COG geotiff.  Other formats may not be available for all input '
         'options and will change some defaults.  '
         'Aperio (svs) defaults to no-subifds.  If there is no label image, a '
-        'cropped square thumbnail is used in its place if the source image '
-        'can be read by anyt of the known tile sources.')
+        'cropped nearly square thumbnail is used in its place if the source '
+        'image can be read by any of the known tile sources.')
     parser.add_argument(
         '--compression', '-c',
         choices=[

--- a/utilities/converter/large_image_converter/format_aperio.py
+++ b/utilities/converter/large_image_converter/format_aperio.py
@@ -1,0 +1,264 @@
+import json
+import math
+
+import tifftools
+
+import large_image
+import large_image_source_tiff
+
+AperioHeader = 'Aperio Image Library v10.0.0\n'
+FullHeaderStart = '{width}x{height} [0,0 {width}x{height}] ({tileSize}x{tileSize})'
+LowHeaderChunk = ' -> {width}x{height}'
+AssociatedHeader = '{name} {width}x{height}'
+ThumbnailHeader = '-> {width}x{height} - |'
+
+
+def adjust_params(geospatial, params, **kwargs):
+    """
+    Adjust options for aperio format.
+
+    :param geospatial: True if the source is geospatial.
+    :param params: the conversion options.  Possibly modified.
+    :returns: suffix: the recommended suffix for the new file.
+    """
+    if geospatial:
+        raise Exception('Aperio format cannot be used with geospatial sources.')
+    if params.get('subifds') is None:
+        params['subifds'] = False
+    return '.svs'
+
+
+def modify_vips_image_before_output(image, convertParams, **kwargs):
+    """
+    Make sure the vips image is either 1 or 3 bands.
+
+    :param image: a vips image.
+    :param convertParams: the parameters that will be used for compression.
+    :returns: a vips image.
+    """
+    return image[:3 if image.bands >= 3 else 1]
+
+
+def modify_tiled_ifd(info, ifd, idx, ifdIndices, lidata, liDesc, **kwargs):
+    """
+    Modify a tiled image to add aperio metadata and ensure tags are set
+    appropriately.
+
+    :param info: the tifftools info that will be written to the tiff tile;
+        modified.
+    :param ifd: the full resolution ifd as read by tifftools.
+    :param idx: index of this ifd.
+    :param ifdIndices: the 0-based index of the full resolution ifd of each
+        frame followed by the ifd of the first associated image.
+    :param lidata: large_image data including metadata and associated images.
+    :param liDesc: the parsed json from the original large_image_converter
+        description.
+    """
+    descStart = FullHeaderStart.format(
+        width=ifd['tags'][tifftools.Tag.ImageWidth.value]['data'][0],
+        height=ifd['tags'][tifftools.Tag.ImageHeight.value]['data'][0],
+        tileSize=ifd['tags'][tifftools.Tag.TileWidth.value]['data'][0],
+    )
+    formatChunk = '-'
+    if kwargs['compression'] == 'jpeg':
+        formatChunk = 'JPEG/RGB Q=%s' % (kwargs.get('Q', 90))
+    elif kwargs['compression'] == 'jp2k':
+        formatChunk = 'J2K/YUV16 Q=%s' % (kwargs.get('psnr', kwargs.get('cratios', 0)))
+    metadata = {
+        'Converter': 'large_image_converter',
+        'ConverterVersion': liDesc['large_image_converter']['version'],
+        'ConverterEpoch': liDesc['large_image_converter']['conversion_epoch'],
+    }
+    metadata['MPP'] = (
+        lidata['metadata']['mm_x'] * 1000
+        if lidata and lidata['metadata'].get('mm_x') else None)
+    metadata['AppMag'] = (
+        lidata['metadata']['magnification']
+        if lidata and (lidata or {})['metadata'].get('magnification') else None)
+    compressionTag = ifd['tags'][tifftools.Tag.Compression.value]
+    if compressionTag['data'][0] == tifftools.constants.Compression.JP2000:
+        compressionTag['data'][0] = tifftools.constants.Compression.JP2kRGB
+    if len(ifdIndices) > 2:
+        metadata['OffsetZ'] = idx
+        metadata['TotalDepth'] = len(ifdIndices) - 1
+        try:
+            if metadata['IndexRange']['IndexZ'] == metadata['TotalDepth']:
+                metadata['OffsetZ'] = lidata['metadata']['frames'][idx]['mm_z'] * 1000
+                metadata['TotalDepth'] = (
+                    lidata['metadata']['frames'][-1]['mm_z'] * 2 +
+                    lidata['metadata']['frames'][-2]['mm_z'])
+        except Exception:
+            pass
+    description = (
+        f'{AperioHeader}{descStart} {formatChunk}|' +
+        '|'.join(f'{k} = {v}' for k, v in sorted(metadata.items()) if v is not None))
+    ifd['tags'][tifftools.Tag.ImageDescription.value] = {
+        'data': description,
+        'datatype': tifftools.Datatype.ASCII,
+    }
+    ifd['tags'][tifftools.Tag.NewSubfileType.value] = {
+        'data': [0],
+        'datatype': tifftools.Datatype.LONG,
+    }
+    if ifdIndices[idx + 1] == idx + 1:
+        subifds = ifd['tags'][tifftools.Tag.SubIFD.value]['ifds']
+    else:
+        subifds = info['ifds'][ifdIndices[idx] + 1: ifdIndices[idx + 1]]
+    for subifd in subifds:
+        lowerDesc = LowHeaderChunk.format(
+            width=subifd['tags'][tifftools.Tag.ImageWidth.value]['data'][0],
+            height=subifd['tags'][tifftools.Tag.ImageHeight.value]['data'][0],
+        )
+        metadata['MPP'] = metadata['MPP'] * 2 if metadata['MPP'] else None
+        metadata['AppMag'] = metadata['AppMag'] / 2 if metadata['AppMag'] else None
+        description = (
+            f'{AperioHeader}{descStart}{lowerDesc} {formatChunk}|' +
+            '|'.join(f'{k} = {v}' for k, v in sorted(metadata.items()) if v is not None))
+        subifd['tags'][tifftools.Tag.ImageDescription.value] = {
+            'data': description,
+            'datatype': tifftools.Datatype.ASCII,
+        }
+        subifd['tags'][tifftools.Tag.NewSubfileType.value] = {
+            'data': [0],
+            'datatype': tifftools.Datatype.LONG,
+        }
+        compressionTag = subifd['tags'][tifftools.Tag.Compression.value]
+        if compressionTag['data'][0] == tifftools.constants.Compression.JP2000:
+            compressionTag['data'][0] = tifftools.constants.Compression.JP2kRGB
+
+
+def create_thumbnail_and_label(tempPath, info, ifdCount, needsLabel, labelPosition, **kwargs):
+    """
+    Create a thumbnail and, optionally, label image for the aperio file.
+
+    :params tempPath: a temporary file in a temporary directory.
+    :param info: the tifftools info that will be written to the tiff tile;
+        modified.
+    :param ifdCount: the number of ifds in the first tiled image.  This is 1 if
+        there are subifds.
+    :param needsLabel: true if a label image needs to be added.
+    :param labelPosition: the position in the ifd list where a label image
+        should be inserted.
+    """
+    thumbnailSize = 1024
+    labelSize = 640
+    maxLabelAspect = 1.5
+    tileSize = info['ifds'][0]['tags'][tifftools.Tag.TileWidth.value]['data'][0]
+    levels = int(math.ceil(math.log(max(thumbnailSize, labelSize) / tileSize) / math.log(2))) + 1
+
+    neededList = ['thumbnail']
+    if needsLabel:
+        neededList[0:0] = ['label']
+    tiledPath = tempPath + '-overview.tiff'
+    firstFrameIfds = info['ifds'][max(0, ifdCount - levels):ifdCount]
+    tifftools.write_tiff(firstFrameIfds, tiledPath)
+    ts = large_image_source_tiff.open(tiledPath)
+    for subImage in neededList:
+        if subImage == 'label':
+            x = max(0, (ts.sizeX - min(ts.sizeX, ts.sizeY) * maxLabelAspect) // 2)
+            y = max(0, (ts.sizeY - min(ts.sizeX, ts.sizeY) * maxLabelAspect) // 2)
+            regionParams = {
+                'output': dict(maxWidth=labelSize, maxHeight=labelSize),
+                'region': dict(left=x, right=ts.sizeX - x, top=y, bottom=ts.sizeY - y),
+            }
+        else:
+            regionParams = {'output': dict(maxWidth=thumbnailSize, maxHeight=thumbnailSize)}
+        image, _ = ts.getRegion(
+            format=large_image.constants.TILE_FORMAT_PIL, **regionParams)
+        if image.mode not in {'RGB', 'L'}:
+            image = image.convert('RGB')
+        if subImage == 'label':
+            image = image.rotate(90, expand=True)
+        imagePath = tempPath + '-image_%s.tiff' % subImage
+        image.save(
+            imagePath, 'TIFF', compression='tiff_jpeg',
+            quality=int(kwargs.get('quality', 90)))
+        imageInfo = tifftools.read_tiff(imagePath)
+        ifd = imageInfo['ifds'][0]
+        if subImage == 'label':
+            ifd['tags'][tifftools.Tag.Orientation.value] = {
+                'data': [tifftools.constants.Orientation.RightTop.value],
+                'datatype': tifftools.Datatype.LONG,
+            }
+            description = AperioHeader + AssociatedHeader.format(
+                name='label',
+                width=ifd['tags'][tifftools.Tag.ImageWidth.value]['data'][0],
+                height=ifd['tags'][tifftools.Tag.ImageHeight.value]['data'][0],
+            )
+            ifd['tags'][tifftools.Tag.ImageDescription.value] = {
+                'data': description,
+                'datatype': tifftools.Datatype.ASCII,
+            }
+            ifd['tags'][tifftools.Tag.NewSubfileType.value] = {
+                'data': [
+                    tifftools.constants.NewSubfileType.ReducedImage.value
+                ],
+                'datatype': tifftools.Datatype.LONG,
+            }
+            info['ifds'][labelPosition:labelPosition] = imageInfo['ifds']
+        else:
+            fullDesc = info['ifds'][0]['tags'][tifftools.Tag.ImageDescription.value]['data']
+            description = fullDesc.split('[', 1)[0] + ThumbnailHeader.format(
+                width=ifd['tags'][tifftools.Tag.ImageWidth.value]['data'][0],
+                height=ifd['tags'][tifftools.Tag.ImageHeight.value]['data'][0],
+            ) + fullDesc.split('|', 1)[1]
+            ifd['tags'][tifftools.Tag.ImageDescription.value] = {
+                'data': description,
+                'datatype': tifftools.Datatype.ASCII,
+            }
+            info['ifds'][1:1] = imageInfo['ifds']
+
+
+def modify_tiff_before_write(info, ifdIndices, tempPath, lidata, **kwargs):
+    """
+    Adjust the metadata and ifds for a tiff file to make it compatible with
+    Aperio (svs).
+
+    Aperio files are tiff files which are stored without subifds in the order
+    full res, optional thumbnail, half res, quarter res, ..., full res, half
+    res, quarter res, ..., label, macro.  All ifds have an ImageDescription
+    that start with an aperio header followed by some dimension information and
+    then an option key-.value list
+
+    :param info: the tifftools info that will be written to the tiff tile;
+        modified.
+    :param ifdIndices: the 0-based index of the full resolution ifd of each
+        frame followed by the ifd of the first associated image.
+    :params tempPath: a temporary file in a temporary directory.
+    :param lidata: large_image data including metadata and associated images.
+    """
+    liDesc = json.loads(info['ifds'][0]['tags'][tifftools.Tag.ImageDescription.value]['data'])
+    # Adjust tiled images
+    for idx, ifdIndex in enumerate(ifdIndices[:-1]):
+        ifd = info['ifds'][ifdIndex]
+        modify_tiled_ifd(info, ifd, idx, ifdIndices, lidata, liDesc, **kwargs)
+    # Remove all but macro and label image, keeping track if either is present
+    assocKeys = set()
+    for idx in range(len(info['ifds']) - 1, ifdIndices[-1] - 1, -1):
+        ifd = info['ifds'][idx]
+        try:
+            assocKey = ifd['tags'][tifftools.Tag.ImageDescription.value]['data']
+        except Exception:
+            assocKey = 'none'
+        if assocKey not in {'label', 'macro'}:
+            info['ifds'][idx: idx + 1] = []
+        description = AssociatedHeader.format(
+            name=assocKey,
+            width=ifd['tags'][tifftools.Tag.ImageWidth.value]['data'][0],
+            height=ifd['tags'][tifftools.Tag.ImageHeight.value]['data'][0],
+        )
+        ifd['tags'][tifftools.Tag.ImageDescription.value] = {
+            'data': description,
+            'datatype': tifftools.Datatype.ASCII,
+        }
+        ifd['tags'][tifftools.Tag.NewSubfileType.value] = {
+            'data': [
+                tifftools.constants.NewSubfileType.ReducedImage.value if assocKey == 'label' else
+                (tifftools.constants.NewSubfileType.ReducedImage.value |
+                 tifftools.constants.NewSubfileType.Macro.value)
+            ],
+            'datatype': tifftools.Datatype.LONG,
+        }
+        assocKeys.add(assocKey)
+    create_thumbnail_and_label(
+        tempPath, info, ifdIndices[1], 'label' not in assocKeys, ifdIndices[-1], **kwargs)

--- a/utilities/converter/large_image_converter/format_aperio.py
+++ b/utilities/converter/large_image_converter/format_aperio.py
@@ -131,7 +131,7 @@ def create_thumbnail_and_label(tempPath, info, ifdCount, needsLabel, labelPositi
     """
     Create a thumbnail and, optionally, label image for the aperio file.
 
-    :params tempPath: a temporary file in a temporary directory.
+    :param tempPath: a temporary file in a temporary directory.
     :param info: the tifftools info that will be written to the tiff tile;
         modified.
     :param ifdCount: the number of ifds in the first tiled image.  This is 1 if
@@ -224,7 +224,7 @@ def modify_tiff_before_write(info, ifdIndices, tempPath, lidata, **kwargs):
         modified.
     :param ifdIndices: the 0-based index of the full resolution ifd of each
         frame followed by the ifd of the first associated image.
-    :params tempPath: a temporary file in a temporary directory.
+    :param tempPath: a temporary file in a temporary directory.
     :param lidata: large_image data including metadata and associated images.
     """
     liDesc = json.loads(info['ifds'][0]['tags'][tifftools.Tag.ImageDescription.value]['data'])

--- a/utilities/converter/setup.py
+++ b/utilities/converter/setup.py
@@ -44,6 +44,7 @@ setup(
     ],
     install_requires=[
         'gdal',
+        'large_image_source_tiff',
         'numpy',
         'psutil',
         'pyvips',

--- a/utilities/tasks/large_image_tasks/tasks.py
+++ b/utilities/tasks/large_image_tasks/tasks.py
@@ -16,15 +16,15 @@ def create_tiff(self, inputFile, outputName=None, outputDir=None, quality=90,
     Take a source input file, readable by vips, and output a pyramidal tiff
     file.
 
-    :params inputFile: the path to the input file or base file of a set.
-    :params outputName: the name of the output file.  If None, the name is
+    :param inputFile: the path to the input file or base file of a set.
+    :param outputName: the name of the output file.  If None, the name is
         based on the input name and current date and time.  May be a full path.
-    :params outputDir: the location to store the output.  If unspecified, the
+    :param outputDir: the location to store the output.  If unspecified, the
         inputFile's directory is used.  If the outputName is a fully qualified
         path, this is ignored.
-    :params quality: a jpeg quality passed to vips.  0 is small, 100 is high
+    :param quality: a jpeg quality passed to vips.  0 is small, 100 is high
         quality.  90 or above is recommended.
-    :params tileSize: the horizontal and vertical tile size.
+    :param tileSize: the horizontal and vertical tile size.
     Optional parameters that can be specified in kwargs:
     :param compression: one of 'jpeg', 'deflate' (zip), 'lzw', 'packbits', or
         'zstd'.

--- a/utilities/tasks/large_image_tasks/tasks.py
+++ b/utilities/tasks/large_image_tasks/tasks.py
@@ -47,7 +47,8 @@ def create_tiff(self, inputFile, outputName=None, outputDir=None, quality=90,
     inputPath = os.path.abspath(os.path.expanduser(inputFile))
     geospatial = large_image_converter.is_geospatial(inputPath)
     inputName = kwargs.get('inputName', os.path.basename(inputPath))
-    suffix = '.tiff' if not geospatial else '.geo.tiff'
+    suffix = large_image_converter.format_hook('adjust_params', geospatial, kwargs, **kwargs)
+    suffix = suffix or ('.tiff' if not geospatial else '.geo.tiff')
     if not outputName:
         outputName = os.path.splitext(inputName)[0] + suffix
         if outputName.endswith('.geo' + suffix):


### PR DESCRIPTION
This can be accessed either via the command line (`large_image_converter`) or via the `POST item/{itemId}/tiles/convert` endpoint and selecting the `format` `aperio` option.

It has some basic integration tests and manually has been checked to work with ImageScope.

If the source image does not have a label image, a thumbnail with a restricted aspect ratio (no more than a factor of 1.5 between the larger and smaller dimension) is used.   ImageScope essentially requires there to be some image for the label; in the future we may want options to place a different image there.

For multi-frame images that have distinct z values for each frame, the z value is store so ImageScope will show the appropriate focus slider with units in microns.  For other multi-frame images, the z value is just the frame value.

Not all metadata is preserved in the conversion; this can be expanded in the future.