### PR TITLE
Improve frame slider response with base quads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add more opacity support for image overlays ([#761](../../pull/761))
 - Make annotation schema more uniform ([#763](../../pull/763))
 - Improve TileSource class repr ([#765](../../pull/765))
+- Improve frame slider response with base quads ([#771](../../pull/771))
 
 ## Version 1.10.0
 

--- a/girder/girder_large_image/web_client/views/imageViewerWidget/setFrameQuad.js
+++ b/girder/girder_large_image/web_client/views/imageViewerWidget/setFrameQuad.js
@@ -192,6 +192,9 @@ function setFrameQuad(tileinfo, layer, options) {
                         options.progress(status);
                     } catch (err) {}
                 }
+                if (status.frame !== undefined) {
+                    layer.baseQuad = Object.assign({}, status.quads[status.framesToIdx[status.frame]]);
+                }
             };
         } else {
             ((idx) => {
@@ -233,10 +236,10 @@ function setFrameQuad(tileinfo, layer, options) {
     status.images[0].src = status.src[0];
 
     layer.setFrameQuad = function (frame) {
-        if (status.framesToIdx[frame] !== undefined) {
+        if (status.framesToIdx[frame] !== undefined && status.loaded) {
             layer.baseQuad = Object.assign({}, status.quads[status.framesToIdx[frame]]);
-            status.frame = frame;
         }
+        status.frame = frame;
     };
     layer.setFrameQuad.status = status;
 }


### PR DESCRIPTION
Before, once a base quad was requested, the frame slider would not update the display until the base quad was loaded, even though it could be substantially slower than loading individual tiles.