### PR TITLE
Support pixelmap annotations

### DIFF
--- a/girder_annotation/girder_large_image_annotation/web_client/models/AnnotationModel.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/models/AnnotationModel.js
@@ -366,9 +366,10 @@ export default AccessControlledModel.extend({
      * features, such as image overlays.
      */
     overlays() {
+        const overlayElementTypes = ['image', 'pixelmap'];
         const json = this.get('annotation') || {};
         const elements = json.elements || [];
-        return elements.filter((element) => element.type === 'image');
+        return elements.filter((element) => overlayElementTypes.includes(element.type));
     },
 
     /**

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -132,8 +132,11 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             layerParams.url = layerParams.url + `?encoding=PNG`;
             let pixelmapData = pixelmapElement.values;
             if (pixelmapElement.boundaries) {
-                let valuesWithBoundaries = new Array(pixelmapData.length * 2).fill(0);
-                pixelmapData = valuesWithBoundaries.map((d, i) => pixelmapData[Math.floor(i / 2)]);
+                let valuesWithBoundaries = new Array(pixelmapData.length * 2);
+                for (let i = 0; i < pixelmapData.length; i++) {
+                    valuesWithBoundaries[i * 2] = valuesWithBoundaries[i * 2 + 1] = pixelmapData[i];
+                }
+                pixelmapData = valuesWithBoundaries;
             }
             layerParams.data = pixelmapData;
             layerParams.style = {

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -129,7 +129,6 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
          */
         _addPixelmapLayerParams(layerParams, pixelmapElement) {
             // For pixelmap overlays, there are additional parameters to set
-            layerParams.keepLower = false;
             layerParams.url = layerParams.url + `?encoding=PNG`;
             let pixelmapData = pixelmapElement.values;
             if (pixelmapElement.boundaries) {

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -129,6 +129,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
          */
         _addPixelmapLayerParams(layerParams, pixelmapElement) {
             // For pixelmap overlays, there are additional parameters to set
+            layerParams.keepLower = false;
             layerParams.url = layerParams.url + `?encoding=PNG`;
             let pixelmapData = pixelmapElement.values;
             if (pixelmapElement.boundaries) {

--- a/girder_annotation/test_annotation/web_client_specs/geojsSpec.js
+++ b/girder_annotation/test_annotation/web_client_specs/geojsSpec.js
@@ -207,6 +207,38 @@ $(function () {
             });
         });
 
+        it('generates pixelmap layer parameters', function() {
+            const overlayMetadata = {
+                sizeX: 500,
+                sizeY: 500,
+                tileWidth: 256,
+                tileHeight: 256,
+                levels: viewer.levels,
+            };
+            const overlayId = '012345678901234567890123';
+            const pixelMapElement = {
+                type: 'pixelmap',
+                id: '00001111222233334444',
+                opacity: 0.5,
+                girderId: overlayId,
+                boundaries: false,
+                values: [0, 1, 0, 1, 0, 1],
+                categories: [
+                    {fillColor: '#000000'},
+                    {fillColor: '#ffffff'}
+                ]
+            }
+            const pixelmapLayerParams = viewer._generateOverlayLayerParams(overlayMetadata, overlayId, pixelMapElement);
+            const expectedUrl = 'api/v1/item/' + overlayId + '/tiles/zxy/{z}/{x}/{y}?encoding=PNG';
+            expect(pixelmapLayerParams.url).toBe(expectedUrl);
+            expect(pixelmapLayerParams.data).toEqual(pixelMapElement.values);
+
+            pixelMapElement.boundaries = true;
+            const pixelmapLayerParamsWithBoundaries = viewer._generateOverlayLayerParams(overlayMetadata, overlayId, pixelMapElement);
+            const expectedDataArray = [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1];
+            expect(pixelmapLayerParamsWithBoundaries.data).toEqual(expectedDataArray);
+        });
+
         it('mouse over events', function () {
             var mouseon, mouseover, context = {};
             runs(function () {


### PR DESCRIPTION
This PR updates the `large_image` plugin to support drawing `pixelmap` annotations (see #767).