### PR TITLE
Add support for named MPL colormaps

### DIFF
--- a/requirements-dev-core.txt
+++ b/requirements-dev-core.txt
@@ -2,7 +2,7 @@
 -e sources/bioformats
 -e sources/deepzoom
 -e sources/dummy
--e sources/gdal
+-e sources/gdal[colormaps]
 -e sources/nd2
 -e sources/openjpeg
 -e sources/openslide

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -358,6 +358,15 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         try:
             return attrgetter(palette)(palettable).hex_colors
         except AttributeError:
+            pass
+        try:
+            # Attempt getting palette by MPL cmap name, e.g. 'viridis' or 'jet'
+            import matplotlib
+            import matplotlib.colors as mcolors
+
+            cmap = matplotlib.cm.get_cmap(palette, 255)  # 255 might be overkill
+            return [mcolors.rgb2hex(cmap(i)) for i in range(cmap.N)]
+        except (ImportError, ValueError):
             raise TileSourceError('Palette is not a valid palettable path.')
 
     def getProj4String(self):

--- a/sources/gdal/setup.py
+++ b/sources/gdal/setup.py
@@ -50,6 +50,7 @@ setup(
     ],
     extras_require={
         'girder': 'girder-large-image>=1.0.0',
+        'colormaps': 'matplotlib',
     },
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -108,7 +108,7 @@ def testTileStyleMatplotlibColormap():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
     style = json.dumps({'band': 1, 'min': 0, 'max': 100,
-                        'palette': 'jet',  # use a named MPL colormap
+                        'palette': 'viridis',  # use a named MPL colormap
                         'scheme': 'linear'})
     source = large_image_source_gdal.open(
         imagePath, projection='EPSG:3857', style=style, encoding='PNG')

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -104,6 +104,17 @@ def testTileLinearStyleFromGeotiffs():
     _assertImageMatches(image, 'geotiff_style_linear_7_22_51')
 
 
+def testTileStyleMatplotlibColormap():
+    testDir = os.path.dirname(os.path.realpath(__file__))
+    imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
+    style = json.dumps({'band': 1, 'min': 0, 'max': 100,
+                        'palette': 'jet',  # use a named MPL colormap
+                        'scheme': 'linear'})
+    source = large_image_source_gdal.open(
+        imagePath, projection='EPSG:3857', style=style, encoding='PNG')
+    assert source
+
+
 def testTileStyleBadInput():
     def _assertStyleResponse(imagePath, style, message):
         with pytest.raises(TileSourceError, match=message):


### PR DESCRIPTION
These changes are adapted from what I implemented here in `localtileserver` to support using MPL colormaps by name:

https://github.com/banesullivan/localtileserver/blob/0c444034f63165857c57f4043a05cb73b5df5b71/localtileserver/palettes.py#L56-L63

This should make it so that any Matplotlib named colormap can be used as a `'palette'` when MPL is installed. https://matplotlib.org/stable/tutorials/colors/colormaps.html

(I haven't tested this locally yet)