### PR TITLE
Add more cache configuration options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Features
+- Allow setting the cache memory portion and maximum for tilesources (#601)
+
 ### Improvements
 - Cache histogram requests (#598)
 

--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -137,7 +137,8 @@ class LruCacheMetaclass(type):
                 CacheProperties[cacheName].get('itemExpectedSize')):
             maxSize = pickAvailableCache(
                 CacheProperties[cacheName]['itemExpectedSize'],
-                maxItems=CacheProperties[cacheName]['maxItems'])
+                maxItems=CacheProperties[cacheName]['maxItems'],
+                cacheName=cacheName)
         maxSize = namespace.pop('cacheMaxSize', maxSize)
         maxSize = kwargs.get('cacheMaxSize', maxSize)
         if maxSize is None:
@@ -154,10 +155,10 @@ class LruCacheMetaclass(type):
             cacheName = cls
 
         if LruCacheMetaclass.namedCaches.get(cacheName) is None:
-            cache, cacheLock = CacheFactory().getCache(maxSize)
+            cache, cacheLock = CacheFactory().getCache(maxSize, cacheName=cacheName)
             LruCacheMetaclass.namedCaches[cacheName] = (cache, cacheLock)
             config.getConfig('logger').info(
-                'Created LRU Cache for %r with %d maximum size' % (cacheName, maxSize))
+                'Created LRU Cache for %r with %d maximum size' % (cacheName, cache.maxsize))
         else:
             (cache, cacheLock) = LruCacheMetaclass.namedCaches[cacheName]
 
@@ -204,7 +205,7 @@ def getTileCache():
 
     if _tileCache is None:
         # Decide whether to use Memcached or cachetools
-        _tileCache, _tileLock = CacheFactory().getCache()
+        _tileCache, _tileLock = CacheFactory().getCache(cacheName='tileCache')
     return _tileCache, _tileLock
 
 

--- a/large_image/config.py
+++ b/large_image/config.py
@@ -11,6 +11,7 @@ ConfigValues = {
     'logger': fallbackLogger,
     'logprint': fallbackLogger,
 
+    # For tiles
     'cache_backend': 'python',  # 'python' or 'memcached'
     # 'python' cache can use 1/(val) of the available memory
     'cache_python_memory_portion': 32,
@@ -18,6 +19,15 @@ ConfigValues = {
     'cache_memcached_url': '127.0.0.1',
     'cache_memcached_username': None,
     'cache_memcached_password': None,
+
+    # Generally, these keys are the form of "cache_<cacheName>_<key>"
+
+    # For tilesources.  These are also limited by available file handles.
+    # 'python' cache can use 1/(val) of the available memory based on a very
+    # rough estimate of the amount of memory used by a tilesource
+    'cache_tilesource_memory_portion': 8,
+    # If >0, this is the maximum number of tilesources that will be cached
+    'cache_tilesource_maximum': 0,
 
     'max_small_image_size': 4096,
 }


### PR DESCRIPTION
Added `cache_tilesource_memory_portion` and `cache_tilesource_maximum` config options.  The number of tile sources that are caches is the smallest of (a) the number of available file handles divided by a factor and reduced by a constant, (b) the available memory divided by the portion (default 8) and the expected size of the largest tile source, (c) the cache maximum value.  Before, the portion was always 8 and there was no way to specify a maximum value.

This can be applied in girder, for instance via the `[large_image]` section of the config file with something like::

```
    cache_tilesource_memory_portion = 16
    cache_tilesource_maximum = 64
```