### PR TITLE
Improve the cache miss exception context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ### Improvements
 - More untiled tiff files are handles by the bioformats reader (#569)
+- Expose a concurrent option on endpoints for converting images (#583)
+
+### Changes
+- Exceptions on cached items are no longer within the KeyError context (#584)
 
 ## Version 1.4.3
 

--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -181,11 +181,15 @@ class LruCacheMetaclass(type):
         key = cls.__name__ + ' ' + key
         with cacheLock:
             try:
-                instance = cache[key]
+                return cache[key]
             except KeyError:
-                instance = super().__call__(*args, **kwargs)
-                cache[key] = instance
-                instance._classkey = key
+                # By passing and handling the cache miss outside of the
+                # exception, any exceptions while trying to populate the cache
+                # will not be reported in the cache exception context.
+                pass
+            instance = super().__call__(*args, **kwargs)
+            cache[key] = instance
+            instance._classkey = key
 
         return instance
 


### PR DESCRIPTION
When an exception occurs when trying to fetch an item that could be cached, the exception was reported in the cache KeyError context which made debugging harder.  By changing the flow pattern, the exception is now reported in its expected context.