### PR TITLE
Reduce pytest warnings.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ passenv = PYTEST_*
 extras =
   memcached
 setenv =
-  GDAL_PAM_ENABLED=no
   PIP_FIND_LINKS=https://girder.github.io/large_image_wheels
+  GDAL_PAM_ENABLED=no
 
 [testenv:test]
 description = Run all tests, including Girder
@@ -46,8 +46,8 @@ setenv =
   NPM_CONFIG_LOGLEVEL=warn
   NPM_CONFIG_PROGRESS=false
   NPM_CONFIG_PREFER_OFFLINE=true
-  GDAL_PAM_ENABLED=no
   PIP_FIND_LINKS=https://girder.github.io/large_image_wheels
+  GDAL_PAM_ENABLED=no
 
 [testenv:test-py{36,37,38,39,310}]
 deps = {[testenv:test]deps}
@@ -152,10 +152,10 @@ show-source = True
 format = pylint
 max-complexity = 14
 exclude =
-    build
-    docs
-    */web_client/*
-    */*egg*/*
+  build
+  docs
+  */web_client/*
+  */*egg*/*
 # Ignore missing docstring errors.
 ignore = D100,D101,D102,D103,D104,D105,D106,D107,D200,D205,D400,D401,E741,W504
 
@@ -171,39 +171,52 @@ markers =
   girder: mark a test as requiring girder
   girder_client: mark a test as requiring girder client
   plugin: use by girder to load plugins
+# Some of these warnings are filtered by their own packages (e.g., the numpy
+# warnings), and pytest shows them anyway unless they are listed here.  Others,
+# such as the mongo warnings, we can't do anything about as this package has no
+# stake in the version of pymongo used by Girder.
 filterwarnings =
   ignore::pytest.PytestUnraisableExceptionWarning
-  ignore:count is deprecated. Use Collection.count_documents instead.:DeprecationWarning
+  ignore:.*count is deprecated.*:DeprecationWarning
+  ignore::DeprecationWarning:.*mongo.*
   ignore::UserWarning:pymongo.collection
   ignore::DeprecationWarning:bioformats.formatreader
+  ignore:.*numpy.dtype size changed.*
+  ignore:.*numpy.ufunc size changed.*
+  ignore:.*numpy.ndarray size changed.*
+  ignore:.*Unrecognized box.*:UserWarning:glymur.*
+  ignore:.*SetUnitType.*not supported on this raster band.*
+  ignore::pytest.PytestUnhandledThreadExceptionWarning:cachetools.*
+  ignore:::celery.backends.amqp
+  ignore:Creating a LegacyVersion.*:DeprecationWarning
 
 [coverage:paths]
 # As of pytest-cov 2.6, all but the first source line is relative to the first
 # source line.  The first line is relative to the local path.  Prior to 2.6,
 # all lines were relative to the local path.
 source =
-    large_image/
-    ../sources/
-    ../utilities/converter/
-    ../examples/
-    ../girder/girder_large_image
-    ../girder_annotation/girder_large_image_annotation
-    ../utilities/converter/tasks/
-    ../build/tox/*/lib/*/site-packages/large_image/
+  large_image/
+  ../sources/
+  ../utilities/converter/
+  ../examples/
+  ../girder/girder_large_image
+  ../girder_annotation/girder_large_image_annotation
+  ../utilities/converter/tasks/
+  ../build/tox/*/lib/*/site-packages/large_image/
 
 [coverage:run]
 data_file = build/coverage/.coverage
 branch = True
 omit = test/*
 include =
-    large_image/*
-    sources/*
-    utilities/converter/*
-    examples/*
-    girder/girder_large_image/*
-    girder_annotation/girder_large_image_annotation/*
-    utilities/tasks*
-    build/tox/*/lib/*/site-packages/*large_image*/*
+  large_image/*
+  sources/*
+  utilities/converter/*
+  examples/*
+  girder/girder_large_image/*
+  girder_annotation/girder_large_image_annotation/*
+  utilities/tasks*
+  build/tox/*/lib/*/site-packages/*large_image*/*
 parallel = True
 
 [coverage:html]

--- a/utilities/converter/large_image_converter/__main__.py
+++ b/utilities/converter/large_image_converter/__main__.py
@@ -135,6 +135,7 @@ def compute_error_metrics(original, altered, results, converterOpts=None):
 
     import large_image_source_tiff
     import numpy
+    import packaging
     import skimage.metrics
 
     lastlog = 0
@@ -176,11 +177,17 @@ def compute_error_metrics(original, altered, results, converterOpts=None):
                 mse += last_mse * diff.size
                 last_ssim = 0
                 try:
+                    kwargs = {}
+                    if (packaging.version.parse(skimage.__version__) >=
+                            packaging.version.parse('0.19')):
+                        kwargs['channel_axis'] = 2 if len(do.shape) > 2 else None
+                    else:
+                        kwargs['multichannel'] = len(do.shape) > 2
                     last_ssim = skimage.metrics.structural_similarity(
                         do.astype(float), da.astype(float),
                         data_range=255 if tileOrig['tile'].dtype == numpy.uint8 else 65535,
                         gaussian_weights=True, sigma=1.5, use_sample_covariance=False,
-                        multichannel=len(do.shape) > 2)
+                        **kwargs)
                     ssim += last_ssim * diff.size
                     ssim_count += diff.size
                 except ValueError:

--- a/utilities/converter/setup.py
+++ b/utilities/converter/setup.py
@@ -63,6 +63,7 @@ setup(
             'large_image[sources]',
         ],
         'stats': [
+            'packaging',
             'scikit-image',
         ],
     },


### PR DESCRIPTION
Ideally, warnings should indicate actual, actionable problems.