### PR TITLE
Add a tiledoutput extra_requires entry.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ extraReqs = {
     'memcached': ['pylibmc>=1.5.1 ; platform_system != "Windows"'],
     'converter': ['large-image-converter'],
     'colormaps': ['matplotlib'],
+    'tiledoutput': ['pyvips'],
 }
 sources = {
     'bioformats': ['large-image-source-bioformats'],


### PR DESCRIPTION
This is needed when generating tiled output regions.