### PR TITLE
Simplify thumbnail generation.

### DIFF
--- a/girder/test_girder/test_tiles_rest.py
+++ b/girder/test_girder/test_tiles_rest.py
@@ -836,14 +836,6 @@ def testGetTileSource(server, admin, fsAssetstore):
     image, mime = source.getThumbnail(encoding='JPEG', width=200)
     assert image[:len(utilities.JPEGHeader)] == utilities.JPEGHeader
 
-    # Test the level0 thumbnail code path
-    image, mime = source.getThumbnail(
-        encoding='PNG', width=200, height=100, levelZero=True, fill='blue')
-    assert image[:len(utilities.PNGHeader)] == utilities.PNGHeader
-    (width, height) = struct.unpack('!LL', image[16:24])
-    assert width == 200
-    assert height == 100
-
 
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -879,17 +879,17 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             metadata, left, top, right, bottom, width, height, units, **kwargs)
 
     @methodcache()
-    def getThumbnail(self, width=None, height=None, levelZero=False, **kwargs):
+    def getThumbnail(self, width=None, height=None, **kwargs):
         """
         Get a basic thumbnail from the current tile source.  Aspect ratio is
         preserved.  If neither width nor height is given, a default value is
         used.  If both are given, the thumbnail will be no larger than either
-        size.
+        size.  A thumbnail has the same options as a region except that it
+        always includes the entire image if there is no projection and has a
+        default size of 256 x 256.
 
         :param width: maximum width in pixels.
         :param height: maximum height in pixels.
-        :param levelZero: if true, always use the level zero tile.  Otherwise,
-            the thumbnail is generated so that it is never upsampled.
         :param kwargs: optional arguments.  Some options are encoding,
             jpegQuality, jpegSubsampling, and tiffCompression.
         :returns: thumbData, thumbMime: the image data and the mime type.
@@ -904,7 +904,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             params['output'] = {'maxWidth': width, 'maxHeight': height}
             params['region'] = {'units': 'projection'}
             return self.getRegion(**params)
-        return super().getThumbnail(width, height, levelZero, **kwargs)
+        return super().getThumbnail(width, height, **kwargs)
 
     def toNativePixelCoordinates(self, x, y, proj=None, roundResults=True):
         """


### PR DESCRIPTION
There has been two code paths, but one was essentially a lower quality option that was not enough faster to be worth maintaining.  Remove the low-quality option.