### PR TITLE
Support frame options for the test tile source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Features
 - Provide band information on all tile sources (#622, #623)
+- Add a tileFrames method to tile sources and appropriate endpoints to composite regions from multiple frames to a single output image (#629)
+- The test tile source now support frames (#631)
+
+### Improvements
+- Better handle TIFFs with missing levels and tiles (#624, #627)
+- Better report inefficient TIFFs (#626)
 
 ## Version 1.6.2
 

--- a/girder/girder_large_image/rest/tiles.py
+++ b/girder/girder_large_image/rest/tiles.py
@@ -265,6 +265,9 @@ class TilesItemResource(ItemResource):
             ('sizeX', int),
             ('sizeY', int),
             ('fractal', lambda val: val == 'true'),
+            ('frame', int),
+            ('frames', str),
+            ('monochrome', lambda val: val == 'true'),
             ('encoding', str),
         ])
 

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -289,3 +289,26 @@ def testConverterMissingTiles(tmpdir):
     large_image_converter.convert(imagePath, outputPath)
     info = tifftools.read_tiff(outputPath)
     assert len(info['ifds']) == 6
+
+
+def testConvertFromTestSourceFrames(tmpdir):
+    outputPath = os.path.join(tmpdir, 'out.tiff')
+    large_image_converter.convert('large_image://test?maxLevel=3&frames=4', outputPath)
+    source = large_image_source_tiff.open(outputPath)
+    metadata = source.getMetadata()
+    assert metadata['levels'] == 4
+    assert len(metadata['frames']) == 4
+    info = tifftools.read_tiff(outputPath)
+    assert len(info['ifds']) == 4
+
+
+def testConvertFromTestSourceFrameArray(tmpdir):
+    outputPath = os.path.join(tmpdir, 'out.tiff')
+    large_image_converter.convert(
+        'large_image://test?maxLevel=3&frames=2,3&monochrome=true', outputPath)
+    source = large_image_source_tiff.open(outputPath)
+    metadata = source.getMetadata()
+    assert metadata['levels'] == 4
+    assert len(metadata['frames']) == 6
+    info = tifftools.read_tiff(outputPath)
+    assert len(info['ifds']) == 6

--- a/utilities/converter/large_image_converter/__init__.py
+++ b/utilities/converter/large_image_converter/__init__.py
@@ -53,10 +53,19 @@ def _data_from_large_image(path, outputPath, **kwargs):
         readable by large_image.
     """
     _import_pyvips()
-    try:
-        ts = large_image.getTileSource(path)
-    except Exception:
-        return
+    if not path.startswith('large_image://test'):
+        try:
+            ts = large_image.getTileSource(path)
+        except Exception:
+            return
+    else:
+        import urllib.parse
+
+        tsparams = {
+            k: int(v[0]) if v[0].isdigit() else v[0]
+            for k, v in urllib.parse.parse_qs(
+                path.split('?', 1)[1] if '?' in path else '').items()}
+        ts = large_image.getTileSource('large_image://test', **tsparams)
     results = {
         'metadata': ts.getMetadata(),
         'internal_metadata': ts.getInternalMetadata(),

--- a/utilities/converter/large_image_converter/__main__.py
+++ b/utilities/converter/large_image_converter/__main__.py
@@ -212,7 +212,7 @@ def main(args=sys.argv[1:]):
     except ImportError:
         pass
     logger.debug('Command line options: %r' % opts)
-    if not os.path.isfile(opts.source):
+    if not os.path.isfile(opts.source) and not opts.source.startswith('large_image://test'):
         logger.error('Source is not a file (%s)', opts.source)
         return 1
     if opts.compression == 'zip':


### PR DESCRIPTION
Allow using the test tile source as an input to the converter to make it easier to test some behavior and to generate test files.