### PR TITLE
Don't specify the default encoding for encode/decode.

### DIFF
--- a/girder_annotation/test_annotation/girder_utilities.py
+++ b/girder_annotation/test_annotation/girder_utilities.py
@@ -53,9 +53,9 @@ def getBody(response, text=True):
 
     for chunk in response.body:
         if text and isinstance(chunk, bytes):
-            chunk = chunk.decode('utf8')
+            chunk = chunk.decode()
         elif not text and not isinstance(chunk, bytes):
-            chunk = chunk.encode('utf8')
+            chunk = chunk.encode()
         data += chunk
 
     return data

--- a/girder_annotation/test_annotation/test_annotations_rest.py
+++ b/girder_annotation/test_annotation/test_annotations_rest.py
@@ -110,7 +110,7 @@ class TestLargeImageAnnotationRest:
         assert b'\x00' in result
         elements = result.split(b'\x00', 1)[1].rsplit(b'\x00', 1)[0]
         data = result.split(b'\x00', 1)[0] + result.rsplit(b'\x00', 1)[1]
-        data = json.loads(data.decode('utf8'))
+        data = json.loads(data.decode())
         assert len(data['_elementQuery']['props']) == 1
         assert len(elements) == 28 * 1
         x, y, r, s = struct.unpack('<fffl', elements[12:28])

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -125,7 +125,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         if projection and projection.lower().startswith('epsg:'):
             projection = NeededInitPrefix + projection.lower()
         if projection and not isinstance(projection, bytes):
-            projection = projection.encode('utf8')
+            projection = projection.encode()
         self.projection = projection
         try:
             with self._getDatasetLock:
@@ -486,7 +486,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                     key = keys[idx]
                     bounds[key]['x'] = pt[0]
                     bounds[key]['y'] = pt[1]
-                bounds['srs'] = srs.decode('utf8') if isinstance(srs, bytes) else srs
+                bounds['srs'] = srs.decode() if isinstance(srs, bytes) else srs
             bounds['xmin'] = min(bounds['ll']['x'], bounds['ul']['x'],
                                  bounds['lr']['x'], bounds['ur']['x'])
             bounds['xmax'] = max(bounds['ll']['x'], bounds['ul']['x'],
@@ -723,7 +723,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             res = (self.unitsAcrossLevel0 / self.tileSize) * (2 ** -z)
             if not hasattr(self, '_warpSRS'):
                 self._warpSRS = (self.getProj4String(),
-                                 self.projection.decode('utf8'))
+                                 self.projection.decode())
                 if self._warpSRS[1].startswith(InitPrefix) and tuple(
                         int(p) for p in gdal.__version__.split('.')[:2]) >= (3, 1):
                     self._warpSRS = (self._warpSRS[0], self._warpSRS[1][len(InitPrefix):])
@@ -760,7 +760,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             cannot be created.
         """
         if isinstance(proj, bytes):
-            proj = proj.decode('utf8')
+            proj = proj.decode()
         if not isinstance(proj, str):
             return
         if proj.lower().startswith('proj4:'):

--- a/sources/nd2/large_image_source_nd2/__init__.py
+++ b/sources/nd2/large_image_source_nd2/__init__.py
@@ -22,7 +22,7 @@ import types
 import warnings
 
 # Work around an issue in the PIMS package (can be removed once pims is
-# released for Python 3.10)
+# released for Python 3.10).  This must be before improt nd2reader.
 if True:
     import collections.abc
     collections.Iterable = collections.abc.Iterable
@@ -161,12 +161,12 @@ class ND2FileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         for key, value in olddict.items():
             if value not in (None, b'', ''):
                 if isinstance(key, bytes):
-                    key = key.decode('utf8')
+                    key = key.decode()
                 if (isinstance(value, dict) and len(value) == 1 and
                         list(value.keys())[0] in (b'', '')):
                     value = list(value.values())[0]
                 if isinstance(value, bytes):
-                    value = value.decode('utf8')
+                    value = value.decode()
                 if isinstance(value, dict):
                     value = self._getND2MetadataCleanDict(value)
                     if not len(value):
@@ -178,7 +178,7 @@ class ND2FileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                         continue
                     for idx, entry in enumerate(value):
                         if isinstance(entry, bytes):
-                            entry = entry.decode('utf8')
+                            entry = entry.decode()
                         if isinstance(entry, dict):
                             entry = self._getND2MetadataCleanDict(entry)
                         value[idx] = entry

--- a/sources/openslide/large_image_source_openslide/__init__.py
+++ b/sources/openslide/large_image_source_openslide/__init__.py
@@ -367,7 +367,7 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 return None
         bytePath = self._largeImagePath
         if not isinstance(bytePath, bytes):
-            bytePath = bytePath.encode('utf8')
+            bytePath = bytePath.encode()
         _tiffFile = libtiff_ctypes.TIFF.open(bytePath)
         _tiffFile.SetDirectory(images[imageKey])
         img = _tiffFile.read_image()

--- a/sources/tiff/large_image_source_tiff/__init__.py
+++ b/sources/tiff/large_image_source_tiff/__init__.py
@@ -389,7 +389,7 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 if not len(self._associatedImages):
                     id = 'macro'
             if not isinstance(id, str):
-                id = id.decode('utf8')
+                id = id.decode()
             # Only use this as an associated image if the parsed id is
             # a reasonable length, alphanumeric characters, and the
             # image isn't too large.
@@ -520,7 +520,7 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                     if isinstance(v, (str, bytes)) and k:
                         if isinstance(v, bytes):
                             try:
-                                v = v.decode('utf8')
+                                v = v.decode()
                             except UnicodeDecodeError:
                                 continue
                         results.setdefault('tiff', {})

--- a/sources/tiff/large_image_source_tiff/tiff_reader.py
+++ b/sources/tiff/large_image_source_tiff/tiff_reader.py
@@ -165,7 +165,7 @@ class TiledTiffDirectory:
         try:
             bytePath = filePath
             if not isinstance(bytePath, bytes):
-                bytePath = filePath.encode('utf8')
+                bytePath = filePath.encode()
             self._tiffFile = libtiff_ctypes.TIFF.open(bytePath)
         except TypeError:
             raise IOTiffException(
@@ -824,7 +824,7 @@ class TiledTiffDirectory:
         if not meta:
             return
         if not isinstance(meta, str):
-            meta = meta.decode('utf8', 'ignore')
+            meta = meta.decode(errors='ignore')
         try:
             parsed = json.loads(meta)
             if isinstance(parsed, dict):


### PR DESCRIPTION
This just simplifies the code slightly.