### PR TITLE
Display image overlay annotations

### DIFF
--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -491,12 +491,10 @@ class AnnotationSchema:
                                'an X offset and a Y offset.',
                 'properties': {
                     'xoffset': {
-                        'type': 'number',
-                        'minimum': 0
+                        'type': 'number'
                     },
                     'yoffset': {
-                        'type': 'number',
-                        'minimum': 0
+                        'type': 'number'
                     },
                     'matrix': transformArray
                 },

--- a/girder_annotation/girder_large_image_annotation/web_client/annotations/convertFeatures.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/annotations/convertFeatures.js
@@ -95,32 +95,6 @@ function convertHeatmap(record, properties, layer) {
 }
 
 /**
- * Convert an image overlay annotation to a geojs feature.
- *
- * @param record: the image overlay annotation element.
- * @param properties: a property map of additional data, such as the original
- *      annotation id.
- * @param layer: the layer where this may be added.
- */
-// function convertImageOverlay(record, properties, layer) {
-    // /* Image overlays need to be in their own layer */
-    // const overlayItemId = record.girderId;
-
-    // // Get overlay overlay metadata to inform layer params
-    // restRequest({
-        // url: `item/${overlayItemId}/tiles`
-    // }).done((response) => {
-        // const map = layer.map();
-        // const geo = window.geo;
-        // let params = geo.util.pixelCoordinateParams(
-           // map.node(), response.sizeX, response.sizeY, response.tileHeight, response.tileWidth
-        // );
-        // return params;
-    // }).fail((response) => {
-    // });
-// }
-
-/**
  * Convert a griddata heatmap annotation to a geojs feature.
  *
  * @param record: the griddata heatmap annotation element.

--- a/girder_annotation/girder_large_image_annotation/web_client/annotations/convertFeatures.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/annotations/convertFeatures.js
@@ -1,5 +1,3 @@
-// import { restRequest } from '@girder/core/rest';
-
 /**
  * Create a color table that can be used for a heatmap.
  *

--- a/girder_annotation/girder_large_image_annotation/web_client/annotations/convertFeatures.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/annotations/convertFeatures.js
@@ -1,3 +1,5 @@
+// import { restRequest } from '@girder/core/rest';
+
 /**
  * Create a color table that can be used for a heatmap.
  *
@@ -91,6 +93,32 @@ function convertHeatmap(record, properties, layer) {
     heatmap._ownLayer = true;
     return [heatmap];
 }
+
+/**
+ * Convert an image overlay annotation to a geojs feature.
+ *
+ * @param record: the image overlay annotation element.
+ * @param properties: a property map of additional data, such as the original
+ *      annotation id.
+ * @param layer: the layer where this may be added.
+ */
+// function convertImageOverlay(record, properties, layer) {
+    // /* Image overlays need to be in their own layer */
+    // const overlayItemId = record.girderId;
+
+    // // Get overlay overlay metadata to inform layer params
+    // restRequest({
+        // url: `item/${overlayItemId}/tiles`
+    // }).done((response) => {
+        // const map = layer.map();
+        // const geo = window.geo;
+        // let params = geo.util.pixelCoordinateParams(
+           // map.node(), response.sizeX, response.sizeY, response.tileHeight, response.tileWidth
+        // );
+        // return params;
+    // }).fail((response) => {
+    // });
+// }
 
 /**
  * Convert a griddata heatmap annotation to a geojs feature.

--- a/girder_annotation/girder_large_image_annotation/web_client/models/AnnotationModel.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/models/AnnotationModel.js
@@ -362,6 +362,16 @@ export default AccessControlledModel.extend({
     },
 
     /**
+     * Return annotation elements that cannot be represented as geojs
+     * features, such as image overlays.
+     */
+    overlays() {
+        const json = this.get('annotation') || {};
+        const elements = json.elements || [];
+        return elements.filter((element) => element.type === 'imageoverlay');
+    },
+
+    /**
      * Set the view.  If we are paging elements, possibly refetch the elements.
      * Callers should listen for the g:fetched event to know when new elements
      * have been fetched.

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -212,9 +212,10 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                     params.layer.autoshareRenderer = false;
                     params.layer.opacity = overlay.opacity || 1;
                     let overlayLayer = this.viewer.createLayer('osm', params.layer);
-                    console.log({ overlayLayer });
+                    overlayLayer.id(overlay.id);
+                    this.viewer.scheduleAnimationFrame(this.viewer.draw, true);
                 }).fail((response) => {
-                    console.log({ response });
+                    console.error(`There was an error overlaying image with ID ${overlayItemId}`);
                 });
             });
             this._featureOpacity[annotation.id] = {};
@@ -428,6 +429,11 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                     } else {
                         this.featureLayer.deleteFeature(feature);
                     }
+                });
+                _.each(this._annotations[annotation.id].overlays, (overlay) => {
+                    const overlayLayer = this.viewer.layers().find(
+                        (layer) => layer.id() === overlay.id);
+                    this.viewer.deleteLayer(overlayLayer);
                 });
                 delete this._annotations[annotation.id];
                 delete this._featureOpacity[annotation.id];

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -67,6 +67,9 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             const xOffset = transformInfo.xoffset || 0;
             const yOffset = transformInfo.yoffset || 0;
             const matrix = transformInfo.matrix || [[1, 0], [0, 1]];
+            if (xOffset === 0 && yOffset === 0 && matrix === [[1, 0], [0, 1]]) {
+                return '+proj=longlat +axis=enu';
+            }
             return `+proj=longlat +axis=enu +s11=${1 / matrix[0][0]} +s12=${matrix[0][1]}` +
                    ` +s21=${matrix[1][0]} +s22=${1 / matrix[1][1]} +xoff=-${xOffset} +yoff=${yOffset}`;
         },

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -115,7 +115,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                     this.viewer.deleteLayer(overlayLayer);
                 });
             }
-            let overlays = annotation.overlays();
+            const overlays = annotation.overlays() || [];
             this._annotations[annotation.id] = {
                 features: centroidFeature ? [centroidFeature] : [],
                 options: options,
@@ -214,6 +214,10 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                 });
             }
             // draw overlays
+            if (this._annotations[annotation.id].overlays.length > 0) {
+                this.viewer.clampBoundsY(false);
+                this.viewer.clampBoundsX(false);
+            }
             _.each(this._annotations[annotation.id].overlays, (overlay) => {
                 const overlayItemId = overlay.girderId;
                 restRequest({
@@ -454,6 +458,8 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                 });
                 delete this._annotations[annotation.id];
                 delete this._featureOpacity[annotation.id];
+                this.viewer.clampBoundsY(true);
+                this.viewer.clampBoundsX(true);
                 this.viewer.scheduleAnimationFrame(this.viewer.draw);
             }
         },

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -82,7 +82,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
          */
         _getOverlayTransformProjString: function (overlay) {
             const transformInfo = overlay.transform || {};
-            const xOffset = transformInfo.xoffset || 0;
+            let xOffset = transformInfo.xoffset || 0;
             const yOffset = transformInfo.yoffset || 0;
             const matrix = transformInfo.matrix || [[1, 0], [0, 1]];
             const s11 = matrix[0][0];
@@ -91,10 +91,13 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             const s22 = matrix[1][1];
 
             let projString = '+proj=longlat +axis=enu';
-            if (xOffset > 0) {
-                projString = projString + ` +xoff=-${xOffset}`;
+            if (xOffset !== 0) {
+                // negate x offset so positive values specified in the annotation
+                // move overlays to the right
+                xOffset = -1 * xOffset;
+                projString = projString + ` +xoff=${xOffset}`;
             }
-            if (yOffset > 0) {
+            if (yOffset !== 0) {
                 projString = projString + ` +yoff=${yOffset}`;
             }
             if (s11 !== 1 || s12 !== 0 || s21 !== 0 || s22 !== 1) {

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -85,11 +85,22 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             const xOffset = transformInfo.xoffset || 0;
             const yOffset = transformInfo.yoffset || 0;
             const matrix = transformInfo.matrix || [[1, 0], [0, 1]];
-            if (xOffset === 0 && yOffset === 0 && matrix === [[1, 0], [0, 1]]) {
-                return '+proj=longlat +axis=enu';
+            const s11 = matrix[0][0];
+            const s12 = matrix[0][1];
+            const s21 = matrix[1][0];
+            const s22 = matrix[1][1];
+            let projString = '+proj=longlat +axis=enu';
+            if (xOffset > 0) {
+                projString = projString + ` +xoff=-${xOffset}`;
             }
-            return `+proj=longlat +axis=enu +s11=${1 / matrix[0][0]} +s12=${matrix[0][1]}` +
-                   ` +s21=${matrix[1][0]} +s22=${1 / matrix[1][1]} +xoff=-${xOffset} +yoff=${yOffset}`;
+            if (yOffset > 0) {
+                projString = projString + ` +yoff=${yOffset}`;
+            }
+            if (s11 !== 1 || s12 !== 0 || s21 !== 0 || s22 !== 1) {
+                // add affine matrix vals to projection string if not identity matrix
+                projString = projString + ` +s11=${1 / s11} +s12=${s12} +s21=${s21} +s22=${1 / s22}`;
+            }
+            return projString;
         },
 
         /**

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -61,7 +61,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
          * @returns whether to clamp viewer bounds when image overlays are
          * rendered
          */
-        getUnclampBoundsForOverlay() {
+        getUnclampBoundsForOverlay: function () {
             return this._unclampBoundsForOverlay;
         },
 
@@ -70,7 +70,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
          * @param {bool} newValue Set whether to clamp viewer bounds when image
          * overlays are rendered.
          */
-        setUnclampBoundsForOverlay(newValue) {
+        setUnclampBoundsForOverlay: function (newValue) {
             this._unclampBoundsForOverlay = newValue;
         },
 
@@ -90,6 +90,19 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             }
             return `+proj=longlat +axis=enu +s11=${1 / matrix[0][0]} +s12=${matrix[0][1]}` +
                    ` +s21=${matrix[1][0]} +s22=${1 / matrix[1][1]} +xoff=-${xOffset} +yoff=${yOffset}`;
+        },
+
+        /**
+         * @returns The number of currently drawn overlay elements across
+         * all annotations.
+         */
+        _countDrawnImageOverlays: function () {
+            let numOverlays = 0;
+            _.each(this._annotations, (value, key, obj) => {
+                let annotationOverlays = value.overlays || [];
+                numOverlays += annotationOverlays.length;
+            });
+            return numOverlays;
         },
 
         /**
@@ -249,7 +262,11 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                     );
                     params.layer.useCredentials = true;
                     params.layer.url = `api/v1/item/${overlayItemId}/tiles/zxy/{z}/{x}/{y}`;
-                    params.layer.autoshareRenderer = false;
+                    if (this._countDrawnImageOverlays() <= 6) {
+                        params.layer.autoshareRenderer = false;
+                    } else {
+                        params.layer.renderer = 'canvas';
+                    }
                     params.layer.opacity = overlay.opacity || 1;
                     const overlayLayer = this.viewer.createLayer('osm', params.layer);
                     overlayLayer.id(overlay.id);

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -68,7 +68,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             const yOffset = transformInfo.yoffset || 0;
             const matrix = transformInfo.matrix || [[1, 0], [0, 1]];
             return `+proj=longlat +axis=enu +s11=${1 / matrix[0][0]} +s12=${matrix[0][1]}` +
-                   ` +s21=${matrix[1][0]} +s22=${ 1 / matrix[1][1]} +xoff=-${xOffset} +yoff=${yOffset}`;
+                   ` +s21=${matrix[1][0]} +s22=${1 / matrix[1][1]} +xoff=-${xOffset} +yoff=${yOffset}`;
         },
 
         /**
@@ -109,11 +109,11 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                         centroidFeature = feature;
                     }
                 });
-                let overlayLayerIds = this._annotations[annotation.id].overlays.map((overlay) => overlay.id);
-                let overlayLayers = this.viewer.layers().filter((layer) => overlayLayerIds.contains(layer.id()));
-                for (const layer of overlayLayers) {
-                    this.viewer.deleteLayer(layer);
-                }
+                _.each(this._annotations[annotation.id].overlays, (overlay) => {
+                    const overlayLayer = this.viewer.layers().find(
+                        (layer) => layer.id() === overlay.id);
+                    this.viewer.deleteLayer(overlayLayer);
+                });
             }
             let overlays = annotation.overlays();
             this._annotations[annotation.id] = {

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -26,6 +26,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
 
         this._annotations = {};
         this._featureOpacity = {};
+        this._unclampBoundsForOverlay = true;
         this._globalAnnotationOpacity = settings.globalAnnotationOpacity || 1.0;
         this._globalAnnotationFillOpacity = settings.globalAnnotationFillOpacity || 1.0;
         this._highlightFeatureSizeLimit = settings.highlightFeatureSizeLimit || 10000;
@@ -55,6 +56,23 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
         },
 
         annotationAPI: _.constant(true),
+
+        /**
+         * @returns whether to clamp viewer bounds when image overlays are
+         * rendered
+         */
+        getUnclampBoundsForOverlay() {
+            return this._unclampBoundsForOverlay;
+        },
+
+        /**
+         *
+         * @param {bool} newValue Set whether to clamp viewer bounds when image
+         * overlays are rendered.
+         */
+        setUnclampBoundsForOverlay(newValue) {
+            this._unclampBoundsForOverlay = newValue;
+        },
 
         /**
          * Given an image overlay annotation element, compute and return
@@ -217,7 +235,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                 });
             }
             // draw overlays
-            if (this._annotations[annotation.id].overlays.length > 0) {
+            if (this.getUnclampBoundsForOverlay() && this._annotations[annotation.id].overlays.length > 0) {
                 this.viewer.clampBoundsY(false);
                 this.viewer.clampBoundsX(false);
             }

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -496,8 +496,13 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                 });
                 delete this._annotations[annotation.id];
                 delete this._featureOpacity[annotation.id];
-                this.viewer.clampBoundsY(true);
-                this.viewer.clampBoundsX(true);
+
+                // If removing an overlay annotation results in no more overlays drawn, and we've
+                // previously un-clamped bounds for overlays, re-clamp bounds
+                if (this._countDrawnImageOverlays() === 0 && this.getUnclampBoundsForOverlay()) {
+                    this.viewer.clampBoundsY(true);
+                    this.viewer.clampBoundsX(true);
+                }
                 this.viewer.scheduleAnimationFrame(this.viewer.draw);
             }
         },

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -130,7 +130,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
         _generateOverlayLayerParams(overlayImageMetadata, overlayImageId, overlay) {
             const geo = window.geo;
             let params = geo.util.pixelCoordinateParams(
-                this.viewer.node(), overlayImageMetadata.sizeX, overlayImageMetadata.sizeY, overlayImageMetadata.tileHeight, overlayImageMetadata.tileWidth
+                this.viewer.node(), overlayImageMetadata.sizeX, overlayImageMetadata.sizeY, overlayImageMetadata.tileWidth, overlayImageMetadata.tileHeight
             );
             params.layer.useCredentials = true;
             params.layer.url = `api/v1/item/${overlayImageId}/tiles/zxy/{z}/{x}/{y}`;
@@ -142,7 +142,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             params.layer.opacity = overlay.opacity || 1;
 
             if (this.levels !== overlayImageMetadata.levels) {
-                const levelDifference = Math.abs(this.levels - overlayImageMetadata.levels);
+                const levelDifference = this.levels - overlayImageMetadata.levels;
                 params.layer.url = (x, y, z) => 'api/v1/item/' + overlayImageId + `/tiles/zxy/${z - levelDifference}/${x}/${y}`;
                 params.layer.minLevel = levelDifference;
                 params.layer.maxLevel += levelDifference;


### PR DESCRIPTION
Implement client support for image overlay annotation elements.

Changes include:

- [x] Draw image overlays when annotations containing them are selected in the Girder `large_image` UI
- [x] Remove image overlays when their annotations are deselected
- [x] Support rendering image overlays with opacity specified in the annotation JSON
- [x] Support image overlay offset
- [x] Support image overlay transform via affine matrix

(opening as draft PR to kick start discussion about implementation details)

Closes #678 