### PR TITLE
Improve tile source locking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 - Improve warnings on inefficient tiff files ([#668](../../pull/668))
 - Add more options to setFrameQuad ([#669](../../pull/669), [#670](../../pull/670))
+- Improved concurrency of opening multiple distinct tile sources ([#671](../../pull/671))
 
 ## Version 1.8.3
 


### PR DESCRIPTION
Before, if two different tile sources using the same cache were being opened simultaneously, they would be opened sequentially due to the locking semantics.  This also prevented opening the same source twice.

Now, when a tile source is not in cache, a separate per-key lock is created for opening that source.  This prevents the same source from being opened twice but allows different sources to be opened concurrently.