### PR TITLE
Add the image converter to the extra requires.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Improvements
+- Add the image converter to the extra requires ([#677](../../pull/677))
+
 ## Version 1.8.6
 
 ### Bug Fixes

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ with open('README.rst') as readme_file:
 
 extraReqs = {
     'memcached': ['pylibmc>=1.5.1'] if platform.system() != 'Windows' else [],
+    'converter': ['large-image-converter'],
 }
 sources = {
     'bioformats': ['large-image-source-bioformats'],


### PR DESCRIPTION
If you pip install large-image[converter] or large-image[all], this will be included.