### PR TITLE
Change the repr of the TileSource class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 - Add more opacity support for image overlays ([#761](../../pull/761))
 - Make annotation schema more uniform ([#763](../../pull/763))
+- Improve TileSource class repr ([#765](../../pull/765))
 
 ## Version 1.10.0
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -134,6 +134,9 @@ class TileSource:
             except TypeError:
                 raise exceptions.TileSourceError('Style is not a valid json object.')
 
+    def __repr__(self):
+        return self.getState()
+
     @staticmethod
     def getLRUHash(*args, **kwargs):
         """

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -202,3 +202,9 @@ def testExpanduserPath():
         userPath = '~' + os.sep + absPath[len(userDir):]
         assert large_image.canRead(userPath)
         assert large_image.canRead(Path(userPath))
+
+
+def testClassRepr():
+    imagePath = datastore.fetch('sample_image.ptif')
+    ts = large_image.open(imagePath)
+    assert 'sample_image.ptif' in repr(ts)


### PR DESCRIPTION
The repr now returns the state string, which includes the specific information that makes the class unique.