### PR TITLE
Handle tiff tiles with zero length.

### DIFF
--- a/large_image/tilesource/tiledict.py
+++ b/large_image/tilesource/tiledict.py
@@ -143,7 +143,8 @@ class LazyTileDict(dict):
                     y0 = 0
                 tileData = tileData[:min(tileData.shape[0], self.height - y0),
                                     :min(tileData.shape[1], self.width - x0)]
-                retile[y0:y0 + tileData.shape[0], x0:x0 + tileData.shape[1]] = tileData
+                retile[y0:y0 + tileData.shape[0], x0:x0 + tileData.shape[1]] = tileData[
+                    :, :, :retile.shape[2]]
         return retile
 
     def __getitem__(self, key, *args, **kwargs):

--- a/sources/tiff/large_image_source_tiff/tiff_reader.py
+++ b/sources/tiff/large_image_source_tiff/tiff_reader.py
@@ -503,7 +503,7 @@ class TiledTiffDirectory:
         # long to an int
         return int(rawTileSizes[tileNum])
 
-    def _getJpegFrame(self, tileNum, entire=False):
+    def _getJpegFrame(self, tileNum, entire=False):  # noqa
         """
         Get the raw encoded JPEG image frame from a tile.
 
@@ -517,6 +517,8 @@ class TiledTiffDirectory:
         """
         # This raises an InvalidOperationTiffException if the tile doesn't exist
         rawTileSize = self._getJpegFrameSize(tileNum)
+        if rawTileSize <= 0:
+            raise IOTiffException('No raw tile data')
 
         frameBuffer = ctypes.create_string_buffer(rawTileSize)
 

--- a/test/datastore.py
+++ b/test/datastore.py
@@ -66,6 +66,9 @@ registry = {
     # Typical SVS file with 240x240 tiles
     # Source: sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs
     'sample_svs_image.TCGA-DU-6399-01A-01-TS1.e8eb65de-d63e-42db-af6f-14fefbbdf7bd.svs': 'sha512:5580c2b5a5360d279d102f1eb5b0e646a4943e362ec1d47f2db01f8e9e52b302e51692171198d0d35c7fa9ec9f5b8e445ef91fa7ea0bdb05ead31ab49e0118f9',  # noqa
+    # One layer tiff with missing tiles
+    # Source: one_layer_missing_tiles.tiff
+    'one_layer_missing_tiles.tiff': 'sha512:53d52abbb82d312b114407d2974fa0a4116c3b50875c5b360798b5d529cbb67596b1dff7d8feceb319d0b4377d12d023b64e374ea3df37f795c5a940afaa4cd5',  # noqa
 }
 
 

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -281,3 +281,11 @@ def testConverterMainConcurrency(tmpdir):
     outputPath = os.path.join(tmpdir, 'out.tiff')
     main.main([imagePath, outputPath, '--concurrency', '2'])
     assert os.path.getsize(outputPath) > 100
+
+
+def testConverterMissingTiles(tmpdir):
+    imagePath = datastore.fetch('one_layer_missing_tiles.tiff')
+    outputPath = os.path.join(tmpdir, 'out.tiff')
+    large_image_converter.convert(imagePath, outputPath)
+    info = tifftools.read_tiff(outputPath)
+    assert len(info['ifds']) == 6

--- a/test/test_source_tiff.py
+++ b/test/test_source_tiff.py
@@ -748,3 +748,18 @@ def testTilesFromMultiFrameTiffWithSubIFD():
 
     tile = source.getSingleTile()
     assert list(tile['tile'][0, 0]) == [7710]
+
+
+def testTilesFromMissingLayer():
+    imagePath = datastore.fetch('one_layer_missing_tiles.tiff')
+    source = large_image_source_tiff.open(imagePath)
+    tileMetadata = source.getMetadata()
+
+    assert tileMetadata['tileWidth'] == 256
+    assert tileMetadata['tileHeight'] == 256
+    assert tileMetadata['sizeX'] == 5477
+    assert tileMetadata['sizeY'] == 4515
+    assert tileMetadata['levels'] == 6
+    with pytest.raises(Exception):
+        utilities.checkTilesZXY(source, tileMetadata)
+    utilities.checkTilesZXY(source, tileMetadata, {'sparseFallback': True})

--- a/utilities/converter/large_image_converter/__init__.py
+++ b/utilities/converter/large_image_converter/__init__.py
@@ -461,6 +461,12 @@ def _convert_large_image_tile(tilelock, strips, tile):
             strips[ty] = vimg
             if not x:
                 return
+        print('A', vimg.bands, strips[ty].bands)
+        if vimg.bands > strips[ty].bands:
+            vimg = vimg[:strips[ty].bands]
+        elif strips[ty].bands > vimg.bands:
+            strips[ty] = strips[ty][:vimg.bands]
+        print('B', vimg.bands, strips[ty].bands)
         strips[ty] = strips[ty].insert(vimg, x, 0, expand=True)
 
 
@@ -795,7 +801,7 @@ def format_hook(funcname, *args, **kwargs):
         return func(*args, **kwargs)
 
 
-def convert(inputPath, outputPath=None, **kwargs):
+def convert(inputPath, outputPath=None, **kwargs):  # noqa: C901
     """
     Take a source input file and output a pyramidal tiff file.
 
@@ -879,7 +885,11 @@ def convert(inputPath, outputPath=None, **kwargs):
             elif _is_multiframe(inputPath):
                 _generate_multiframe_tiff(inputPath, outputPath, tempPath, lidata, **kwargs)
             else:
-                _generate_tiff(inputPath, outputPath, tempPath, lidata, **kwargs)
+                try:
+                    _generate_tiff(inputPath, outputPath, tempPath, lidata, **kwargs)
+                except Exception:
+                    if lidata:
+                        _convert_large_image(inputPath, outputPath, tempPath, lidata, **kwargs)
     return outputPath
 
 


### PR DESCRIPTION
This handles files with jpeg compression and some tiles with zero length that are functionally just missing.