### PR TITLE
Improve geospatial bounds in some projections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 ### Improvements
-- More control over associated image caching
+- More control over associated image caching (#638)
+- Better handling some geospatial bounds (#639)
 
 ## Version 1.7.0
 

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -456,8 +456,18 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                     yBound = 90.0
                 except RuntimeError:
                     yBound = 89.999999
-                for key in ('ll', 'ul', 'lr', 'ur'):
+                keys = ('ll', 'ul', 'lr', 'ur')
+                for key in keys:
                     bounds[key]['y'] = max(min(bounds[key]['y'], yBound), -yBound)
+                while any(bounds[key]['x'] > 180 for key in keys):
+                    for key in keys:
+                        bounds[key]['x'] -= 360
+                while any(bounds[key]['x'] < -180 for key in keys):
+                    for key in keys:
+                        bounds[key]['x'] += 360
+                if any(bounds[key]['x'] >= 180 for key in keys):
+                    bounds['ul']['x'] = bounds['ll']['x'] = -180
+                    bounds['ur']['x'] = bounds['lr']['x'] = 180
             if srs and srs != nativeSrs:
                 inProj = self._proj4Proj(nativeSrs)
                 outProj = self._proj4Proj(srs)

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -283,8 +283,8 @@ def testGuardAgainstBadLatLong():
     source = large_image_source_gdal.open(imagePath)
     bounds = source.getBounds(srs='EPSG:4326')
 
-    assert bounds['xmin'] == -180.00416667
-    assert bounds['xmax'] == 179.99583333
+    assert bounds['xmin'] == -180
+    assert bounds['xmax'] == 180
     assert bounds['ymin'] == -89.99583333
     assert bounds['ymax'] == 90
 

--- a/test/test_source_mapnik.py
+++ b/test/test_source_mapnik.py
@@ -328,8 +328,8 @@ def testGuardAgainstBadLatLong():
     source = large_image_source_mapnik.open(imagePath)
     bounds = source.getBounds(srs='EPSG:4326')
 
-    assert bounds['xmin'] == -180.00416667
-    assert bounds['xmax'] == 179.99583333
+    assert bounds['xmin'] == -180
+    assert bounds['xmax'] == 180
     assert bounds['ymin'] == -89.99583333
     assert bounds['ymax'] == 90
 


### PR DESCRIPTION
When some files that wrap around the globe had their bounds calculated, instead of it being the entire span of longitude, it was a singular longitude value.