### PR TITLE
Add a deepzoom tile source

### DIFF
--- a/.circleci/make_wheels.sh
+++ b/.circleci/make_wheels.sh
@@ -23,6 +23,8 @@ cd "$ROOTPATH/utilities/tasks"
 pip wheel . --no-deps -w ~/wheels && rm -rf build
 cd "$ROOTPATH/sources/bioformats"
 pip wheel . --no-deps -w ~/wheels && rm -rf build
+cd "$ROOTPATH/sources/deepzoom"
+pip wheel . --no-deps -w ~/wheels && rm -rf build
 cd "$ROOTPATH/sources/dummy"
 pip wheel . --no-deps -w ~/wheels && rm -rf build
 cd "$ROOTPATH/sources/gdal"

--- a/.circleci/release_pypi.sh
+++ b/.circleci/release_pypi.sh
@@ -35,6 +35,11 @@ python setup.py sdist
 cp "$ROOTPATH/README.rst" .
 pip wheel . --no-deps -w dist
 twine upload --verbose dist/*
+cd "$ROOTPATH/sources/deepzoom"
+python setup.py sdist
+cp "$ROOTPATH/README.rst" .
+pip wheel . --no-deps -w dist
+twine upload --verbose dist/*
 cd "$ROOTPATH/sources/dummy"
 python setup.py sdist
 cp "$ROOTPATH/README.rst" .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Features
+- Deepzoom tile source (#641)
+
 ## Version 1.7.1
 
 ### Improvements

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,8 @@ Large Image consists of several Python modules designed to work together.  These
 
   - ``large-image-source-bioformats``: A tile source for reading any file handled by the Java Bioformats library.
 
+  - ``large-image-source-deepzoom``: A tile source for reading Deepzoom tiles.
+
   - ``large-image-source-test``: A tile source that generates test tiles, including a simple fractal pattern.  Useful for testing extreme zoom levels.
 
   - ``large-image-source-dummy``: A tile source that does nothing.

--- a/docs/make_docs.sh
+++ b/docs/make_docs.sh
@@ -10,6 +10,8 @@ stat make_docs.sh
 large_image_converter --help > source/large_image_converter.txt
 
 sphinx-apidoc -f -o source/large_image ../large_image
+sphinx-apidoc -f -o source/large_image_source_bioformats ../sources/bioformats/large_image_source_bioformats
+sphinx-apidoc -f -o source/large_image_source_deepzoom ../sources/deepzoom/large_image_source_deepzoom
 sphinx-apidoc -f -o source/large_image_source_dummy ../sources/dummy/large_image_source_dummy
 sphinx-apidoc -f -o source/large_image_source_gdal ../sources/gdal/large_image_source_gdal
 sphinx-apidoc -f -o source/large_image_source_mapnik ../sources/mapnik/large_image_source_mapnik

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,8 @@ large_image also works as a Girder plugin with optional annotation support.
    config_options
    image_conversion
    large_image/modules
+   large_image_source_bioformats/modules
+   large_image_source_deepzoom/modules
    large_image_source_dummy/modules
    large_image_source_gdal/modules
    large_image_source_mapnik/modules

--- a/girder/test_girder/test_large_image.py
+++ b/girder/test_girder/test_large_image.py
@@ -224,6 +224,7 @@ def testThumbnailFileJob(server, admin, user, fsAssetstore):
     Setting().set(constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES, 0)
 
 
+@pytest.mark.singular
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testDeleteIncompleteTile(server, admin, user, fsAssetstore, unavailableWorker):

--- a/girder/test_girder/test_tiles_rest.py
+++ b/girder/test_girder/test_tiles_rest.py
@@ -398,6 +398,7 @@ def testTilesFromTest(server, admin, fsAssetstore):
         _createTestTiles(server, admin, {key: badParams[key]}, error=err)
 
 
+@pytest.mark.singular
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesFromPNG(boundServer, admin, fsAssetstore, girderWorker):
@@ -448,6 +449,7 @@ def testTilesFromPNG(boundServer, admin, fsAssetstore, girderWorker):
     assert 'No large image file' in resp.json['message']
 
 
+@pytest.mark.singular
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesDeleteJob(boundServer, admin, fsAssetstore, girderWorker):
@@ -472,6 +474,7 @@ def testTilesDeleteJob(boundServer, admin, fsAssetstore, girderWorker):
     assert tileMetadata['levels'] == 7
 
 
+@pytest.mark.singular
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesFromGreyscale(boundServer, admin, fsAssetstore, girderWorker):
@@ -490,6 +493,7 @@ def testTilesFromGreyscale(boundServer, admin, fsAssetstore, girderWorker):
     _testTilesZXY(boundServer, admin, itemId, tileMetadata)
 
 
+@pytest.mark.singular
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesFromUnicodeName(boundServer, admin, fsAssetstore, girderWorker):
@@ -541,6 +545,7 @@ def testTilesWithUnicodeName(server, admin, fsAssetstore):
     assert tileMetadata['sizeY'] == 12288
 
 
+@pytest.mark.singular
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesFromBadFiles(boundServer, admin, fsAssetstore, girderWorker):
@@ -1010,6 +1015,7 @@ def testTilesDZIEndpoints(server, admin, fsAssetstore):
     assert height == 260
 
 
+@pytest.mark.singular
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesAfterCopyItem(boundServer, admin, fsAssetstore, girderWorker):
@@ -1212,6 +1218,7 @@ def testTilesBandInformationWithFrames(server, admin, fsAssetstore):
     assert resp != resp2
 
 
+@pytest.mark.singular
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesFromMultipleDotName(boundServer, admin, fsAssetstore, girderWorker):
@@ -1231,6 +1238,7 @@ def testTilesFromMultipleDotName(boundServer, admin, fsAssetstore, girderWorker)
     _testTilesZXY(boundServer, admin, itemId, tileMetadata)
 
 
+@pytest.mark.singular
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesForcedConversion(boundServer, admin, fsAssetstore, girderWorker):
@@ -1248,6 +1256,7 @@ def testTilesForcedConversion(boundServer, admin, fsAssetstore, girderWorker):
     assert item['largeImage']['fileId'] != fileId
 
 
+@pytest.mark.singular
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesFromWithOptions(boundServer, admin, fsAssetstore, girderWorker):
@@ -1293,6 +1302,7 @@ def testTilesConvertLocal(boundServer, admin, fsAssetstore):
     _testTilesZXY(boundServer, admin, itemId, tileMetadata)
 
 
+@pytest.mark.singular
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesConvertRemote(boundServer, admin, fsAssetstore, girderWorker):

--- a/girder/test_girder/test_web_client.py
+++ b/girder/test_girder/test_web_client.py
@@ -4,6 +4,7 @@ import pytest
 from pytest_girder.web_client import runWebClientTest
 
 
+@pytest.mark.singular
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 @pytest.mark.parametrize('spec', (

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ girder>=3.0.4 ; python_version < '3.8'
 girder>=3.0.13.dev6 ; python_version >= '3.8'
 girder-jobs>=3.0.3
 -e sources/bioformats
+-e sources/deepzoom
 -e sources/dummy
 -e sources/gdal
 -e sources/nd2

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -1,4 +1,5 @@
 -e sources/bioformats
+-e sources/deepzoom
 -e sources/dummy
 -e sources/gdal
 -e sources/nd2

--- a/sources/deepzoom/large_image_source_deepzoom/__init__.py
+++ b/sources/deepzoom/large_image_source_deepzoom/__init__.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+
+import builtins
+import math
+import os
+from xml.etree import ElementTree
+
+import PIL.Image
+
+from large_image import config
+from large_image.cache_util import LruCacheMetaclass, methodcache
+from large_image.constants import TILE_FORMAT_NUMPY, SourcePriority
+from large_image.exceptions import TileSourceException
+from large_image.tilesource import FileTileSource, etreeToDict
+
+
+class DeepzoomFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
+    """
+    Provides tile access to a Deepzoom xml (dzi) file and associated pngs/jpegs
+    in relative folders on the local file system.
+    """
+
+    cacheName = 'tilesource'
+    name = 'deepzoomfile'
+    extensions = {
+        None: SourcePriority.LOW,
+        'dzi': SourcePriority.HIGH,
+    }
+    mimeTypes = {
+        None: SourcePriority.FALLBACK,
+    }
+
+    def __init__(self, path, **kwargs):
+        """
+        Initialize the tile class.  See the base class for other available
+        parameters.
+
+        :param path: a filesystem path for the tile source.
+        """
+        super(DeepzoomFileTileSource, self).__init__(path, **kwargs)
+
+        self._largeImagePath = self._getLargeImagePath()
+        self._logger = config.getConfig('logger')
+        # Read the root dzi file and check that the expected image files exist
+        try:
+            with builtins.open(self._largeImagePath) as fptr:
+                if fptr.read(1024).strip()[:5] != '<?xml':
+                    raise TileSourceException('File cannot be opened via deepzoom reader.')
+                fptr.seek(0)
+            xml = ElementTree.parse(self._largeImagePath).getroot()
+            self._info = etreeToDict(xml)['Image']
+        except (ElementTree.ParseError, KeyError, UnicodeDecodeError):
+            raise TileSourceException('File cannot be opened via Deepzoom reader.')
+        # We should now have a dictionary like
+        # {'Format': 'png',   # or 'jpeg'
+        #  'Overlap': '1',
+        #  'Size': {'Height': '41784', 'Width': '44998'},
+        #  'TileSize': '254'}
+        # and a file structure like
+        # <rootname>_files/<level>/<x>_<y>.<format>
+        # images will be TileSize+Overlap square; final images will be
+        # truncated.  Base level is either 0 or probably 8 (level 0 is a 1x1
+        # pixel tile)
+        self.sizeX = int(self._info['Size']['Width'])
+        self.sizeY = int(self._info['Size']['Height'])
+        self.tileWidth = self.tileHeight = int(self._info['TileSize'])
+        maxXY = max(self.sizeX, self.sizeY)
+        self.levels = int(math.ceil(
+            math.log(maxXY / self.tileWidth) / math.log(2))) + 1
+        tiledirName = os.path.splitext(os.path.basename(self._largeImagePath))[0] + '_files'
+        rootdir = os.path.dirname(self._largeImagePath)
+        self._tiledir = os.path.join(rootdir, tiledirName)
+        if not os.path.isdir(self._tiledir):
+            rootdir = os.path.dirname(rootdir)
+            self._tiledir = os.path.join(rootdir, tiledirName)
+        zeroname = '0_0.%s' % self._info['Format']
+        self._nested = os.path.isdir(os.path.join(self._tiledir, '0', zeroname))
+        zeroimg = PIL.Image.open(
+            os.path.join(self._tiledir, '0', zeroname) if not self._nested else
+            os.path.join(self._tiledir, '0', zeroname, zeroname))
+        if zeroimg.size == (1, 1):
+            self._baselevel = int(
+                math.ceil(math.log(maxXY) / math.log(2)) -
+                math.ceil(math.log(maxXY / self.tileWidth) / math.log(2)))
+        else:
+            self._baselevel = 0
+
+    def getInternalMetadata(self, **kwargs):
+        """
+        Return additional known metadata about the tile source.  Data returned
+        from this method is not guaranteed to be in any particular format or
+        have specific values.
+
+        :returns: a dictionary of data or None.
+        """
+        result = {}
+        result['deepzoom'] = self._info
+        result['baselevel'] = self._baselevel
+        return result
+
+    @methodcache()
+    def getTile(self, x, y, z, pilImageAllowed=False, numpyAllowed=False, **kwargs):
+        self._xyzInRange(x, y, z)
+        tilename = '%d_%d.%s' % (x, y, self._info['Format'])
+        tilepath = os.path.join(self._tiledir, '%d' % (self._baselevel + z), tilename)
+        if self._nested:
+            tilepath = os.path.join(tilepath, tilename)
+        tile = PIL.Image.open(tilepath)
+        overlap = int(self._info.get('Overlap', 0))
+        tile = tile.crop((
+            overlap if x else 0, overlap if y else 0,
+            self.tileWidth + (overlap if x else 0),
+            self.tileHeight + (overlap if y else 0)))
+        return self._outputTile(tile, TILE_FORMAT_NUMPY, x, y, z,
+                                pilImageAllowed, numpyAllowed, **kwargs)
+
+
+def open(*args, **kwargs):
+    """Create an instance of the module class."""
+    return DeepzoomFileTileSource(*args, **kwargs)
+
+
+def canRead(*args, **kwargs):
+    """Check if an input can be read by the module class."""
+    return DeepzoomFileTileSource.canRead(*args, **kwargs)

--- a/sources/deepzoom/large_image_source_deepzoom/girder_source.py
+++ b/sources/deepzoom/large_image_source_deepzoom/girder_source.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from girder_large_image.girder_tilesource import GirderTileSource
+
+from . import DeepzoomFileTileSource
+
+
+class DeepzoomGirderTileSource(DeepzoomFileTileSource, GirderTileSource):
+    """
+    Deepzoom large_image tile source for Girder.
+
+    Provides tile access to Girder items with a Deepzoom xml (dzi) file and
+    associated pngs/jpegs in relative folders and items or on the local file
+    system.
+    """
+
+    cacheName = 'tilesource'
+    name = 'deepzoom'
+
+    _mayHaveAdjacentFiles = True

--- a/sources/deepzoom/setup.py
+++ b/sources/deepzoom/setup.py
@@ -1,0 +1,59 @@
+import os
+
+from setuptools import find_packages, setup
+
+
+def prerelease_local_scheme(version):
+    """
+    Return local scheme version unless building on master in CircleCI.
+
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') in ('master', ):
+        return ''
+    else:
+        return get_local_node_and_date(version)
+
+
+setup(
+    name='large-image-source-deepzoom',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm'],
+    description='A deepzoom tilesource for large_image',
+    long_description='See the large-image package for more details.',
+    author='Kitware, Inc.',
+    author_email='kitware@kitware.com',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+    ],
+    install_requires=[
+        'large-image>=1.0.0',
+    ],
+    extras_require={
+        'girder': 'girder-large-image>=1.0.0',
+    },
+    license='Apache Software License 2.0',
+    keywords='large_image, tile source',
+    packages=find_packages(exclude=['test', 'test.*']),
+    url='https://github.com/girder/large_image',
+    python_requires='>=3.6',
+    entry_points={
+        'large_image.source': [
+            'deepzoom = large_image_source_deepzoom:DeepzoomFileTileSource'
+        ],
+        'girder_large_image.source': [
+            'deepzoom = large_image_source_deepzoom.girder_source:DeepzoomGirderTileSource'
+        ]
+    },
+)

--- a/test/test_source_deepzoom.py
+++ b/test/test_source_deepzoom.py
@@ -1,0 +1,53 @@
+import os
+
+import large_image_source_deepzoom
+import pytest
+import pyvips
+
+from . import utilities
+from .datastore import datastore
+
+
+@pytest.fixture
+def vipsToDzi(tmpdir):
+    def convert(imagePath, options=None):
+        if options is None:
+            options = {}
+        image = pyvips.Image.new_from_file(imagePath)
+        outputPath = os.path.join(tmpdir, 'out')
+        image.dzsave(outputPath, **options)
+        outputPath += '.dzi'
+        return outputPath
+    yield convert
+
+
+@pytest.mark.parametrize('dzoptions', [
+    {},
+    {'depth': 'onetile'},
+    {'suffix': '.png'},
+    {'suffix': '.jpeg'},
+    {'tile_width': 192, 'tile_height': 192, 'overlap': 6},
+])
+def testTilesFromDeepzoom(vipsToDzi, dzoptions):
+    imagePath = datastore.fetch('G10-3_pelvis_crop-powers-of-3.tif')
+    dziPath = vipsToDzi(imagePath, options=dzoptions)
+    source = large_image_source_deepzoom.open(dziPath)
+    tileMetadata = source.getMetadata()
+    assert tileMetadata['sizeX'] == 3000
+    assert tileMetadata['sizeY'] == 5000
+    utilities.checkTilesZXY(source, tileMetadata)
+
+
+def testInternalMetadata(vipsToDzi):
+    imagePath = datastore.fetch('G10-3_pelvis_crop-powers-of-3.tif')
+    dziPath = vipsToDzi(imagePath)
+    source = large_image_source_deepzoom.open(dziPath)
+    metadata = source.getInternalMetadata()
+    assert 'baselevel' in metadata
+
+
+def testCanRead(vipsToDzi):
+    imagePath = datastore.fetch('G10-3_pelvis_crop-powers-of-3.tif')
+    dziPath = vipsToDzi(imagePath)
+    assert large_image_source_deepzoom.canRead(imagePath) is False
+    assert large_image_source_deepzoom.canRead(dziPath) is True

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,8 @@ whitelist_externals =
 commands =
   rm -rf build/test/coverage/web_temp
   girder build --dev
-  pytest --numprocesses logical -m 'not singular' --cov-config setup.cfg {posargs}
-  pytest -m 'singular' --cov-config setup.cfg --cov-append {posargs}
+  pytest -m 'singular' --cov-config setup.cfg {posargs}
+  pytest --numprocesses logical -m 'not singular' --cov-config setup.cfg --cov-append {posargs}
   - npx nyc report --temp-dir build/test/coverage/web_temp --report-dir build/test/coverage --reporter cobertura --reporter text-summary
 # Reduce npm chatter
 setenv =


### PR DESCRIPTION
This works with the dzi files as output by vips in both onetile and onepixel modes and with both png and jpeg compression.  It should allow for any tile size and overlap as generated by vips.

A future expansion would be to read property files and handle center and other options in dzsave.

Closes #31.