### PR TITLE
Add additional behaviors to image overlays

### DIFF
--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -508,7 +508,7 @@ class AnnotationSchema:
             'group': groupSchema,
         },
         'required': ['girderId', 'type'],
-        'additionalProperties': False,
+        'additionalProperties': True,
         'description': 'An image to overlay onto another like an '
                        'annotation.'
     }

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -140,6 +140,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                 params.layer.renderer = 'canvas';
             }
             params.layer.opacity = overlay.opacity || 1;
+            params.layer.opacity *= this.featureLayer.opacity();
 
             if (this.levels !== overlayImageMetadata.levels) {
                 const levelDifference = this.levels - overlayImageMetadata.levels;
@@ -660,6 +661,14 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                     feature.layer().opacity(opacity);
                 }
             }));
+            _.each(this._annotations, (annotation) => {
+                _.each(annotation.overlays, (overlay) => {
+                    const overlayLayer = this.viewer.layers().find((layer) => layer.id() === overlay.id);
+                    if (overlayLayer) {
+                        overlayLayer.opacity(opacity * overlay.opacity);
+                    }
+                });
+            });
             return this;
         },
 

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -190,6 +190,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             var geo = window.geo;
             options = _.defaults(options || {}, {fetch: true});
             var geojson = annotation.geojson();
+            const overlays = annotation.overlays() || [];
             var present = _.has(this._annotations, annotation.id);
             var centroidFeature;
             if (present) {
@@ -204,8 +205,20 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                         centroidFeature = feature;
                     }
                 });
+                if (this._annotations[annotation.id].overlays) {
+                    // Ensure that overlay elements that have been deleted are not rendered on a re-draw
+                    _.each(this._annotations[annotation.id].overlays, (overlay) => {
+                        const oldOverlayIds = this._annotations[annotation.id].overlays.map((overlay) => overlay.id);
+                        const updatedOverlayIds = overlays.map((overlay) => overlay.id);
+                        _.each(oldOverlayIds, (id) => {
+                            if (!updatedOverlayIds.includes(id)) {
+                                const overlayLayer = this.viewer.layers().find((layer) => layer.id() === id);
+                                this.viewer.deleteLayer(overlayLayer);
+                            }
+                        });
+                    });
+                }
             }
-            const overlays = annotation.overlays() || [];
             this._annotations[annotation.id] = {
                 features: centroidFeature ? [centroidFeature] : [],
                 options: options,
@@ -506,11 +519,13 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             if (overlays) {
                 _.each(overlays, (overlay) => {
                     const overlayLayer = this.viewer.layers().find((layer) => layer.id() === overlay.id);
-                    let newOpacity = (overlay.opacity || 1) * this._globalAnnotationOpacity;
-                    if (this._highlightAnnotation && annotationId !== this._highlightAnnotation) {
-                        newOpacity = newOpacity * 0.25;
+                    if (overlayLayer) {
+                        let newOpacity = (overlay.opacity || 1) * this._globalAnnotationOpacity;
+                        if (this._highlightAnnotation && annotationId !== this._highlightAnnotation) {
+                            newOpacity = newOpacity * 0.25;
+                        }
+                        overlayLayer.opacity(newOpacity);
                     }
-                    overlayLayer.opacity(newOpacity);
                 });
             }
         },

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -140,7 +140,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                 params.layer.renderer = 'canvas';
             }
             params.layer.opacity = overlay.opacity || 1;
-            params.layer.opacity *= this.featureLayer.opacity();
+            params.layer.opacity *= this._globalAnnotationOpacity;
 
             if (this.levels !== overlayImageMetadata.levels) {
                 const levelDifference = this.levels - overlayImageMetadata.levels;
@@ -501,6 +501,18 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                 feature.updateStyleFromArray('strokeOpacity', strokeOpacityArray);
                 feature._lastFeatureProp = prop;
             });
+            // Also modify opacity of image overlay layers
+            const overlays = this._annotations[annotationId].overlays || null;
+            if (overlays) {
+                _.each(overlays, (overlay) => {
+                    const overlayLayer = this.viewer.layers().find((layer) => layer.id() === overlay.id);
+                    let newOpacity = (overlay.opacity || 1) * this._globalAnnotationOpacity;
+                    if (this._highlightAnnotation && annotationId !== this._highlightAnnotation) {
+                        newOpacity = newOpacity * 0.25;
+                    }
+                    overlayLayer.opacity(newOpacity);
+                });
+            }
         },
 
         /**
@@ -665,7 +677,8 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                 _.each(annotation.overlays, (overlay) => {
                     const overlayLayer = this.viewer.layers().find((layer) => layer.id() === overlay.id);
                     if (overlayLayer) {
-                        overlayLayer.opacity(opacity * overlay.opacity);
+                        const overlayOpacity = overlay.opacity || 1;
+                        overlayLayer.opacity(opacity * overlayOpacity);
                     }
                 });
             });


### PR DESCRIPTION
This PR rounds out some functionality for image overlays that make them more reactive in applications like [HistomicsUI](https://github.com/DigitalSlideArchive/HistomicsUI).

Specifically, this PR introduces the following changes:
- Image overlay layers now properly respond to the `globalAnnotationOpacity` of the image viewer. As a result, image overlays now change opacity based on the slider in HistomicsUI.
- Image overlays now respect the currently highlighted annotation. Image overlay elements of non-highlighted annotations will reduce their opacity by 75% like other element types. This can be demonstrated in HUI by selecting "Interactive" in the annotations widget and hovering over different annotations in the list.
- Schema for image overlays now allows for additional properties. This fixes an issue where editing an annotation (e.g. via HUI) would cause an error when trying to save, since the `id` property would be added to the overlay elements.
-  `drawAnnotation` has been updated to account for the case where an image overlay element was removed from the annotation between an initial call to `drawAnnotation` and a follow up call to `drawAnnotation`.