### PR TITLE
Enable python 3.10 testing on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,13 +281,13 @@ workflows:
             branches:
               ignore:
                 - gh-pages
-      # - py310:
-      #     filters:
-      #       tags:
-      #         only: /^v.*/
-      #       branches:
-      #         ignore:
-      #           - gh-pages
+      - py310:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore:
+                - gh-pages
       - lint_and_docs:
           filters:
             tags:
@@ -315,7 +315,7 @@ workflows:
             - py37
             - py38
             - py39
-            # - py310
+            - py310
             - lint_and_docs
           filters:
             tags:
@@ -328,7 +328,7 @@ workflows:
             - py37
             - py38
             - py39
-            # - py310
+            - py310
             - lint_and_docs
           filters:
             tags:
@@ -351,6 +351,6 @@ workflows:
       - py37
       - py38
       - py39
-      # - py310
+      - py310
       - lint_and_docs
       - wheels

--- a/girder/setup.py
+++ b/girder/setup.py
@@ -43,16 +43,14 @@ setup(
         'Programming Language :: Python :: 3.10',
     ],
     install_requires=[
-        'enum34>=1.1.6;python_version<"3.4"',
-        'futures;python_version<"3.4"',
         'girder>=3.0.4',
         'girder-jobs>=3.0.3',
-        'girder-worker[girder]>=0.6.0',
         'large_image>=1.0.0',
     ],
     extras_require={
         'tasks': [
-            'large-image-tasks',
+            'large-image-tasks[girder]',
+            'girder-worker[girder]>=0.6.0',
         ],
     },
     include_package_data=True,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ girder-jobs>=3.0.3
 # Don't specify other extras for the converter; they are already present above
 -e utilities/converter[stats]
 # Girder and worker dependencies are already installed above
--e utilities/tasks
+-e utilities/tasks[girder]
 -e girder/.
 -e girder_annotation/.
 

--- a/tox.ini
+++ b/tox.ini
@@ -28,8 +28,6 @@ deps =
   pytest-custom-exit-code
   pytest-girder>=3.0.4
   pytest-xdist
-  celery!=4.4.4,<5
-# celery 4.4.4 is broken; avoid it until a new version is released
 whitelist_externals =
   rm
   npx

--- a/utilities/tasks/setup.py
+++ b/utilities/tasks/setup.py
@@ -48,18 +48,19 @@ setup(
         'Programming Language :: Python :: 3.10',
     ],
     install_requires=[
-        'girder-worker>=0.6.0',
-        'girder-worker-utils>=0.8.5',
         # Packages required by both producer and consumer side installations
+        'girder-worker-utils>=0.8.5',
     ],
     extras_require={
         'girder': [
             # Dependencies required on the producer (Girder) side.
             'large-image-converter',
+            'girder-worker[girder]>=0.6.0',
         ],
         'worker': [
             # Dependencies required on the consumer (Girder Worker) side.
             'large-image-converter[sources]',
+            'girder-worker[worker]>=0.6.0',
         ],
     },
     python_requires='>=3.6',


### PR DESCRIPTION
Now that scikit-image has a 3.10 wheel, this can run in a sensible amount of time.

Remove some older cruft from earlier python versions.

Reduce dependencies for the girder plugin if tasks aren't used.