### PR TITLE
Have appropriate default properties when emitting centroids.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - On Girder with read-only assetstores, return results even if caching fails ([#684](../../pull/684))
 - Handle geospatial files with no explicit projection ([#686](../../pull/686))
 
+### Bug Fixes
+- Fix default properties on annotations when emitted as centroids ([#687](../../pull/687))
+
 ## Version 1.8.6
 
 ### Bug Fixes

--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -919,7 +919,7 @@ class Annotation(AccessControlledModel):
                         return False
         elif isinstance(a, list):
             if len(a) != len(b):
-                if parentKey not in {'points', 'values'} or len(a) < 3 or len(b) < 3:
+                if parentKey not in {'points', 'values'} or len(a) < 2 or len(b) < 2:
                     return False
                 # If this is an array of points, let it pass
                 for idx in range(len(b)):

--- a/girder_annotation/girder_large_image_annotation/models/annotationelement.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotationelement.py
@@ -221,6 +221,12 @@ class Annotationelement(Model):
                 'bbox': True}
             proplist = []
             propskeys = ['type', 'fillColor', 'lineColor', 'lineWidth', 'closed']
+            # This should match the javascript
+            defaultProps = {
+                'fillColor': 'rgba(0,0,0,0)',
+                'lineColor': 'rgb(0,0,0)',
+                'lineWidth': 2,
+            }
             for key in propskeys:
                 fields['element.%s' % key] = True
             props = {}
@@ -249,7 +255,9 @@ class Annotationelement(Model):
                 bbox = entry.get('bbox')
                 if not bbox or 'lowx' not in bbox or 'size' not in bbox:
                     continue
-                prop = tuple(element.get(key) for key in propskeys)
+                prop = tuple(
+                    element.get(key, defaultProps.get(key)) for key in propskeys
+                    if element.get(key, defaultProps.get(key)) is not None)
                 if prop not in props:
                     props[prop] = len(props)
                     proplist.append(list(prop))


### PR DESCRIPTION
This fixes a bug when emitting annotations where centroids are used for rendering and the annotation element doesn't specify color.