### PR TITLE
Allow named color palettes to be used by all sources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Features
+- Better palette support in styles ([#724](../../pull/724))
+
 ### Improvements
 - The openjpeg girder source handles uploaded files better ([#721](../../pull/721))
 - Suppress some warnings on Girder and on bioformats ([#727](../../pull/727))

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Modules
 Large Image consists of several Python modules designed to work together.  These include:
 
 - ``large-image``: The core module.
-  You can specify extras_require of the name of any tile source included with this repository, ``sources`` for all of the tile sources in the repository, a specific source name (e.g., ``tiff``), ``memcached`` for using memcached for tile caching, ``converter`` to include the converter module, or ``all`` for all of the tile sources, memcached, and the converter module.
+  You can specify extras_require of the name of any tile source included with this repository, ``sources`` for all of the tile sources in the repository, a specific source name (e.g., ``tiff``), ``memcached`` for using memcached for tile caching, ``converter`` to include the converter module, ``colormap`` for using matplotlib for named color palettes used in styles, or ``all`` for all of the tile sources, memcached, the converter module, and better color map support.
 
 - ``large-image-converter``: A utility for using pyvips and other libraries to convert images into pyramidal tiff files that can be read efficiently by large_image.
   You can specify extras_require of ``jp2k`` to include modules to allow output to JPEG2000 compression, ``sources`` to include all sources, and ``stats`` to include modules to allow computing compression noise statistics.

--- a/docs/tilesource_options.rst
+++ b/docs/tilesource_options.rst
@@ -45,7 +45,10 @@ A band definition is an object which can contain the following keys:
 
 - ``max``: the value to map to the last palette value.  Defaults to 255.  'auto' to use 0 if the reported minimum and maximum of the band are between [0, 255] or use the reported maximum otherwise.  'min' or 'max' to always uses the reported minimum or maximum.
 
-- ``palette``: a list of two or more color strings, where color strings are of the form #RRGGBB, #RRGGBBAA, #RGB, #RGBA.  The values between min and max are interpolated using a piecewise linear algorithm to map to the specified palette values.
+- ``palette``: This is a list or two or more colors. The values between min and max are interpolated using a piecewise linear algorithm to map to the specified palette values.  It can be specified in a variety of ways:
+  - a list of two or more color values, where the color values are css-style strings (e.g., of the form #RRGGBB, #RRGGBBAA, #RGB, #RGBA, or a css ``rgb``, ``rgba``, ``hsl``, or ``hsv`` string, or a css color name), or, if matplotlib is available, a matplotlib color name, or a list or tuple of RGB(A) values on a scale of [0-1].
+  - a single string that is a color string as above.  This is functionally a two-color palette with the first color as solid black (``#000``), and the second color the specified value
+  - a named color palette from the palettable library (e.g., ``matplotlib.Plasma_6``) or, if available, from the matplotlib library or one of its plugins (e.g., ``viridis``).
 
 - ``nodata``: the value to use for missing data.  null or unset to not use a nodata value.
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -22,7 +22,7 @@ from .tiledict import LazyTileDict
 from .utilities import (_encodeImage, _gdalParameters,  # noqa: F401
                         _imageToNumpy, _imageToPIL, _letterboxImage, _vipsCast,
                         _vipsParameters, dictToEtree, etreeToDict,
-                        nearPowerOfTwo)
+                        getPaletteColors, nearPowerOfTwo)
 
 
 class TileSource:
@@ -87,7 +87,12 @@ class TileSource:
                     maximum otherwise.  'min' or 'max' to always uses the
                     reported minimum or maximum.
                 :palette: a list of two or more color strings, where color
-                    strings are of the form #RRGGBB, #RRGGBBAA, #RGB, #RGBA.
+                    strings are of the form #RRGGBB, #RRGGBBAA, #RGB, #RGBA, or
+                    any string parseable by the PIL modules, or, if it is
+                    installed, byt matplotlib.  Alternately, this can be a
+                    single color, which implies ['#000', <color>], or the name
+                    of a palettable paletter or, if available, a matplotlib
+                    palette.
                 :nodata: the value to use for missing data.  null or unset to
                     not use a nodata value.
                 :composite: either 'lighten' or 'multiply'.  Defaults to
@@ -1063,10 +1068,9 @@ class TileSource:
                 composite = entry.get('composite', 'multiply')
             if band is None:
                 band = image[:, :, bandidx]
-            palette = numpy.array([
-                PIL.ImageColor.getcolor(clr, 'RGBA') for clr in entry.get(
-                    'palette', ['#000', '#FFF']
-                    if entry.get('band') != 'alpha' else ['#FFF0', '#FFFF'])])
+            palette = getPaletteColors(entry.get(
+                'palette', ['#000', '#FFF']
+                if entry.get('band') != 'alpha' else ['#FFF0', '#FFFF']))
             palettebase = numpy.linspace(0, 1, len(palette), endpoint=True)
             nodata = entry.get('nodata')
             min = self._getMinMax('min', entry.get('min', 'auto'), image.dtype, bandidx, frame)

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -13,7 +13,6 @@ import PIL.ImageDraw
 
 from ..constants import (TILE_FORMAT_IMAGE, TILE_FORMAT_NUMPY, TILE_FORMAT_PIL,
                          TileOutputMimeTypes, TileOutputPILFormat)
-from ..exceptions import TileSourceError
 
 # Turn off decompression warning check
 PIL.Image.MAX_IMAGE_PIXELS = None
@@ -423,7 +422,7 @@ def _arrayToPalette(palette):
 
                     arr.append(PIL.ImageColor.getcolor(matplotlib.colors.to_hex(clr), 'RGBA'))
                 except (ImportError, ValueError):
-                    raise TileSourceError('Value cannot be used as a color palette.')
+                    raise ValueError('cannot be used as a color palette: %r.' % palette)
     return numpy.array(arr)
 
 
@@ -467,5 +466,20 @@ def getPaletteColors(value):
         except (ImportError, ValueError):
             pass
     if palette is None:
-        raise TileSourceError('Value cannot be used as a color palette.')
+        raise ValueError('cannot be used as a color palette.: %r.' % value)
     return _arrayToPalette(palette)
+
+
+def isValidPalette(value):
+    """
+    Check if a value can be used as a palette.
+
+    :param value: Either a list, a single color name, or a palette name.  See
+        getPaletteColors.
+    :returns: a boolean; true if the value can be used as a palette.
+    """
+    try:
+        getPaletteColors(value)
+        return True
+    except ValueError:
+        return False

--- a/requirements-dev-core.txt
+++ b/requirements-dev-core.txt
@@ -18,6 +18,7 @@
 
 # Extras from main setup.py
 pylibmc>=1.5.1
+matplotlib
 
 # External dependencies
 pip>=9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,6 +25,7 @@ girder-jobs>=3.0.3
 
 # Extras from main setup.py
 pylibmc>=1.5.1
+matplotlib
 
 # External dependencies
 pip>=9

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ long_description = readme
 extraReqs = {
     'memcached': ['pylibmc>=1.5.1 ; platform_system != "Windows"'],
     'converter': ['large-image-converter'],
+    'colormaps': ['matplotlib'],
 }
 sources = {
     'bioformats': ['large-image-source-bioformats'],
@@ -69,6 +70,7 @@ setup(
     ],
     install_requires=[
         'cachetools>=3.0.0',
+        'palettable',
         # We don't pin the version of Pillow, as anything newer than 3.0
         # probably works, though we'd rather have the latest.  8.3.0 won't
         # save jpeg compressed tiffs properly.

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -355,7 +355,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         :returns: List of colors
         """
         palette = getPaletteColors(palette)
-        return ['#%02X%02X%02X%02X' % tuple(clr) for clr in palette]
+        return ['#%02X%02X%02X%02X' % tuple(int(val) for val in clr) for clr in palette]
 
     def getProj4String(self):
         """

--- a/sources/gdal/setup.py
+++ b/sources/gdal/setup.py
@@ -45,7 +45,6 @@ setup(
     install_requires=[
         'large-image>=1.0.0',
         'gdal',
-        'palettable',
         'pyproj>=2.2.0',
     ],
     extras_require={

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -167,6 +167,7 @@ def testIsGeospatial(filename, isgeo):
 ])
 def testGoodGetPaletteColors(palette):
     large_image.tilesource.utilities.getPaletteColors(palette)
+    assert large_image.tilesource.utilities.isValidPalette(palette) is True
 
 
 @pytest.mark.parametrize('palette', [
@@ -177,5 +178,6 @@ def testGoodGetPaletteColors(palette):
     'matplotlib.Plasma_128',
 ])
 def testBadGetPaletteColors(palette):
-    with pytest.raises(large_image.exceptions.TileSourceError):
+    with pytest.raises(ValueError):
         large_image.tilesource.utilities.getPaletteColors(palette)
+    assert large_image.tilesource.utilities.isValidPalette(palette) is False

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -151,3 +151,31 @@ def testSourcesTilesAndMethods(source, filename):
 def testIsGeospatial(filename, isgeo):
     imagePath = datastore.fetch(filename)
     assert large_image.tilesource.isGeospatial(imagePath) == isgeo
+
+
+@pytest.mark.parametrize('palette', [
+    ['#000', '#FFF'],
+    ['#000', '#888', '#FFF'],
+    '#fff',
+    'black',
+    'rgba(128, 128, 128, 128)',
+    'rgb(128, 128, 128)',
+    'xkcd:blue',
+    'viridis',
+    'matplotlib.Plasma_6',
+    [(0.5, 0.5, 0.5), (0.1, 0.1, 0.1, 0.1), 'xkcd:blue'],
+])
+def testGoodGetPaletteColors(palette):
+    large_image.tilesource.utilities.getPaletteColors(palette)
+
+
+@pytest.mark.parametrize('palette', [
+    'notacolor',
+    [0.5, 0.5, 0.5],
+    ['notacolor', '#fff'],
+    'notapalette',
+    'matplotlib.Plasma_128',
+])
+def testBadGetPaletteColors(palette):
+    with pytest.raises(large_image.exceptions.TileSourceError):
+        large_image.tilesource.utilities.getPaletteColors(palette)

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -106,7 +106,7 @@ def testTileLinearStyleFromGeotiffs():
 
 def testTileStyleBadInput():
     def _assertStyleResponse(imagePath, style, message):
-        with pytest.raises(TileSourceError, match=message):
+        with pytest.raises((TileSourceError, ValueError), match=message):
             source = large_image_source_gdal.open(
                 imagePath, projection='EPSG:3857', style=json.dumps(style), encoding='PNG')
             source.getTile(22, 51, 7)
@@ -125,7 +125,7 @@ def testTileStyleBadInput():
     _assertStyleResponse(imagePath, {
         'band': 1,
         'palette': 'nonexistent.palette'
-    }, 'Value cannot be used as a color palette.')
+    }, 'cannot be used as a color palette')
 
     _assertStyleResponse(imagePath, ['style'],
                          'Style is not a valid json object.')

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -125,7 +125,7 @@ def testTileStyleBadInput():
     _assertStyleResponse(imagePath, {
         'band': 1,
         'palette': 'nonexistent.palette'
-    }, 'Palette is not a valid palettable path.')
+    }, 'Value cannot be used as a color palette.')
 
     _assertStyleResponse(imagePath, ['style'],
                          'Style is not a valid json object.')

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -507,3 +507,16 @@ def testFileWithoutProjection():
     assert tileMetadata['bounds']['ymax'] == pytest.approx(2477890, 1)
     assert tileMetadata['bounds']['ymin'] == pytest.approx(2420966, 1)
     assert 'epsg:3857' in tileMetadata['bounds']['srs']
+
+
+def testMatplotlibPalette():
+    testDir = os.path.dirname(os.path.realpath(__file__))
+    imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
+    style = json.dumps({'band': 1, 'min': 0, 'max': 100,
+                        'palette': 'viridis'})
+    source = large_image_source_gdal.open(
+        imagePath, projection='EPSG:3857', style=style, encoding='PNG')
+    image = source.getTile(22, 51, 7)
+    image = PIL.Image.open(io.BytesIO(image))
+    image = numpy.asarray(image)
+    assert list(image[0, 0, :]) == [68, 1, 84, 0]

--- a/test/test_source_mapnik.py
+++ b/test/test_source_mapnik.py
@@ -148,12 +148,12 @@ def testTileStyleBadInput():
     _assertStyleResponse(imagePath, {
         'band': 1,
         'palette': 'nonexistent.palette'
-    }, 'Palette is not a valid palettable path.')
+    }, 'Value cannot be used as a color palette.')
 
     _assertStyleResponse(imagePath, {
         'band': 1,
         'palette': ['notacolor', '#00ffff']
-    }, 'Mapnik failed to parse color')
+    }, 'Value cannot be used as a color palette.')
 
     _assertStyleResponse(imagePath, {
         'band': 1,

--- a/test/test_source_mapnik.py
+++ b/test/test_source_mapnik.py
@@ -117,7 +117,7 @@ def testTileLinearStyleFromGeotiffs():
 
 def testTileStyleBadInput():
     def _assertStyleResponse(imagePath, style, message):
-        with pytest.raises(TileSourceError, match=message):
+        with pytest.raises((TileSourceError, ValueError), match=message):
             source = large_image_source_mapnik.open(
                 imagePath, projection='EPSG:3857', style=json.dumps(style))
             source.getTile(22, 51, 7, encoding='PNG')
@@ -148,12 +148,12 @@ def testTileStyleBadInput():
     _assertStyleResponse(imagePath, {
         'band': 1,
         'palette': 'nonexistent.palette'
-    }, 'Value cannot be used as a color palette.')
+    }, 'cannot be used as a color palette')
 
     _assertStyleResponse(imagePath, {
         'band': 1,
         'palette': ['notacolor', '#00ffff']
-    }, 'Value cannot be used as a color palette.')
+    }, 'cannot be used as a color palette')
 
     _assertStyleResponse(imagePath, {
         'band': 1,


### PR DESCRIPTION
This also increase the ability to handle css and named colors.

This generalized and supercedes #714.  This closes #716.