### PR TITLE
Add scooby Report

### DIFF
--- a/large_image/__init__.py
+++ b/large_image/__init__.py
@@ -17,8 +17,8 @@
 from pkg_resources import DistributionNotFound, get_distribution
 
 from . import tilesource  # noqa
+from .report import Report  # noqa
 from .tilesource import canRead, getTileSource, open  # noqa
-from .report import Report
 
 try:
     __version__ = get_distribution(__name__).version

--- a/large_image/__init__.py
+++ b/large_image/__init__.py
@@ -18,6 +18,7 @@ from pkg_resources import DistributionNotFound, get_distribution
 
 from . import tilesource  # noqa
 from .tilesource import canRead, getTileSource, open  # noqa
+from .report import Report
 
 try:
     __version__ = get_distribution(__name__).version

--- a/large_image/report.py
+++ b/large_image/report.py
@@ -4,7 +4,6 @@ import scooby
 class Report(scooby.Report):
     def __init__(self, additional=None, ncol=3, text_width=80, sort=False):
         """Initiate a scooby.Report instance."""
-
         # Mandatory packages.
         core = [
             'large_image',
@@ -15,14 +14,12 @@ class Report(scooby.Report):
             'palettable',
             'scooby',
         ]
-
         # Optional packages.
         girder = [
             'girder_large_image',
             'girder_worker_utils'
             'girder_worker'
         ]
-
         sources = [
             'large_image_source_bioformats',
             'bioformats',
@@ -47,7 +44,6 @@ class Report(scooby.Report):
             'libtiff',
             'large_image_converter',
         ]
-
         optional = [
             'pylibmc',
             'matplotlib',
@@ -58,7 +54,6 @@ class Report(scooby.Report):
             'packaging',
             'skimage',
         ] + sources + girder
-
         scooby.Report.__init__(
             self,
             additional=additional,

--- a/large_image/report.py
+++ b/large_image/report.py
@@ -1,0 +1,70 @@
+import scooby
+
+
+class Report(scooby.Report):
+    def __init__(self, additional=None, ncol=3, text_width=80, sort=False):
+        """Initiate a scooby.Report instance."""
+
+        # Mandatory packages.
+        core = [
+            'large_image',
+            'cachetools',
+            'PIL',
+            'psutil',
+            'numpy',
+            'palettable',
+            'scooby',
+        ]
+
+        girder = [
+            'girder_large_image',
+            'girder_worker_utils'
+            'girder_worker'
+        ]
+
+        # Optional packages.
+        sources = [
+            'large_image_source_bioformats',
+            'bioformats',
+            'large_image_source_deepzoom',
+            'large_image_source_dummy',
+            'large_image_source_gdal',
+            'osgeo.gdal',
+            'pyproj',
+            'large_image_source_mapnik',
+            'mapnik',
+            'large_image_source_nd2',
+            'importlib',
+            'nd2reader',
+            'large_image_source_ometiff',
+            'large_image_source_openjpeg',
+            'glymur',
+            'large_image_source_openslide',
+            'openslide',
+            'large_image_source_pil',
+            'large_image_source_test',
+            'large_image_source_tiff',
+            'libtiff',
+            'large_image_converter',
+        ]
+
+        optional = [
+            'pylibmc',
+            'matplotlib',
+            'colorcet',
+            'cmocean',
+            'tifftools',
+            'pyvips',
+            'packaging',
+            'skimage',
+        ] + sources + girder
+
+        scooby.Report.__init__(
+            self,
+            additional=additional,
+            core=core,
+            optional=optional,
+            ncol=ncol,
+            text_width=text_width,
+            sort=sort,
+        )

--- a/large_image/report.py
+++ b/large_image/report.py
@@ -16,13 +16,13 @@ class Report(scooby.Report):
             'scooby',
         ]
 
+        # Optional packages.
         girder = [
             'girder_large_image',
             'girder_worker_utils'
             'girder_worker'
         ]
 
-        # Optional packages.
         sources = [
             'large_image_source_bioformats',
             'bioformats',

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         'Pillow!=8.3.0,!=8.3.1',
         'psutil>=4.2.0',  # technically optional
         'numpy>=1.10.4',
+        'scooby',
     ],
     extras_require=extraReqs,
     include_package_data=True,


### PR DESCRIPTION
`large_image` and all of it's source modules have quite a few optional dependencies. Uncovering the different versions of all of these packages when debugging can be tedious/burdensome - especially for users who aren't familiar with all of the optional packages.

I've added a [scooby Report](https://github.com/banesullivan/scooby) to the base `large_image` package to make it easier to see what's installed.

Here's an example:

```py
>>> import large_image
>>> large_image.Report()
Could not find Java JRE compatible with x86_64 architecture

--------------------------------------------------------------------------------
  Date: Sat Dec 18 12:57:36 2021 MST

                           OS : Darwin
                       CPU(s) : 16
                      Machine : x86_64
                 Architecture : 64bit
                          RAM : 64.0 GiB
                  Environment : Python
                  File system : apfs

  Python 3.8.12 | packaged by conda-forge | (default, Sep 16 2021, 01:59:00)
  [Clang 11.1.0 ]

                  large_image : 1.8.8.dev16+ga8e032a.d20211130
                   cachetools : 4.2.2
                          PIL : 8.3.2
                       psutil : 5.8.0
                        numpy : 1.21.4
                   palettable : 3.3.0
                       scooby : 0.5.9
                   matplotlib : 3.5.0
                    tifftools : 1.2.9
                       pyvips : Trouble importing
                    packaging : 21.0
                      skimage : 0.18.3
large_image_source_bioformats : 1.8.8.dev16+ga8e032a.d20211130
                   bioformats : 0.0.0
  large_image_source_deepzoom : Version unknown
     large_image_source_dummy : 1.8.8.dev16+ga8e032a.d20211130
      large_image_source_gdal : 1.8.8.dev16+ga8e032a.d20211130
                   osgeo.gdal : 3.4.0
                       pyproj : 3.2.1
       large_image_source_nd2 : 1.8.8.dev16+ga8e032a.d20211130
                    importlib : Version unknown
                    nd2reader : 3.3.0
   large_image_source_ometiff : 1.8.8.dev16+ga8e032a.d20211130
  large_image_source_openjpeg : 1.8.8.dev16+ga8e032a.d20211130
                       glymur : 0.9.6
 large_image_source_openslide : 1.8.8.dev16+ga8e032a.d20211130
                    openslide : 1.1.2
       large_image_source_pil : 1.8.8.dev16+ga8e032a.d20211130
      large_image_source_test : 1.8.8.dev16+ga8e032a.d20211130
      large_image_source_tiff : 1.8.8.dev16+ga8e032a.d20211130
                      libtiff : Version unknown
        large_image_converter : 1.8.8.dev16+ga8e032a.d20211130
--------------------------------------------------------------------------------
```

@manthey, scooby is pure Python with no dependencies, so it should be lightweight enough to add as a hard requirement but if you are hesitant, we can implement this logic:

From https://github.com/banesullivan/scooby#implementing-as-a-soft-dependency
```py
# Make scooby a soft dependency:
try:
    from scooby import Report as ScoobyReport
except ImportError:
    class ScoobyReport:
        def __init__(self, *args, **kwargs):
            message = (
                '\n  *ERROR*: `Report` requires `scooby`.'
                '\n           Install it via `pip install scooby` or'
                '\n           `conda install -c conda-forge scooby`.\n'
            )
            raise ImportError(message)
```

----

Also, there are a lot of dependencies so it may be good to double-check that I didn't miss any