### PR TITLE
The tile iterator could return excess tiles with overlap.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Improve frame slider response with base quads ([#771](../../pull/771))
 - Default to nearest-neighbor scaling in lossless image conversion ([#772](../../pull/772))
 
+### Bug Fixes
+- The tile iterator could return excess tiles with overlap ([#773](../../pull/773))
+
 ## Version 1.10.0
 
 ### Features

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -532,11 +532,15 @@ class TileSource:
             'edges': kwargs.get('tile_overlap', {}).get('edges', False),
             'offset_x': 0,
             'offset_y': 0,
+            'range_x': 0,
+            'range_y': 0
         }
         if not tile_overlap['edges']:
             # offset by half the overlap
             tile_overlap['offset_x'] = tile_overlap['x'] // 2
             tile_overlap['offset_y'] = tile_overlap['y'] // 2
+            tile_overlap['range_x'] = tile_overlap['x']
+            tile_overlap['range_y'] = tile_overlap['y']
         if 'tile_size' in kwargs:
             tile_size['width'] = int(kwargs['tile_size'].get(
                 'width', kwargs['tile_size'].get('height', tile_size['width'])))
@@ -563,10 +567,10 @@ class TileSource:
         # size of the region is reduced by the overlap.  This factor is stored
         # in the overlap offset_*.
         xmin = int(left / tile_size['width'])
-        xmax = int(math.ceil((float(right) - tile_overlap['offset_x']) /
+        xmax = int(math.ceil((float(right) - tile_overlap['range_x']) /
                              tile_size['width']))
         ymin = int(top / tile_size['height'])
-        ymax = int(math.ceil((float(bottom) - tile_overlap['offset_y']) /
+        ymax = int(math.ceil((float(bottom) - tile_overlap['range_y']) /
                              tile_size['height']))
         tile_overlap.update({'xmin': xmin, 'xmax': xmax,
                              'ymin': ymin, 'ymax': ymax})

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -221,3 +221,35 @@ def testClassRepr():
     imagePath = datastore.fetch('sample_image.ptif')
     ts = large_image.open(imagePath)
     assert 'sample_image.ptif' in repr(ts)
+
+
+def testTileOverlap():
+    testDir = os.path.dirname(os.path.realpath(__file__))
+    imagePath = os.path.join(testDir, 'test_files', 'test_orient1.tif')
+    ts = large_image.open(imagePath)
+    assert [(
+        tiles['x'], tiles['x'] + tiles['width'], tiles['width'],
+        tiles['tile_overlap']['left'], tiles['tile_overlap']['right']
+    ) for tiles in ts.tileIterator(
+        tile_size=dict(width=75, height=180), tile_overlap=dict(x=60))
+    ] == [
+        (0, 75, 75, 0, 30),
+        (15, 90, 75, 30, 30),
+        (30, 105, 75, 30, 30),
+        (45, 120, 75, 30, 0),
+    ]
+    assert [(
+        tiles['x'], tiles['x'] + tiles['width'], tiles['width'],
+        tiles['tile_overlap']['left'], tiles['tile_overlap']['right']
+    ) for tiles in ts.tileIterator(
+        tile_size=dict(width=75, height=180), tile_overlap=dict(x=60, edges=True))
+    ] == [
+        (0, 45, 45, 0, 30),
+        (0, 60, 60, 15, 30),
+        (0, 75, 75, 30, 30),
+        (15, 90, 75, 30, 30),
+        (30, 105, 75, 30, 30),
+        (45, 120, 75, 30, 30),
+        (60, 120, 60, 30, 15),
+        (75, 120, 45, 30, 0),
+    ]


### PR DESCRIPTION
This fixes a bug where, when overlap was specified, some smaller tiles could be returned at the right/bottom edges that were not necessary.  Since the overlap was documented, this probably only resulted in inefficiency, not and breakage.  This change now conforms to the tileIterator documentation and adds a test to ensure this is the case.