### PR TITLE
Support tile query default parameters for the image viewer widget

### DIFF
--- a/girder/girder_large_image/web_client/views/imageViewerWidget/base.js
+++ b/girder/girder_large_image/web_client/views/imageViewerWidget/base.js
@@ -6,6 +6,9 @@ import View from '@girder/core/views/View';
 var ImageViewerWidget = View.extend({
     initialize: function (settings) {
         this.itemId = settings.itemId;
+        // optional query parameters, such as {encoding: 'PNG'}, may be
+        // undefined or null
+        this.tileQueryDefaults = settings.tileQueryDefaults;
 
         return restRequest({
             type: 'GET',
@@ -31,6 +34,9 @@ var ImageViewerWidget = View.extend({
      * @param {object} [query]: optional query parameters to add to the url.
      */
     _getTileUrl: function (level, x, y, query) {
+        if (this.tileQueryDefaults) {
+            query = $.extend({}, this.tileQueryDefaults, query || {});
+        }
         var url = getApiRoot() + '/item/' + this.itemId + '/tiles/zxy/' +
             level + '/' + x + '/' + y;
         if (query) {


### PR DESCRIPTION
This allows a custom client to override parameters without subclassing the tile url generator.  For instance, in a wrapped `ItemView` `initialize` function, you could add `this.once('h:viewerWidgetCreated', viewerWidget => viewerWidget.tileQueryDefaults = {encoding: 'PNG'});`.