### PR TITLE
Allow GDAL to read non-geospatial files.

### DIFF
--- a/girder/test_girder/test_tiles_rest.py
+++ b/girder/test_girder/test_tiles_rest.py
@@ -481,7 +481,8 @@ def testTilesFromGreyscale(boundServer, admin, fsAssetstore, girderWorker):
     file = utilities.uploadTestFile('grey10kx5k.tif', admin, fsAssetstore)
     itemId = str(file['itemId'])
     fileId = str(file['_id'])
-    tileMetadata = _postTileViaHttp(boundServer, admin, itemId, fileId)
+    boundServer.request(path='/item/%s/tiles' % itemId, method='DELETE', user=admin)
+    tileMetadata = _postTileViaHttp(boundServer, admin, itemId, fileId, data={'force': True})
     assert tileMetadata['tileWidth'] == 256
     assert tileMetadata['tileHeight'] == 256
     assert tileMetadata['sizeX'] == 10000

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -134,10 +134,12 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             scale = self.getPixelSizeInMeters()
         except RuntimeError:
             raise TileSourceException('File cannot be opened via GDAL.')
-        if not scale and not is_netcdf:
+        if (self.projection or self._getDriver() in {
+            'PNG',
+        }) and not scale and not is_netcdf:
             raise TileSourceException(
                 'File does not have a projected scale, so will not be '
-                'opened via GDAL.')
+                'opened via GDAL with a projection.')
         self.sourceLevels = self.levels = int(max(0, math.ceil(max(
             math.log(float(self.sizeX) / self.tileWidth),
             math.log(float(self.sizeY) / self.tileHeight)) / math.log(2))) + 1)

--- a/sources/openjpeg/large_image_source_openjpeg/__init__.py
+++ b/sources/openjpeg/large_image_source_openjpeg/__init__.py
@@ -19,6 +19,7 @@ import io
 import math
 import multiprocessing
 import queue
+import struct
 import warnings
 from xml.etree import ElementTree
 
@@ -90,7 +91,7 @@ class OpenjpegFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         self._pixelInfo = {}
         try:
             self._openjpeg = glymur.Jp2k(largeImagePath)
-        except glymur.jp2box.InvalidJp2kError:
+        except (glymur.jp2box.InvalidJp2kError, struct.error):
             raise TileSourceException('File cannot be opened via Glymur and OpenJPEG.')
         glymur.set_option('lib.num_threads', multiprocessing.cpu_count())
         self._openjpegHandles = queue.LifoQueue()


### PR DESCRIPTION
This will be lower priority than non-geospatial sources.

Closes #652.  GDAL should support ENVI format.