### PR TITLE
Rename Exceptions to Errors.

### DIFF
--- a/girder/girder_large_image/girder_tilesource.py
+++ b/girder/girder_large_image/girder_tilesource.py
@@ -4,7 +4,7 @@ from girder.models.file import File
 from girder.models.item import Item
 from large_image import tilesource
 from large_image.constants import SourcePriority
-from large_image.exceptions import TileSourceAssetstoreException, TileSourceException
+from large_image.exceptions import TileSourceAssetstoreError, TileSourceError
 
 AvailableGirderTileSources = {}
 KnownMimeTypes = set()
@@ -101,13 +101,13 @@ class GirderTileSource(tilesource.FileTileSource):
                 try:
                     largeImagePath = File().getLocalFilePath(largeImageFile)
                 except AttributeError as e:
-                    raise TileSourceException(
+                    raise TileSourceError(
                         'No local file path for this file: %s' % e.args[0])
             return largeImagePath
-        except (TileSourceAssetstoreException, FilePathException):
+        except (TileSourceAssetstoreError, FilePathException):
             raise
-        except (KeyError, ValidationException, TileSourceException) as e:
-            raise TileSourceException(
+        except (KeyError, ValidationException, TileSourceError) as e:
+            raise TileSourceError(
                 'No large image file in this item: %s' % e.args[0])
 
 

--- a/girder/girder_large_image/rest/large_image_resource.py
+++ b/girder/girder_large_image/rest/large_image_resource.py
@@ -34,7 +34,7 @@ from girder.models.file import File
 from girder.models.item import Item
 from girder.models.setting import Setting
 from large_image import cache_util
-from large_image.exceptions import TileGeneralException
+from large_image.exceptions import TileGeneralError
 
 from .. import constants, girder_tilesource
 from ..models.image_item import ImageItem
@@ -56,7 +56,7 @@ def createThumbnailsJobTask(item, spec):
             else:
                 result = ImageItem().getThumbnail(item, checkAndCreate=True, **entry)
             status['checked' if result is True else 'created'] += 1
-        except TileGeneralException as exc:
+        except TileGeneralError as exc:
             status['failed'] += 1
             status['lastFailed'] = str(item['_id'])
             logger.info('Failed to get thumbnail for item %s: %r' % (item['_id'], exc))

--- a/girder/girder_large_image/rest/tiles.py
+++ b/girder/girder_large_image/rest/tiles.py
@@ -34,7 +34,7 @@ from girder.models.item import Item
 from girder.utility.progress import setResponseTimeLimit
 from large_image.cache_util import strhash
 from large_image.constants import TileInputUnits
-from large_image.exceptions import TileGeneralException
+from large_image.exceptions import TileGeneralError
 
 from .. import loadmodelcache
 from ..models.image_item import ImageItem
@@ -188,7 +188,7 @@ class TilesItemResource(ItemResource):
                 createJob='always' if self.boolParam('force', params, default=False) else True,
                 notify=notify,
                 **params)
-        except TileGeneralException as e:
+        except TileGeneralError as e:
             raise RestException(e.args[0])
 
     @describeRoute(
@@ -251,7 +251,7 @@ class TilesItemResource(ItemResource):
         try:
             return self.imageItemModel.convertImage(
                 item, largeImageFile, user, token, localJob=localJob, **params)
-        except TileGeneralException as e:
+        except TileGeneralError as e:
             raise RestException(e.args[0])
 
     @classmethod
@@ -325,7 +325,7 @@ class TilesItemResource(ItemResource):
         """
         try:
             return self.imageItemModel.getMetadata(item, **imageArgs)
-        except TileGeneralException as e:
+        except TileGeneralError as e:
             raise RestException(e.args[0], code=400)
 
     def _setContentDisposition(self, item, contentDisposition, mime, subname, fullFilename=None):
@@ -383,7 +383,7 @@ class TilesItemResource(ItemResource):
     def getInternalMetadata(self, item, params):
         try:
             return self.imageItemModel.getInternalMetadata(item, **params)
-        except TileGeneralException as e:
+        except TileGeneralError as e:
             raise RestException(e.args[0], code=400)
 
     @describeRoute(
@@ -462,7 +462,7 @@ class TilesItemResource(ItemResource):
             try:
                 tileData, tileMime = self.imageItemModel.getTile(
                     item, x, y, z, mayRedirect=mayRedirect, **imageArgs)
-            except TileGeneralException as e:
+            except TileGeneralError as e:
                 raise RestException(e.args[0], code=404)
         setResponseHeader('Content-Type', tileMime)
         setRawResponse()
@@ -690,7 +690,7 @@ class TilesItemResource(ItemResource):
         _handleETag('getTilesThumbnail', item, params)
         try:
             result = self.imageItemModel.getThumbnail(item, **params)
-        except TileGeneralException as e:
+        except TileGeneralError as e:
             raise RestException(e.args[0])
         except ValueError as e:
             raise RestException('Value Error: %s' % e.args[0])
@@ -828,7 +828,7 @@ class TilesItemResource(ItemResource):
         try:
             regionData, regionMime = self.imageItemModel.getRegion(
                 item, **params)
-        except TileGeneralException as e:
+        except TileGeneralError as e:
             raise RestException(e.args[0])
         except ValueError as e:
             raise RestException('Value Error: %s' % e.args[0])
@@ -884,7 +884,7 @@ class TilesItemResource(ItemResource):
         ])
         try:
             pixel = self.imageItemModel.getPixel(item, **params)
-        except TileGeneralException as e:
+        except TileGeneralError as e:
             raise RestException(e.args[0])
         except ValueError as e:
             raise RestException('Value Error: %s' % e.args[0])
@@ -1005,7 +1005,7 @@ class TilesItemResource(ItemResource):
     def getAssociatedImagesList(self, item, params):
         try:
             return self.imageItemModel.getAssociatedImagesList(item)
-        except TileGeneralException as e:
+        except TileGeneralError as e:
             raise RestException(e.args[0], code=400)
 
     @describeRoute(
@@ -1049,7 +1049,7 @@ class TilesItemResource(ItemResource):
         _handleETag('getAssociatedImage', item, image, params)
         try:
             result = self.imageItemModel.getAssociatedImage(item, image, **params)
-        except TileGeneralException as e:
+        except TileGeneralError as e:
             raise RestException(e.args[0], code=400)
         if not isinstance(result, tuple):
             return result
@@ -1217,7 +1217,7 @@ class TilesItemResource(ItemResource):
         try:
             result = self.imageItemModel.tileFrames(
                 item, checkAndCreate=checkAndCreate, **params)
-        except TileGeneralException as e:
+        except TileGeneralError as e:
             raise RestException(e.args[0])
         except ValueError as e:
             raise RestException('Value Error: %s' % e.args[0])

--- a/girder/test_girder/test_web_client.py
+++ b/girder/test_girder/test_web_client.py
@@ -9,8 +9,17 @@ from pytest_girder.web_client import runWebClientTest
 @pytest.mark.plugin('large_image')
 @pytest.mark.parametrize('spec', (
     'imageViewerSpec.js',
-    'largeImageSpec.js',
 ))
 def testWebClient(boundServer, fsAssetstore, db, spec, girderWorker):
+    spec = os.path.join(os.path.dirname(__file__), 'web_client_specs', spec)
+    runWebClientTest(boundServer, spec, 15000)
+
+
+@pytest.mark.usefixtures('unbindLargeImage')
+@pytest.mark.plugin('large_image')
+@pytest.mark.parametrize('spec', (
+    'largeImageSpec.js',
+))
+def testWebClientNoWorker(boundServer, fsAssetstore, db, spec):
     spec = os.path.join(os.path.dirname(__file__), 'web_client_specs', spec)
     runWebClientTest(boundServer, spec, 15000)

--- a/large_image/exceptions.py
+++ b/large_image/exceptions.py
@@ -1,10 +1,23 @@
-class TileGeneralException(Exception):
+import errno
+
+
+class TileGeneralError(Exception):
     pass
 
 
-class TileSourceException(TileGeneralException):
+class TileSourceError(TileGeneralError):
     pass
 
 
-class TileSourceAssetstoreException(TileSourceException):
+class TileSourceAssetstoreError(TileSourceError):
     pass
+
+
+class TileSourceFileNotFoundError(TileSourceError, FileNotFoundError):
+    def __init__(self, *args, **kwargs):
+        return super().__init__(errno.ENOENT, *args, **kwargs)
+
+
+TileGeneralException = TileGeneralError
+TileSourceException = TileSourceError
+TileSourceAssetstoreException = TileSourceAssetstoreError

--- a/large_image/tilesource/__init__.py
+++ b/large_image/tilesource/__init__.py
@@ -4,7 +4,10 @@ from pkg_resources import iter_entry_points
 
 from .. import config
 from ..constants import SourcePriority
-from ..exceptions import TileGeneralException, TileSourceAssetstoreException, TileSourceException
+from ..exceptions import (TileGeneralError, TileGeneralException,
+                          TileSourceAssetstoreError,
+                          TileSourceAssetstoreException, TileSourceError,
+                          TileSourceException, TileSourceFileNotFoundError)
 from .base import (TILE_FORMAT_IMAGE, TILE_FORMAT_NUMPY, TILE_FORMAT_PIL,
                    FileTileSource, TileOutputMimeTypes, TileSource,
                    dictToEtree, etreeToDict, nearPowerOfTwo)
@@ -108,7 +111,7 @@ def getTileSourceFromDict(availableSources, pathOrUri, *args, **kwargs):
     sourceName = getSourceNameFromDict(availableSources, pathOrUri, *args, **kwargs)
     if sourceName:
         return availableSources[sourceName](pathOrUri, *args, **kwargs)
-    raise TileSourceException('No available tilesource for %s' % pathOrUri)
+    raise TileSourceError('No available tilesource for %s' % pathOrUri)
 
 
 def getTileSource(*args, **kwargs):
@@ -151,7 +154,9 @@ def canRead(*args, **kwargs):
 
 __all__ = [
     'TileSource', 'FileTileSource',
-    'exceptions', 'TileGeneralException', 'TileSourceException', 'TileSourceAssetstoreException',
+    'exceptions', 'TileGeneralError', 'TileSourceError',
+    'TileSourceAssetstoreError', 'TileSourceFileNotFoundError',
+    'TileGeneralException', 'TileSourceException', 'TileSourceAssetstoreException',
     'TileOutputMimeTypes', 'TILE_FORMAT_IMAGE', 'TILE_FORMAT_PIL', 'TILE_FORMAT_NUMPY',
     'AvailableTileSources', 'getTileSource', 'canRead', 'getSourceNameFromDict', 'nearPowerOfTwo',
     'etreeToDict', 'dictToEtree',

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -126,7 +126,7 @@ class TileSource:
                 if not isinstance(self.style, dict):
                     raise TypeError
             except TypeError:
-                raise exceptions.TileSourceException('Style is not a valid json object.')
+                raise exceptions.TileSourceError('Style is not a valid json object.')
 
     @staticmethod
     def getLRUHash(*args, **kwargs):
@@ -1374,17 +1374,17 @@ class TileSource:
         exception if not.
         """
         if z < 0 or z >= self.levels:
-            raise exceptions.TileSourceException('z layer does not exist')
+            raise exceptions.TileSourceError('z layer does not exist')
         scale = 2 ** (self.levels - 1 - z)
         offsetx = x * self.tileWidth * scale
         if not (0 <= offsetx < self.sizeX):
-            raise exceptions.TileSourceException('x is outside layer')
+            raise exceptions.TileSourceError('x is outside layer')
         offsety = y * self.tileHeight * scale
         if not (0 <= offsety < self.sizeY):
-            raise exceptions.TileSourceException('y is outside layer')
+            raise exceptions.TileSourceError('y is outside layer')
         if frame is not None and numFrames is not None:
             if frame < 0 or frame >= numFrames:
-                raise exceptions.TileSourceException('Frame does not exist')
+                raise exceptions.TileSourceError('Frame does not exist')
 
     @methodcache()
     def getTile(self, x, y, z, pilImageAllowed=False, numpyAllowed=False,
@@ -1639,7 +1639,7 @@ class TileSource:
                     (height, width, subimage.shape[2]),
                     dtype=subimage.dtype)
             except MemoryError:
-                raise exceptions.TileSourceException(
+                raise exceptions.TileSourceError(
                     'Insufficient memory to get region of %d x %d pixels.' % (
                         width, height))
         if subimage.shape[2] > image.shape[2]:
@@ -2342,5 +2342,5 @@ class FileTileSource(TileSource):
         try:
             cls(path, *args, **kwargs)
             return True
-        except exceptions.TileSourceException:
+        except exceptions.TileSourceError:
             return False

--- a/large_image/tilesource/tiledict.py
+++ b/large_image/tilesource/tiledict.py
@@ -210,7 +210,7 @@ class LazyTileDict(dict):
                         tileData, **self.imageKwargs)
                     tileFormat = TILE_FORMAT_IMAGE
                 if tileFormat not in self.format:
-                    raise exceptions.TileSourceException(
+                    raise exceptions.TileSourceError(
                         'Cannot yield tiles in desired format %r' % (
                             self.format, ))
             else:

--- a/sources/pil/large_image_source_pil/girder_source.py
+++ b/sources/pil/large_image_source_pil/girder_source.py
@@ -21,7 +21,7 @@ from girder_large_image.girder_tilesource import GirderTileSource
 from girder.models.setting import Setting
 from large_image.cache_util import methodcache
 from large_image.constants import TILE_FORMAT_PIL
-from large_image.exceptions import TileSourceException
+from large_image.exceptions import TileSourceError
 
 from . import PILFileTileSource
 
@@ -53,11 +53,11 @@ class PILGirderTileSource(PILFileTileSource, GirderTileSource):
     def getTile(self, x, y, z, pilImageAllowed=False, numpyAllowed=False,
                 mayRedirect=False, **kwargs):
         if z != 0:
-            raise TileSourceException('z layer does not exist')
+            raise TileSourceError('z layer does not exist')
         if x != 0:
-            raise TileSourceException('x is outside layer')
+            raise TileSourceError('x is outside layer')
         if y != 0:
-            raise TileSourceException('y is outside layer')
+            raise TileSourceError('y is outside layer')
         if (mayRedirect and not pilImageAllowed and not numpyAllowed and
                 cherrypy.request and
                 self._pilFormatMatches(self._pilImage, mayRedirect, **kwargs)):

--- a/sources/test/large_image_source_test/__init__.py
+++ b/sources/test/large_image_source_test/__init__.py
@@ -23,7 +23,7 @@ from pkg_resources import DistributionNotFound, get_distribution
 
 from large_image.cache_util import LruCacheMetaclass, methodcache, strhash
 from large_image.constants import TILE_FORMAT_PIL, SourcePriority
-from large_image.exceptions import TileSourceException
+from large_image.exceptions import TileSourceError
 from large_image.tilesource import TileSource
 
 try:
@@ -169,7 +169,7 @@ class TestTileSource(TileSource, metaclass=LruCacheMetaclass):
         self._xyzInRange(x, y, z, frame, len(self._frames) if hasattr(self, '_frames') else None)
 
         if not (self.minLevel <= z <= self.maxLevel):
-            raise TileSourceException('z layer does not exist')
+            raise TileSourceError('z layer does not exist')
 
         xFraction = (x + 0.5) * self.tileWidth * 2 ** (self.levels - 1 - z) / self.sizeX
         yFraction = (y + 0.5) * self.tileHeight * 2 ** (self.levels - 1 - z) / self.sizeY

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 import large_image
 from large_image.tilesource import nearPowerOfTwo
 
@@ -23,3 +25,25 @@ def testCanRead():
 
     imagePath = datastore.fetch('sample_image.ptif')
     assert large_image.canRead(imagePath) is True
+
+
+@pytest.mark.parametrize('source', [
+    'bioformats',
+    'deepzoom',
+    # 'dummy', # exclude - no files
+    'gdal',
+    'mapnik',
+    'nd2',
+    'ometiff',
+    'openjpeg',
+    'openslide',
+    'pil',
+    # 'test', # exclude - no files
+    'tiff',
+])
+def testSourcesFileNotFound(source):
+    large_image.tilesource.loadTileSources()
+    with pytest.raises(large_image.exceptions.TileSourceFileNotFoundError):
+        large_image.tilesource.AvailableTileSources[source]('nosuchfile')
+    with pytest.raises(large_image.exceptions.TileSourceFileNotFoundError):
+        large_image.tilesource.AvailableTileSources[source]('nosuchfile.ext')

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -10,7 +10,7 @@ import PIL.ImageChops
 import pytest
 
 from large_image import constants
-from large_image.exceptions import TileSourceException
+from large_image.exceptions import TileSourceError
 
 from . import utilities
 from .datastore import datastore
@@ -106,7 +106,7 @@ def testTileLinearStyleFromGeotiffs():
 
 def testTileStyleBadInput():
     def _assertStyleResponse(imagePath, style, message):
-        with pytest.raises(TileSourceException, match=message):
+        with pytest.raises(TileSourceError, match=message):
             source = large_image_source_gdal.open(
                 imagePath, projection='EPSG:3857', style=json.dumps(style), encoding='PNG')
             source.getTile(22, 51, 7)
@@ -200,13 +200,13 @@ def testPixel():
 def testSourceErrors():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
-    with pytest.raises(TileSourceException, match='must not be geographic'):
+    with pytest.raises(TileSourceError, match='must not be geographic'):
         large_image_source_gdal.open(imagePath, 'EPSG:4326')
     imagePath = os.path.join(testDir, 'test_files', 'zero_gi.tif')
-    with pytest.raises(TileSourceException, match='cannot be opened via'):
+    with pytest.raises(TileSourceError, match='cannot be opened via'):
         large_image_source_gdal.open(imagePath)
     imagePath = os.path.join(testDir, 'test_files', 'yb10kx5k.png')
-    with pytest.raises(TileSourceException, match='does not have a projected scale'):
+    with pytest.raises(TileSourceError, match='does not have a projected scale'):
         large_image_source_gdal.open(imagePath)
 
 
@@ -215,7 +215,7 @@ def testStereographicProjection():
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
     # We will fail if we ask for a stereographic projection and don't
     # specify unitsPerPixel
-    with pytest.raises(TileSourceException, match='unitsPerPixel must be specified'):
+    with pytest.raises(TileSourceError, match='unitsPerPixel must be specified'):
         large_image_source_gdal.open(imagePath, 'EPSG:3411')
     # But will pass if unitsPerPixel is specified
     large_image_source_gdal.open(imagePath, 'EPSG:3411', unitsPerPixel=150000)
@@ -265,7 +265,7 @@ def testConvertProjectionUnits():
     assert result[1] == pytest.approx(149, 1)
     assert result[2:] == (None, None, 'base_pixels')
 
-    with pytest.raises(TileSourceException, match='Cannot convert'):
+    with pytest.raises(TileSourceError, match='Cannot convert'):
         tsNoProj._convertProjectionUnits(
             -117.5, None, -117, None, None, None, 'EPSG:4326')
 

--- a/test/test_source_mapnik.py
+++ b/test/test_source_mapnik.py
@@ -9,7 +9,7 @@ import PIL.ImageChops
 import pytest
 
 import large_image
-from large_image.exceptions import TileSourceException
+from large_image.exceptions import TileSourceError
 
 from . import utilities
 from .datastore import datastore
@@ -117,7 +117,7 @@ def testTileLinearStyleFromGeotiffs():
 
 def testTileStyleBadInput():
     def _assertStyleResponse(imagePath, style, message):
-        with pytest.raises(TileSourceException, match=message):
+        with pytest.raises(TileSourceError, match=message):
             source = large_image_source_mapnik.open(
                 imagePath, projection='EPSG:3857', style=json.dumps(style))
             source.getTile(22, 51, 7, encoding='PNG')
@@ -245,13 +245,13 @@ def testPixel():
 def testSourceErrors():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
-    with pytest.raises(TileSourceException, match='must not be geographic'):
+    with pytest.raises(TileSourceError, match='must not be geographic'):
         large_image_source_mapnik.open(imagePath, 'EPSG:4326')
     imagePath = os.path.join(testDir, 'test_files', 'zero_gi.tif')
-    with pytest.raises(TileSourceException, match='cannot be opened via'):
+    with pytest.raises(TileSourceError, match='cannot be opened via'):
         large_image_source_mapnik.open(imagePath)
     imagePath = os.path.join(testDir, 'test_files', 'yb10kx5k.png')
-    with pytest.raises(TileSourceException, match='does not have a projected scale'):
+    with pytest.raises(TileSourceError, match='does not have a projected scale'):
         large_image_source_mapnik.open(imagePath)
 
 
@@ -260,7 +260,7 @@ def testStereographicProjection():
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
     # We will fail if we ask for a stereographic projection and don't
     # specify unitsPerPixel
-    with pytest.raises(TileSourceException, match='unitsPerPixel must be specified'):
+    with pytest.raises(TileSourceError, match='unitsPerPixel must be specified'):
         large_image_source_mapnik.open(imagePath, 'EPSG:3411')
     # But will pass if unitsPerPixel is specified
     large_image_source_mapnik.open(imagePath, 'EPSG:3411', unitsPerPixel=150000)
@@ -310,7 +310,7 @@ def testConvertProjectionUnits():
     assert result[1] == pytest.approx(149, 1)
     assert result[2:] == (None, None, 'base_pixels')
 
-    with pytest.raises(TileSourceException, match='Cannot convert'):
+    with pytest.raises(TileSourceError, match='Cannot convert'):
         tsNoProj._convertProjectionUnits(
             -117.5, None, -117, None, None, None, 'EPSG:4326')
 


### PR DESCRIPTION
Add `TileSourceFileNotFoundError` when a file is attempted to be opened that doesn't exist.  This is a subclass of both `TileSourceError` and `FileNotFoundError`.

Rename exceptions to errors follows standard Python naming conventions.  Old names are still available for compatibility.

This closes #656.