### PR TITLE
Handle OME Tiff files with odd tile sizes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - More untiled tiff files are handles by the bioformats reader (#569)
 - Expose a concurrent option on endpoints for converting images (#583)
 - Better concurrency use in image conversion (#587)
-- Handle more OME tiffs (#585)
+- Handle more OME tiffs (#585, #591)
 
 ### Changes
 - Exceptions on cached items are no longer within the KeyError context (#584)

--- a/sources/ometiff/large_image_source_ometiff/__init__.py
+++ b/sources/ometiff/large_image_source_ometiff/__init__.py
@@ -311,7 +311,8 @@ class OMETiffFileTileSource(TiffFileTileSource, metaclass=LruCacheMetaclass):
         if subdir:
             scale = int(2 ** subdir)
             if (dir is None or
-                    dir.tileWidth != self.tileWidth or dir.tileHeight != self.tileHeight or
+                    (dir.tileWidth != self.tileWidth and dir.tileWidth != dir.imageWidth) or
+                    (dir.tileHeight != self.tileHeight and dir.tileHeight != dir.imageHeight) or
                     abs(dir.imageWidth * scale - self.sizeX) > scale or
                     abs(dir.imageHeight * scale - self.sizeY) > scale):
                 return super().getTile(


### PR DESCRIPTION
Have files where where lower levels report a tile size equal to the image size instead of the regular tile size.