### PR TITLE
Add image overlays to annotation schema

### DIFF
--- a/girder_annotation/docs/annotations.rst
+++ b/girder_annotation/docs/annotations.rst
@@ -6,8 +6,10 @@ The full schema can be obtained by calling the Girder endpoint of
 
 An annotation consists of a basic structure which includes a free-form
 ``attributes`` object and a list of ``elements``. The elements are
-strictly specified by the schema and are limited to a set of defined
+strictly specified by the schema and are mostly limited to a set of defined
 shapes.
+
+In addition to elements defined as shapes, image overlays are supported.
 
 Partial annotations are shown below with some example values. Note that
 the comments are not part of a valid annotation:
@@ -28,8 +30,9 @@ the comments are not part of a valid annotation:
 Elements
 --------
 
-Currently, all defined elements are shapes. All of these have some
-properties that they are allowed. Each shape is listed below:
+Currently, most defined elements are shapes. Image overlays are not defined as
+shapes. All of the shape elements have some properties that they are allowed.
+Each element type is listed below:
 
 All shapes
 ~~~~~~~~~~
@@ -263,6 +266,33 @@ choropleth, a grid with a list of values can be specified.
            0.531
        ]
    }
+
+Image overlays
+~~~~~~~~~~~~~~
+
+Image overlay annotations allow specifying a girder large image item
+to display on top of the base image as an annotation. It supports
+translation via the ``xoffset`` and ``yoffset`` properties, as well as other
+types of transformations via its 'matrix' property which should be specified as
+a ``2x2`` affine matrix.
+
+::
+
+    {
+        "type": "imageoverlay"            # Exact string. Required
+        "girderId": <girder image id>     # 24-character girder id pointing
+                                          # to a large image object. Required
+        "opacity": 1                      # Default opacity for the overlay. Defaults to 1. Optional
+        "transform": {                    # Object specifying additional overlay information. Optional
+            "xoffset": 0,                 # How much to shift the overlaid image right.
+            "yoffset": 0,                 # How much to shift the overlaid image down.
+            "matrix": [                   # Affine matrix to specify tranformations like scaling,
+                                          # rotation, or shearing.
+                [1, 0],
+                [0, 1]
+            ]
+        }
+    }
 
 Component Values
 ----------------

--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -450,12 +450,26 @@ class AnnotationSchema:
         ]
     }
 
+    transformArray = {
+        'type': 'array',
+        'items': {
+            'type': 'array',
+            'minItems': 2,
+            'maxItems': 2
+        },
+        'minItems': 2,
+        'maxItems': 2,
+        'description': 'A 2D matrix representing the transform of an '
+                       'image overlay.'
+    }
+
     overlaySchema = {
         '$schema': 'http://json-schema.org/schema#',
         'type': 'object',
         'properties': {
             'girderId': {
                 'type': 'string',
+                'pattern': '^[0-9a-f]{24}$',
                 'description': 'Girder item ID containing the image to '
                                'overlay.'
             },
@@ -466,22 +480,22 @@ class AnnotationSchema:
                 'description': 'Default opacity for this image overlay. Must '
                                'be between 0 and 1. Defaults to 1.'
             },
-            'location': {
+            'transform': {
                 'type': 'object',
-                'description': 'Position (upper-left coordinate, width, and '
-                               'height) of the overlay.',
+                'description': 'Specification for an affine transform of the '
+                               'image overlay. Includes a 2D transform matrix, '
+                               'an X offset and a Y offset.',
                 'properties': {
-                    'upperLeftCorner': coordSchema,
-                    'width': {
+                    'xoffset': {
                         'type': 'number',
                         'minimum': 0
                     },
-                    'height': {
+                    'yoffset': {
                         'type': 'number',
                         'minimum': 0
-                    }
+                    },
+                    'transform': transformArray
                 },
-                'required': ['upperLeftCorner', 'width', 'height']
             }
         },
         'required': ['girderId'],

--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -450,6 +450,46 @@ class AnnotationSchema:
         ]
     }
 
+    overlaySchema = {
+        '$schema': 'http://json-schema.org/schema#',
+        'type': 'object',
+        'properties': {
+            'girderId': {
+                'type': 'string',
+                'description': 'Girder item ID containing the image to '
+                               'overlay.'
+            },
+            'opacity': {
+                'type': 'number',
+                'minimum': 0,
+                'maximum': 1,
+                'description': 'Default opacity for this image overlay. Must '
+                               'be between 0 and 1. Defaults to 1.'
+            },
+            'location': {
+                'type': 'object',
+                'description': 'Position (upper-left coordinate, width, and '
+                               'height) of the overlay.',
+                'properties': {
+                    'upperLeftCorner': coordSchema,
+                    'width': {
+                        'type': 'number',
+                        'minimum': 0
+                    },
+                    'height': {
+                        'type': 'number',
+                        'minimum': 0
+                    }
+                },
+                'required': ['upperLeftCorner', 'width', 'height']
+            }
+        },
+        'required': ['girderId'],
+        'additionalProperties': False,
+        'description': 'An image to overlay onto another like an '
+                       'annotation.'
+    }
+
     annotationElementSchema = {
         '$schema': 'http://json-schema.org/schema#',
         # Shape subtypes are mutually exclusive, so for efficiency, don't use
@@ -496,7 +536,8 @@ class AnnotationSchema:
                 'title': 'Image Markup',
                 'description': 'Subjective things that apply to a '
                                'spatial region.'
-            }
+            },
+            'overlay': overlaySchema
         },
         'additionalProperties': False
     }

--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -467,6 +467,10 @@ class AnnotationSchema:
         '$schema': 'http://json-schema.org/schema#',
         'type': 'object',
         'properties': {
+            'type': {
+                'type': 'string',
+                'enum': ['imageoverlay']
+            },
             'girderId': {
                 'type': 'string',
                 'pattern': '^[0-9a-f]{24}$',
@@ -494,11 +498,11 @@ class AnnotationSchema:
                         'type': 'number',
                         'minimum': 0
                     },
-                    'transform': transformArray
+                    'matrix': transformArray
                 },
             }
         },
-        'required': ['girderId'],
+        'required': ['girderId', 'type'],
         'additionalProperties': False,
         'description': 'An image to overlay onto another like an '
                        'annotation.'
@@ -521,6 +525,7 @@ class AnnotationSchema:
             polylineShapeSchema,
             rectangleShapeSchema,
             rectangleGridShapeSchema,
+            overlaySchema,
         ]
     }
 
@@ -550,8 +555,7 @@ class AnnotationSchema:
                 'title': 'Image Markup',
                 'description': 'Subjective things that apply to a '
                                'spatial region.'
-            },
-            'overlay': overlaySchema
+            }
         },
         'additionalProperties': False
     }

--- a/girder_annotation/girder_large_image_annotation/models/annotationelement.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotationelement.py
@@ -378,7 +378,7 @@ class Annotationelement(Model):
             lowy = min([corner[1] for corner in corners]).item()
             highy = max([corner[1] for corner in corners]).item()
         except Exception as e:
-            logger.error('Error generating bounding box for image overlay annotation: %s' % e)
+            logger.exception('Error generating bounding box for image overlay annotation')
         return lowx, highx, lowy, highy
 
     def _boundingBox(self, element):

--- a/girder_annotation/girder_large_image_annotation/models/annotationelement.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotationelement.py
@@ -377,7 +377,7 @@ class Annotationelement(Model):
             highx = max([corner[0] for corner in corners]).item()
             lowy = min([corner[1] for corner in corners]).item()
             highy = max([corner[1] for corner in corners]).item()
-        except Exception as e:
+        except Exception:
             logger.exception('Error generating bounding box for image overlay annotation')
         return lowx, highx, lowy, highy
 

--- a/girder_annotation/girder_large_image_annotation/models/annotationelement.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotationelement.py
@@ -379,8 +379,7 @@ class Annotationelement(Model):
             highy = max([corner[1] for corner in corners]).item()
         except Exception as e:
             logger.error('Error generating bounding box for image overlay annotation: %s' % e)
-        finally:
-            return lowx, highx, lowy, highy
+        return lowx, highx, lowy, highy
 
     def _boundingBox(self, element):
         """

--- a/girder_annotation/test_annotation/test_annotations.py
+++ b/girder_annotation/test_annotation/test_annotations.py
@@ -465,6 +465,17 @@ class TestLargeImageAnnotationElement:
         assert highx == (58368 / 2) + 500
         assert highy == (12288 / 2) + 1000
 
+    def testOverlayBoundingBox(self, server, admin, fsAssetstore):
+        file = utilities.uploadExternalFile('sample_image.ptif', admin, fsAssetstore)
+        itemId = str(file['itemId'])
+        bbox = Annotationelement()._boundingBox(
+            {'type': 'imageoverlay', 'girderId': itemId})
+        assert bbox == {
+            'lowx': 0, 'lowy': 0, 'lowz': 0,
+            'highx': 58368, 'highy': 12288, 'highz': 0,
+            'details': 1,
+            'size': (58368**2 + 12288**2)**0.5}
+
     def testBoundingBox(self):
         bbox = Annotationelement()._boundingBox({'points': [[1, -2, 3], [-4, 5, -6], [7, -8, 9]]})
         assert bbox == {

--- a/girder_annotation/test_annotation/test_annotations.py
+++ b/girder_annotation/test_annotation/test_annotations.py
@@ -416,6 +416,55 @@ class TestLargeImageAnnotationElement:
         val3 = Annotationelement().getNextVersionValue()
         assert val3 > val2
 
+    def testOverlayBounds(self, server, admin, fsAssetstore):
+        file = utilities.uploadExternalFile('sample_image.ptif', admin, fsAssetstore)
+        itemId = str(file['itemId'])
+
+        # test no transform
+        lowx, highx, lowy, highy = Annotationelement()._overlayBounds({
+            'type': 'imageoverlay', 'girderId': itemId
+        })
+        assert lowx == 0
+        assert lowy == 0
+        assert highx == 58368
+        assert highy == 12288
+
+        # test offset
+        lowx, highx, lowy, highy = Annotationelement()._overlayBounds({
+            'type': 'imageoverlay', 'girderId': itemId,
+            'transform': {'xoffset': 500, 'yoffset': 1000}
+        })
+        assert lowx == 500
+        assert lowy == 1000
+        assert highx == 58868
+        assert highy == 13288
+
+        # test affine matrix, scale to 50%
+        lowx, highx, lowy, highy = Annotationelement()._overlayBounds({
+            'type': 'imageoverlay', 'girderId': itemId,
+            'transform': {
+                'matrix': [[0.5, 0], [0, 0.5]]
+            }
+        })
+        assert lowx == 0
+        assert lowy == 0
+        assert highx == 58368 / 2
+        assert highy == 12288 / 2
+
+        # test transform and scaling
+        lowx, highx, lowy, highy = Annotationelement()._overlayBounds({
+            'type': 'imageoverlay', 'girderId': itemId,
+            'transform': {
+                'xoffset': 500,
+                'yoffset': 1000,
+                'matrix': [[0.5, 0], [0, 0.5]]
+            }
+        })
+        assert lowx == 500
+        assert lowy == 1000
+        assert highx == (58368 / 2) + 500
+        assert highy == (12288 / 2) + 1000
+
     def testBoundingBox(self):
         bbox = Annotationelement()._boundingBox({'points': [[1, -2, 3], [-4, 5, -6], [7, -8, 9]]})
         assert bbox == {


### PR DESCRIPTION
This PR addresses server-side changes for #678 

Changes include:

- Modification of existing annotation schema to allow for specification of an image overlay

An image overlay is specified on the annotation itself, and not as an element. At a minimum, an image overlay requires a girder large image item ID. Opacity and location can also be specified. Location is specified with properties for position of the top-left corner of the image to overlay, as well as ta height and width. By default the overlaid image has opacity 1 and is aligned in the upper left in its native resolution.

The reason I went with adding the overlay as a direct child to the annotation schema, and not as a type of annotation element, is that I am trying to avoid a major refactor of what an annotation element is. It seems that a lot of downstream code assumes that annotation elements are made up of points/lines/polygons, and image overlays will need to be handled differently by client code (rendering on different layers, ensuring the linked tiled image exists). 

I am open to discussing other possibilities regarding how best to model image overlays on the back end. Particularly I'm wondering if my reasoning above is indeed valid, or if there's another, better approach, like making a dedicated `girder Model` for image overlays. 
