### PR TITLE
Harden detecting file-not-found.

### DIFF
--- a/large_image/tilesource/__init__.py
+++ b/large_image/tilesource/__init__.py
@@ -31,14 +31,15 @@ def isGeospatial(path):
         ds = gdal.Open(path, gdalconst.GA_ReadOnly)
     except Exception:
         return False
-    if ds.GetGCPs() and ds.GetGCPProjection():
-        return True
-    if ds.GetProjection():
-        return True
-    if ds.GetGeoTransform(can_return_null=True):
-        return True
-    if ds.GetDriver().ShortName in {'NITF', 'netCDF'}:
-        return True
+    if ds:
+        if ds.GetGCPs() and ds.GetGCPProjection():
+            return True
+        if ds.GetProjection():
+            return True
+        if ds.GetGeoTransform(can_return_null=True):
+            return True
+        if ds.GetDriver().ShortName in {'NITF', 'netCDF'}:
+            return True
     return False
 
 
@@ -113,6 +114,8 @@ def getTileSourceFromDict(availableSources, pathOrUri, *args, **kwargs):
     sourceName = getSourceNameFromDict(availableSources, pathOrUri, *args, **kwargs)
     if sourceName:
         return availableSources[sourceName](pathOrUri, *args, **kwargs)
+    if not os.path.exists(pathOrUri) and '://' not in pathOrUri:
+        raise TileSourceFileNotFoundError(pathOrUri)
     raise TileSourceError('No available tilesource for %s' % pathOrUri)
 
 

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -77,6 +77,13 @@ def testSourcesFileNotFound(source):
         large_image.tilesource.AvailableTileSources[source]('nosuchfile.ext')
 
 
+def testBaseFileNotFound():
+    with pytest.raises(large_image.exceptions.TileSourceFileNotFoundError):
+        large_image.open('nosuchfile')
+    with pytest.raises(large_image.exceptions.TileSourceFileNotFoundError):
+        large_image.open('nosuchfile.ext')
+
+
 @pytest.mark.parametrize('filename', registry)
 @pytest.mark.parametrize('source', SourceAndFiles)
 def testSourcesCanRead(source, filename):

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -139,3 +139,15 @@ def testSourcesTilesAndMethods(source, filename):
         tsf = sourceClass(imagePath, frame=len(tileMetadata['frames']) - 1)
         tileMetadata = tsf.getMetadata()
         utilities.checkTilesZXY(tsf, tileMetadata)
+
+
+@pytest.mark.parametrize('filename,isgeo', [
+    ('04091217_ruc.nc', True),
+    ('HENormalN801.czi', False),
+    ('landcover_sample_1000.tif', True),
+    ('oahu-dense.tiff', True),
+    ('region_gcp.tiff', True),
+])
+def testIsGeospatial(filename, isgeo):
+    imagePath = datastore.fetch(filename)
+    assert large_image.tilesource.isGeospatial(imagePath) == isgeo


### PR DESCRIPTION
This handles some difference in the conda and pip installations of gdal.

Closes #656.