### PR TITLE
Cache histograms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Improvements
+- Cache histogram requests (#598)
+
 ## Version 1.5.0
 
 ### Features

--- a/girder/girder_large_image/rest/large_image_resource.py
+++ b/girder/girder_large_image/rest/large_image_resource.py
@@ -226,8 +226,9 @@ class LargeImageResource(Resource):
         self.route('DELETE', ('thumbnails',), self.deleteThumbnails)
         self.route('GET', ('associated_images',), self.countAssociatedImages)
         self.route('DELETE', ('associated_images',), self.deleteAssociatedImages)
-        self.route('DELETE', ('tiles', 'incomplete'),
-                   self.deleteIncompleteTiles)
+        self.route('GET', ('histograms',), self.countHistograms)
+        self.route('DELETE', ('histograms',), self.deleteHistograms)
+        self.route('DELETE', ('tiles', 'incomplete'), self.deleteIncompleteTiles)
 
     @describeRoute(
         Description('Clear tile source caches to release resources and file handles.')
@@ -438,3 +439,32 @@ class LargeImageResource(Resource):
                 except Exception:
                     pass
         return results
+
+    @describeRoute(
+        Description('Count the number of cached histograms for large_image items.')
+    )
+    @access.admin
+    def countHistograms(self, params):
+        query = {
+            'isLargeImageData': True,
+            'attachedToType': 'item',
+            'thumbnailKey': {'$regex': '"imageKey":"histogram"'},
+        }
+        count = File().find(query).count()
+        return count
+
+    @describeRoute(
+        Description('Delete cached histograms from large_image items.')
+    )
+    @access.admin
+    def deleteHistograms(self, params):
+        query = {
+            'isLargeImageData': True,
+            'attachedToType': 'item',
+            'thumbnailKey': {'$regex': '"imageKey":"histogram"'},
+        }
+        removed = 0
+        for file in File().find(query):
+            File().remove(file)
+            removed += 1
+        return removed

--- a/girder/test_girder/test_tiles_rest.py
+++ b/girder/test_girder/test_tiles_rest.py
@@ -1130,6 +1130,27 @@ def testTilesHistogram(server, admin, fsAssetstore):
     assert len(resp.json[0]['hist']) == 256
     assert resp.json[1]['samples'] == 2801664
     assert resp.json[1]['hist'][128] == 176
+    # A second query will fetch it from cache
+    resp = server.request(
+        path='/item/%s/tiles/histogram' % itemId,
+        params={'width': 2048, 'height': 2048, 'resample': False})
+    assert len(resp.json) == 3
+    assert len(resp.json[0]['hist']) == 256
+
+
+@pytest.mark.usefixtures('unbindLargeImage')
+@pytest.mark.plugin('large_image')
+def testTilesHistogramWithRange(server, admin, fsAssetstore):
+    file = utilities.uploadExternalFile(
+        'sample_image.ptif', admin, fsAssetstore)
+    itemId = str(file['itemId'])
+    resp = server.request(
+        path='/item/%s/tiles/histogram' % itemId,
+        params={'width': 2048, 'height': 2048, 'resample': False, 'rangeMin': 10, 'rangeMax': 240})
+    assert len(resp.json) == 3
+    assert len(resp.json[0]['hist']) == 256
+    assert resp.json[1]['samples'] == 685979
+    assert resp.json[1]['hist'][128] == 186
 
 
 @pytest.mark.usefixtures('unbindLargeImage')

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1219,6 +1219,7 @@ class TileSource:
         # compatibility could be an issue.
         return False
 
+    @methodcache()
     def histogram(self, dtype=None, onlyMinMax=False, bins=256,
                   density=False, format=None, *args, **kwargs):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,12 @@ setenv =
   GDAL_PAM_ENABLED=no
   PIP_FIND_LINKS=https://girder.github.io/large_image_wheels
 
+# To run just some non-web-client tests, do tox -e server -- -k <test name>
+# Don't use this for CI or full tests.
+[testenv:server]
+commands =
+  pytest {posargs}
+
 [testenv:flake8]
 skipsdist = true
 skip_install = true


### PR DESCRIPTION
This caches them in memory in the core library and to attached files in Girder.