### PR TITLE
A scikit-image as a requirement for the bioformats source.

### DIFF
--- a/sources/bioformats/setup.py
+++ b/sources/bioformats/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires=[
         'large-image',
         'python-bioformats>=1.5.2',
+        'scikit-image',
     ],
     extras_require={
         'girder': 'girder-large-image',


### PR DESCRIPTION
This prevents PIMS from throwing warnings.