### PR TITLE
Ensure that all file tile sources can handle Path and str arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 - Add the image converter to the extra requires ([#677](../../pull/677))
+- All file tile sources can take either strings or pathlib.Path values ([#683](../../pull/683))
 
 ## Version 1.8.6
 

--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -137,7 +137,7 @@ class BioformatsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         """
         super().__init__(path, **kwargs)
 
-        largeImagePath = self._getLargeImagePath()
+        largeImagePath = str(self._getLargeImagePath())
 
         ext = os.path.splitext(largeImagePath)[1]
         if not ext:

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -111,12 +111,12 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         """
         super().__init__(path, **kwargs)
         self._bounds = {}
-        self._path = self._getLargeImagePath()
+        self._largeImagePath = str(self._getLargeImagePath())
         try:
-            self.dataset = gdal.Open(self._path, gdalconst.GA_ReadOnly)
+            self.dataset = gdal.Open(self._largeImagePath, gdalconst.GA_ReadOnly)
         except RuntimeError:
-            if not os.path.isfile(self._path):
-                raise TileSourceFileNotFoundError(self._path) from None
+            if not os.path.isfile(self._largeImagePath):
+                raise TileSourceFileNotFoundError(self._largeImagePath) from None
             raise TileSourceError('File cannot be opened via GDAL')
         self._getDatasetLock = threading.RLock()
         self.tileSize = 256
@@ -133,8 +133,8 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 self.sourceSizeX = self.sizeX = self.dataset.RasterXSize
                 self.sourceSizeY = self.sizeY = self.dataset.RasterYSize
         except AttributeError:
-            if not os.path.isfile(self._path):
-                raise TileSourceFileNotFoundError(self._path) from None
+            if not os.path.isfile(self._largeImagePath):
+                raise TileSourceFileNotFoundError(self._largeImagePath) from None
             raise TileSourceError('File cannot be opened via GDAL.')
         is_netcdf = self._checkNetCDF()
         try:
@@ -1138,7 +1138,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         os.close(fd)
         try:
             self.logger.info('Using gdal warp %r' % gdalParams)
-            ds = gdal.Open(self._path, gdalconst.GA_ReadOnly)
+            ds = gdal.Open(self._largeImagePath, gdalconst.GA_ReadOnly)
             gdal.Warp(outputPath, ds, options=gdalParams)
         except Exception as exc:
             try:

--- a/sources/mapnik/large_image_source_mapnik/__init__.py
+++ b/sources/mapnik/large_image_source_mapnik/__init__.py
@@ -310,7 +310,7 @@ class MapnikFileTileSource(GDALFileTileSource, metaclass=LruCacheMetaclass):
         m.append_style(styleName, style)
         lyr = mapnik.Layer('layer')
         lyr.srs = layerSrs
-        gdalpath = self._path
+        gdalpath = self._largeImagePath
         gdalband = band
         if hasattr(self, '_netcdf') and type(band) is tuple:
             gdalband = band[1]

--- a/sources/nd2/large_image_source_nd2/__init__.py
+++ b/sources/nd2/large_image_source_nd2/__init__.py
@@ -72,7 +72,7 @@ class ND2FileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         """
         super().__init__(path, **kwargs)
 
-        self._largeImagePath = self._getLargeImagePath()
+        self._largeImagePath = str(self._getLargeImagePath())
 
         self._pixelInfo = {}
         try:

--- a/sources/ometiff/large_image_source_ometiff/__init__.py
+++ b/sources/ometiff/large_image_source_ometiff/__init__.py
@@ -93,11 +93,10 @@ class OMETiffFileTileSource(TiffFileTileSource, metaclass=LruCacheMetaclass):
         # Note this is the super of the parent class, not of this class.
         super(TiffFileTileSource, self).__init__(path, **kwargs)
 
-        largeImagePath = self._getLargeImagePath()
-        self._largeImagePath = largeImagePath
+        self._largeImagePath = str(self._getLargeImagePath())
 
         try:
-            base = TiledTiffDirectory(largeImagePath, 0, mustBeTiled=None)
+            base = TiledTiffDirectory(self._largeImagePath, 0, mustBeTiled=None)
         except TiffException:
             if not os.path.isfile(self._largeImagePath):
                 raise TileSourceFileNotFoundError(self._largeImagePath) from None
@@ -106,7 +105,7 @@ class OMETiffFileTileSource(TiffFileTileSource, metaclass=LruCacheMetaclass):
         if not info or not info.get('OME'):
             raise TileSourceError('Not an OME Tiff')
         self._omeinfo = info['OME']
-        self._checkForOMEZLoop(largeImagePath)
+        self._checkForOMEZLoop(self._largeImagePath)
         self._parseOMEInfo()
         omeimages = [
             entry['Pixels'] for entry in self._omeinfo['Image'] if
@@ -119,12 +118,12 @@ class OMETiffFileTileSource(TiffFileTileSource, metaclass=LruCacheMetaclass):
         self._omeLevels = [omebylevel.get(key) for key in range(max(omebylevel.keys()) + 1)]
         if base._tiffInfo.get('istiled'):
             self._tiffDirectories = [
-                TiledTiffDirectory(largeImagePath, int(entry['TiffData'][0].get('IFD', 0)))
+                TiledTiffDirectory(self._largeImagePath, int(entry['TiffData'][0].get('IFD', 0)))
                 if entry else None
                 for entry in self._omeLevels]
         else:
             self._tiffDirectories = [
-                TiledTiffDirectory(largeImagePath, 0, mustBeTiled=None)
+                TiledTiffDirectory(self._largeImagePath, 0, mustBeTiled=None)
                 if entry else None
                 for entry in self._omeLevels]
             self._checkForInefficientDirectories(warn=False)

--- a/sources/openjpeg/large_image_source_openjpeg/__init__.py
+++ b/sources/openjpeg/large_image_source_openjpeg/__init__.py
@@ -86,12 +86,10 @@ class OpenjpegFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         """
         super().__init__(path, **kwargs)
 
-        largeImagePath = self._getLargeImagePath()
-
-        self._largeImagePath = largeImagePath
+        self._largeImagePath = str(self._getLargeImagePath())
         self._pixelInfo = {}
         try:
-            self._openjpeg = glymur.Jp2k(largeImagePath)
+            self._openjpeg = glymur.Jp2k(self._largeImagePath)
             if not self._openjpeg.shape:
                 if not os.path.isfile(self._largeImagePath):
                     raise FileNotFoundError()

--- a/sources/openslide/large_image_source_openslide/__init__.py
+++ b/sources/openslide/large_image_source_openslide/__init__.py
@@ -77,7 +77,7 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         """
         super().__init__(path, **kwargs)
 
-        self._largeImagePath = self._getLargeImagePath()
+        self._largeImagePath = str(self._getLargeImagePath())
 
         try:
             self._openslide = openslide.OpenSlide(self._largeImagePath)

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -1,5 +1,6 @@
 import os
 import re
+from pathlib import Path
 
 import pytest
 
@@ -86,6 +87,19 @@ def testSourcesCanRead(source, filename):
     large_image.tilesource.loadTileSources()
     sourceClass = large_image.tilesource.AvailableTileSources[source]
     assert bool(sourceClass.canRead(imagePath)) is bool(canRead)
+
+
+@pytest.mark.parametrize('filename', registry)
+@pytest.mark.parametrize('source', SourceAndFiles)
+def testSourcesCanReadPath(source, filename):
+    sourceInfo = SourceAndFiles[source]
+    canRead = sourceInfo.get('any') or (
+        re.search(sourceInfo.get('read', r'^$'), filename) and
+        not re.search(sourceInfo.get('noread', r'^$'), filename))
+    imagePath = datastore.fetch(filename)
+    large_image.tilesource.loadTileSources()
+    sourceClass = large_image.tilesource.AvailableTileSources[source]
+    assert bool(sourceClass.canRead(Path(imagePath))) is bool(canRead)
 
 
 @pytest.mark.parametrize('filename', registry)


### PR DESCRIPTION
This also makes some of the internal variables a little more consistent.

Closes #679.