### PR TITLE
Band interpretation for high bands errored.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Bug Fixes
+- getBandInformation could fail on high bands in some cases
+
 ## Version 1.8.0
 
 ### Features

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1344,7 +1344,7 @@ class TileSource:
                 if not getattr(self, '_bandInfoNoStats', None):
                     tile = self.getSingleTile()['tile']
                     bands = tile.shape[2] if len(tile.shape) > 2 else 1
-                    interp = bandInterp.get(bands, 3)
+                    interp = bandInterp.get(bands, bandInterp[3])
                     bandInfo = [{'interpretation': interp[idx] if idx < len(interp) else 'unknown'}
                                 for idx in range(bands)]
                     self._bandInfoNoStats = bandInfo


### PR DESCRIPTION
If there were more than four bands and the band interpretation is not known, an error was thrown instead of returning `unknown`.