### PR TITLE
Provide an option to output large regions as tiled tiffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 - Allow setting the cache memory portion and maximum for tilesources (#601)
 - Add heatmap and griddata to the annotation schema (#589)
+- Regions can be output as tiled tiffs with scale or geospatial metadata (#594)
 
 ### Improvements
 - Cache histogram requests (#598)

--- a/girder/test_girder/girder_utilities.py
+++ b/girder/test_girder/girder_utilities.py
@@ -4,7 +4,7 @@ from girder.models.folder import Folder
 from girder.models.upload import Upload
 
 from test.datastore import datastore
-from test.utilities import JFIFHeader, JPEGHeader, PNGHeader  # noqa
+from test.utilities import JFIFHeader, JPEGHeader, PNGHeader, TIFFHeader, BigTIFFHeader  # noqa
 
 
 def namedFolder(user, folderName='Public'):

--- a/girder/test_girder/test_tiles_rest.py
+++ b/girder/test_girder/test_tiles_rest.py
@@ -783,6 +783,15 @@ def testRegions(server, admin, fsAssetstore):
     assert width == 500
     assert height == 375
 
+    # Get a tiled image
+    params = {'regionWidth': 1000, 'regionHeight': 1000,
+              'left': 48000, 'top': 3000, 'encoding': 'TILED'}
+    resp = server.request(path='/item/%s/tiles/region' % itemId,
+                          user=admin, isJson=False, params=params)
+    assert utilities.respStatus(resp) == 200
+    image = origImage = utilities.getBody(resp, text=False)
+    assert image[:len(utilities.BigTIFFHeader)] == utilities.BigTIFFHeader
+
 
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')

--- a/large_image/constants.py
+++ b/large_image/constants.py
@@ -42,11 +42,12 @@ TileOutputMimeTypes = {
     'JPEG': 'image/jpeg',
     'PNG': 'image/png',
     'TIFF': 'image/tiff',
+    # TILED indicates the region output should be generated as a tiled TIFF
+    'TILED': 'image/tiff',
 }
 TileOutputPILFormat = {
     'JFIF': 'JPEG'
 }
-
 
 TileInputUnits = {
     None: 'base_pixels',
@@ -63,4 +64,18 @@ TileInputUnits = {
     'millimeter': 'mm',
     'millimeters': 'mm',
     'fraction': 'fraction',
+}
+
+# numpy dtype to pyvips GValue
+dtypeToGValue = {
+    'b': 'char',
+    'B': 'uchar',
+    'd': 'double',
+    'D': 'dpcomplex',
+    'f': 'float',
+    'F': 'complex',
+    'h': 'short',
+    'H': 'ushort',
+    'i': 'int',
+    'I': 'uint',
 }

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -435,3 +435,64 @@ def testGetTiledRegion16Bit():
     assert tileMetadata['bounds']['ymin'] == pytest.approx(3899358, 1)
     assert '+proj=merc' in tileMetadata['bounds']['srs']
     region.unlink()
+
+
+def testGetTiledRegionWithStyle():
+    imagePath = datastore.fetch('landcover_sample_1000.tif')
+    ts = large_image_source_gdal.open(imagePath, style='{"bands":[]}')
+    region, _ = ts.getRegion(output=dict(maxWidth=1024, maxHeight=1024),
+                             encoding='TILED')
+    result = large_image_source_gdal.open(str(region))
+    tileMetadata = result.getMetadata()
+    assert tileMetadata['bounds']['xmax'] == pytest.approx(2006547, 1)
+    assert tileMetadata['bounds']['xmin'] == pytest.approx(1319547, 1)
+    assert tileMetadata['bounds']['ymax'] == pytest.approx(2658548, 1)
+    assert tileMetadata['bounds']['ymin'] == pytest.approx(2149548, 1)
+    assert '+proj=aea' in tileMetadata['bounds']['srs']
+    region.unlink()
+
+
+def testGetTiledRegionWithProjectionAndStyle():
+    imagePath = datastore.fetch('landcover_sample_1000.tif')
+    ts = large_image_source_gdal.open(imagePath, projection='EPSG:3857', style='{"bands":[]}')
+    # This gets the whole world
+    region, _ = ts.getRegion(output=dict(maxWidth=1024, maxHeight=1024),
+                             encoding='TILED')
+    result = large_image_source_gdal.open(str(region))
+    tileMetadata = result.getMetadata()
+    assert tileMetadata['bounds']['xmax'] == pytest.approx(20037508, 1)
+    assert tileMetadata['bounds']['xmin'] == pytest.approx(-20037508, 1)
+    assert tileMetadata['bounds']['ymax'] == pytest.approx(20037508, 1)
+    assert tileMetadata['bounds']['ymin'] == pytest.approx(-20037508, 1)
+    assert '+proj=merc' in tileMetadata['bounds']['srs']
+    region.unlink()
+
+    # Ask for a smaller part
+    region, _ = ts.getRegion(
+        output=dict(maxWidth=1024, maxHeight=1024),
+        region=dict(left=-8622811, right=-8192317, bottom=5294998,
+                    top=5477835, units='projection'),
+        encoding='TILED')
+    result = large_image_source_gdal.open(str(region))
+    tileMetadata = result.getMetadata()
+    assert tileMetadata['bounds']['xmax'] == pytest.approx(-8192215, 1)
+    assert tileMetadata['bounds']['xmin'] == pytest.approx(-8622708, 1)
+    assert tileMetadata['bounds']['ymax'] == pytest.approx(5477783, 1)
+    assert tileMetadata['bounds']['ymin'] == pytest.approx(5294946, 1)
+    assert '+proj=merc' in tileMetadata['bounds']['srs']
+    region.unlink()
+
+
+def testGetTiledRegion16BitWithStyle():
+    imagePath = datastore.fetch('region_gcp.tiff')
+    ts = large_image_source_gdal.open(imagePath, style='{"bands":[]}')
+    region, _ = ts.getRegion(output=dict(maxWidth=1024, maxHeight=1024),
+                             encoding='TILED')
+    result = large_image_source_gdal.open(str(region))
+    tileMetadata = result.getMetadata()
+    assert tileMetadata['bounds']['xmax'] == pytest.approx(-10753925, 1)
+    assert tileMetadata['bounds']['xmin'] == pytest.approx(-10871650, 1)
+    assert tileMetadata['bounds']['ymax'] == pytest.approx(3949393, 1)
+    assert tileMetadata['bounds']['ymin'] == pytest.approx(3899358, 1)
+    assert '+proj=merc' in tileMetadata['bounds']['srs']
+    region.unlink()

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -374,3 +374,64 @@ def testGCPProjection():
     assert tileMetadata['bounds']['ymin'] == pytest.approx(3899358, 1)
     assert tileMetadata['bounds']['srs'] == '+init=epsg:3857'
     assert tileMetadata['geospatial']
+
+
+def testGetTiledRegion():
+    imagePath = datastore.fetch('landcover_sample_1000.tif')
+    ts = large_image_source_gdal.open(imagePath)
+    region, _ = ts.getRegion(output=dict(maxWidth=1024, maxHeight=1024),
+                             encoding='TILED')
+    result = large_image_source_gdal.open(str(region))
+    tileMetadata = result.getMetadata()
+    assert tileMetadata['bounds']['xmax'] == pytest.approx(2006547, 1)
+    assert tileMetadata['bounds']['xmin'] == pytest.approx(1319547, 1)
+    assert tileMetadata['bounds']['ymax'] == pytest.approx(2658548, 1)
+    assert tileMetadata['bounds']['ymin'] == pytest.approx(2149548, 1)
+    assert '+proj=aea' in tileMetadata['bounds']['srs']
+    region.unlink()
+
+
+def testGetTiledRegionWithProjection():
+    imagePath = datastore.fetch('landcover_sample_1000.tif')
+    ts = large_image_source_gdal.open(imagePath, projection='EPSG:3857')
+    # This gets the whole world
+    region, _ = ts.getRegion(output=dict(maxWidth=1024, maxHeight=1024),
+                             encoding='TILED')
+    result = large_image_source_gdal.open(str(region))
+    tileMetadata = result.getMetadata()
+    assert tileMetadata['bounds']['xmax'] == pytest.approx(20037508, 1)
+    assert tileMetadata['bounds']['xmin'] == pytest.approx(-20037508, 1)
+    assert tileMetadata['bounds']['ymax'] == pytest.approx(20037508, 1)
+    assert tileMetadata['bounds']['ymin'] == pytest.approx(-20037508, 1)
+    assert '+proj=merc' in tileMetadata['bounds']['srs']
+    region.unlink()
+
+    # Ask for a smaller part
+    region, _ = ts.getRegion(
+        output=dict(maxWidth=1024, maxHeight=1024),
+        region=dict(left=-8622811, right=-8192317, bottom=5294998,
+                    top=5477835, units='projection'),
+        encoding='TILED')
+    result = large_image_source_gdal.open(str(region))
+    tileMetadata = result.getMetadata()
+    assert tileMetadata['bounds']['xmax'] == pytest.approx(-8192215, 1)
+    assert tileMetadata['bounds']['xmin'] == pytest.approx(-8622708, 1)
+    assert tileMetadata['bounds']['ymax'] == pytest.approx(5477783, 1)
+    assert tileMetadata['bounds']['ymin'] == pytest.approx(5294946, 1)
+    assert '+proj=merc' in tileMetadata['bounds']['srs']
+    region.unlink()
+
+
+def testGetTiledRegion16Bit():
+    imagePath = datastore.fetch('region_gcp.tiff')
+    ts = large_image_source_gdal.open(imagePath)
+    region, _ = ts.getRegion(output=dict(maxWidth=1024, maxHeight=1024),
+                             encoding='TILED')
+    result = large_image_source_gdal.open(str(region))
+    tileMetadata = result.getMetadata()
+    assert tileMetadata['bounds']['xmax'] == pytest.approx(-10753925, 1)
+    assert tileMetadata['bounds']['xmin'] == pytest.approx(-10871650, 1)
+    assert tileMetadata['bounds']['ymax'] == pytest.approx(3949393, 1)
+    assert tileMetadata['bounds']['ymin'] == pytest.approx(3899358, 1)
+    assert '+proj=merc' in tileMetadata['bounds']['srs']
+    region.unlink()

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -6,6 +6,7 @@ JFIFHeader = b'\xff\xd8\xff\xe0\x00\x10JFIF'
 JPEGHeader = b'\xff\xd8\xff'
 PNGHeader = b'\x89PNG'
 TIFFHeader = b'II\x2a\x00'
+BigTIFFHeader = b'II\x2b\x00'
 
 
 def checkTilesZXY(source, metadata, tileParams=None, imgHeader=JPEGHeader):


### PR DESCRIPTION
This also will geotag geospatial outputs.

Specifically, when calling the getRegion function or endpoint, if an encoding of `TILED` is used (previously this could have been one of `JPEG`, `PNG`, or `TIFF`), a tiled tiff is output.  For non-geospatial sources, this is tiled using vips.  For geospatial sources, this is tiled using gdal.

When using the `TILED` option, a variety of parameters that can be used in conversions can be used: `compression`, `quality`.  For compatibility, these can also be `tiffCompression` and `jpegQuality`.