### PR TITLE
Better report on memcached cache.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Improvements
+- Better reporting of memcached cache
+
 ## Version 1.6.1
 
 ### Improvements

--- a/girder/girder_large_image/rest/large_image_resource.py
+++ b/girder/girder_large_image/rest/large_image_resource.py
@@ -238,6 +238,11 @@ class LargeImageResource(Resource):
         before = cache_util.cachesInfo()
         cache_util.cachesClear()
         after = cache_util.cachesInfo()
+        # Add a small delay to give the memcached time to clear
+        stoptime = time.time() + 5
+        while time.time() < stoptime and any(after[key]['used'] for key in after):
+            time.sleep(0.1)
+            after = cache_util.cachesInfo()
         return {'cacheCleared': datetime.datetime.utcnow(), 'before': before, 'after': after}
 
     @describeRoute(

--- a/large_image/cache_util/__init__.py
+++ b/large_image/cache_util/__init__.py
@@ -38,12 +38,11 @@ def cachesClear(*args, **kwargs):
             LruCacheMetaclass.namedCaches[name][0].clear()
     if isTileCacheSetup():
         tileCache, tileLock = getTileCache()
-        if isinstance(tileCache, LRUCache):
-            try:
-                with tileLock:
-                    tileCache.clear()
-            except Exception:
-                pass
+        try:
+            with tileLock:
+                tileCache.clear()
+        except Exception:
+            pass
 
 
 def cachesInfo(*args, **kwargs):
@@ -63,17 +62,16 @@ def cachesInfo(*args, **kwargs):
             }
     if isTileCacheSetup():
         tileCache, tileLock = getTileCache()
-        if isinstance(tileCache, LRUCache):
-            try:
-                with tileLock:
-                    info['tileCache'] = {
-                        'maxsize': tileCache.maxsize,
-                        'used': tileCache.currsize
-                    }
-            except Exception:
-                pass
-    # It would be nice to include memcached, but pylibmc's client.get_stats()
-    # doesn't seem to work.
+        try:
+            with tileLock:
+                info['tileCache'] = {
+                    'maxsize': tileCache.maxsize,
+                    'used': tileCache.currsize,
+                    'items': getattr(tileCache, 'curritems' if hasattr(
+                        tileCache, 'curritems') else 'currsize', None)
+                }
+        except Exception:
+            pass
     return info
 
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -141,8 +141,8 @@ class TestClass:
         large_image.cache_util.cache._tileLock = None
         config.setConfig('cache_backend', 'memcached')
         getTileCache()
-        # memcached won't show that it is present
-        assert 'tileCache' not in cachesInfo()
+        # memcached shows an items record as well
+        assert 'items' in cachesInfo()['tileCache']
 
     def testCachesClear(self):
         large_image.cache_util.cache._tileCache = None

--- a/utilities/converter/large_image_converter/__init__.py
+++ b/utilities/converter/large_image_converter/__init__.py
@@ -229,6 +229,7 @@ def _convert_via_vips(inputPathOrBuffer, outputPath, tempPath, forTiled=True,
     :param kwargs: addition arguments that get passed to _vipsParameters
         and _convert_to_jp2k.
     """
+    _import_pyvips()
     convertParams = large_image.tilesource.base._vipsParameters(forTiled, **kwargs)
     status = (', ' + status) if status else ''
     if type(inputPathOrBuffer) == pyvips.vimage.Image:


### PR DESCRIPTION
To get stats from memcached, no_block must be off.

This now reports memcached items and usage and clears it when clearing the cache.