### PR TITLE
Harden on openslide errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Change Log
 
-## Unreleased
+## Version 1.8.1
 
 ### Improvements
 - Allow GDAL source to read non-geospatial files (#655)
 - Rename Exceptions to Errors, improve file-not-found errors (#657)
 - More robust OME TIFF handling (#660)
 - large-image-converter can exclude specified associated images (#663)
+- Harden on some openslide errors (#664)
 
 ### Bug Fixes
 - getBandInformation could fail on high bands in some cases (#651)

--- a/sources/openslide/large_image_source_openslide/__init__.py
+++ b/sources/openslide/large_image_source_openslide/__init__.py
@@ -362,6 +362,8 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             try:
                 return self._openslide.associated_images[imageKey]
             except openslide.lowlevel.OpenSlideError:
+                # Reopen handle after a lowlevel error
+                self._openslide = openslide.OpenSlide(self._largeImagePath)
                 return None
         bytePath = self._largeImagePath
         if not isinstance(bytePath, bytes):


### PR DESCRIPTION
Specifically, after a low level error, reopen the openslide file as the existing process may be in a state that will not work.