### PR TITLE
Better associated image cache control.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Improvements
+- More control over associated image caching
+
 ## Version 1.7.0
 
 ### Features

--- a/girder/test_girder/test_large_image.py
+++ b/girder/test_girder/test_large_image.py
@@ -308,10 +308,23 @@ def testAssociateImageCaching(server, admin, user, fsAssetstore):
     resp = server.request(path='/large_image/associated_images', user=admin)
     assert utilities.respStatus(resp) == 200
     assert resp.json == 1
+    resp = server.request(path='/large_image/associated_images', user=admin, params={
+        'imageKey': 'label'})
+    assert utilities.respStatus(resp) == 200
+    assert resp.json == 1
+    resp = server.request(path='/large_image/associated_images', user=admin, params={
+        'imageKey': 'macro'})
+    assert utilities.respStatus(resp) == 200
+    assert resp.json == 0
     # Test DELETE associated_images
     resp = server.request(
         method='DELETE', path='/large_image/associated_images', user=user)
     assert utilities.respStatus(resp) == 403
+    resp = server.request(
+        method='DELETE', path='/large_image/associated_images', user=admin, params={
+            'imageKey': 'macro'})
+    assert utilities.respStatus(resp) == 200
+    assert resp.json == 0
     resp = server.request(
         method='DELETE', path='/large_image/associated_images', user=admin)
     assert utilities.respStatus(resp) == 200


### PR DESCRIPTION
Before, the per-image cache count was for all images (thumbnails, thumbnails of associated images, etc).  Now it is by type.  Further, a specific imageKey can be queried or deleted independently of the others (e.g., just macro).