### PR TITLE
Improve the import time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Improve TileSource class repr ([#765](../../pull/765))
 - Improve frame slider response with base quads ([#771](../../pull/771))
 - Default to nearest-neighbor scaling in lossless image conversion ([#772](../../pull/772))
+- Improve the import time ([#775](../../pull/775))
 
 ### Bug Fixes
 - The tile iterator could return excess tiles with overlap ([#773](../../pull/773))

--- a/large_image/cache_util/memcache.py
+++ b/large_image/cache_util/memcache.py
@@ -18,7 +18,6 @@ import hashlib
 import time
 
 import cachetools
-import pylibmc
 
 from .. import config
 
@@ -28,6 +27,9 @@ class MemCache(cachetools.Cache):
 
     def __init__(self, url='127.0.0.1', username=None, password=None,
                  getsizeof=None, mustBeAvailable=False):
+        global pylibmc
+        import pylibmc
+
         super().__init__(0, getsizeof=getsizeof)
         if isinstance(url, str):
             url = [url]

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from operator import attrgetter
 
 import numpy
-import palettable
 import PIL
 import PIL.Image
 import PIL.ImageColor
@@ -449,6 +448,8 @@ def getPaletteColors(value):
         above.
     :returns: a numpy array of RGBA value on the scale of [0-255].
     """
+    import palettable
+
     palette = None
     if isinstance(value, (tuple, list)):
         palette = value
@@ -524,6 +525,8 @@ def getAvailableNamedPalettes(includeColors=True, reduced=False):
         colors.
     :returns: a list of names.
     """
+    import palettable
+
     palettes = set()
     if includeColors:
         palettes |= set(PIL.ImageColor.colormap.keys())


### PR DESCRIPTION
Some libraries: palettable and pylibmc account for a substantial import time.  Loaded them as needed rather than on first import.