### PR TITLE
Change pesky logger message to debug level

### DIFF
--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -144,7 +144,7 @@ class LruCacheMetaclass(type):
         if LruCacheMetaclass.namedCaches.get(cacheName) is None:
             cache, cacheLock = CacheFactory().getCache(maxSize, cacheName=cacheName)
             LruCacheMetaclass.namedCaches[cacheName] = (cache, cacheLock)
-            config.getConfig('logger').info(
+            config.getConfig('logger').debug(
                 'Created LRU Cache for %r with %d maximum size' % (cacheName, cache.maxsize))
         else:
             (cache, cacheLock) = LruCacheMetaclass.namedCaches[cacheName]


### PR DESCRIPTION
This little log message shows up anytime you import `large_image` which can be quite unsightly in a Jupyter notebook:

![143664819-36af143b-bc55-4b04-814f-839531fd80f5](https://user-images.githubusercontent.com/22067021/143665039-2d29a537-3615-4b7d-8428-42c23d0033fc.png)



Ref https://github.com/banesullivan/localtileserver/issues/17#issuecomment-980487066