### PR TITLE
Harden tile source detection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 - Deepzoom tile source (#641)
 
+### Bug Fixes
+- Harden tile source detection (#644)
+
 ## Version 1.7.1
 
 ### Improvements

--- a/large_image/tilesource/__init__.py
+++ b/large_image/tilesource/__init__.py
@@ -28,6 +28,8 @@ def isGeospatial(path):
         ds = gdal.Open(path, gdalconst.GA_ReadOnly)
     except Exception:
         return False
+    if ds.GetGCPs() and ds.GetGCPProjection():
+        return True
     if ds.GetProjection():
         return True
     if ds.GetDriver().ShortName in {'NITF', 'netCDF'}:

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -205,11 +205,13 @@ def _vipsCast(image, mustBe8Bit=False, originalScale=None):
     return image
 
 
-def _gdalParameters(defaultCompression=None, **kwargs):
+def _gdalParameters(defaultCompression=None, eightbit=None, **kwargs):
     """
     Return an array of gdal translation parameters.
 
     :param defaultCompression: if not specified, use this value.
+    :param eightbit: True or False to indicate that the bit depth per sample is
+        known.  None for unknown.
 
     Optional parameters that can be specified in kwargs:
 
@@ -227,8 +229,9 @@ def _gdalParameters(defaultCompression=None, **kwargs):
         'tileSize': 256,
         'compression': 'lzw',
         'quality': 90,
-        'predictor': 'yes',
     }
+    if eightbit is not None:
+        options['predictor'] = 'yes' if eightbit else 'none'
     predictor = {
         'none': 'NO',
         'horizontal': 'STANDARD',
@@ -240,7 +243,8 @@ def _gdalParameters(defaultCompression=None, **kwargs):
     cmdopt += ['-co', 'BLOCKSIZE=%d' % options['tileSize']]
     cmdopt += ['-co', 'COMPRESS=%s' % options['compression'].upper()]
     cmdopt += ['-co', 'QUALITY=%s' % options['quality']]
-    cmdopt += ['-co', 'PREDICTOR=%s' % predictor[options['predictor']]]
+    if 'predictor' in options:
+        cmdopt += ['-co', 'PREDICTOR=%s' % predictor[options['predictor']]]
     if 'level' in options:
         cmdopt += ['-co', 'LEVEL=%s' % options['level']]
     return cmdopt

--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -160,7 +160,7 @@ class BioformatsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             javabridge.attach()
             try:
                 self._bioimage = bioformats.ImageReader(largeImagePath)
-            except AttributeError as exc:
+            except (AttributeError, FileNotFoundError) as exc:
                 self.logger.debug('File cannot be opened via Bioformats. (%r)' % exc)
                 raise TileSourceException('File cannot be opened via Bioformats. (%r)' % exc)
             _openImages.append(self)

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -71,6 +71,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
     name = 'gdalfile'
     extensions = {
         None: SourcePriority.MEDIUM,
+        'geotiff': SourcePriority.PREFERRED,
         # National Imagery Transmission Format
         'ntf': SourcePriority.PREFERRED,
         'nitf': SourcePriority.PREFERRED,


### PR DESCRIPTION
Detecting geospatial files was brittler than intended.  Bioformats throws poor errors.