### PR TITLE
Stop using pkg_resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Work with more matplotlib palettes ([#760](../../pull/760))
 
 ### Changes
-- Use importlib rather than pkg_resources internally ([#747](../../pull/747))
+- Use importlib rather than pkg_resources internally ([#747](../../pull/747), [#778](../../pull/778))
 
 ### Bug Fixes
 - Fix expanding a style palette with a single named color ([#754](../../pull/754))

--- a/girder/girder_large_image/__init__.py
+++ b/girder/girder_large_image/__init__.py
@@ -20,7 +20,6 @@ import warnings
 
 from girder_jobs.constants import JobStatus
 from girder_jobs.models.job import Job
-from pkg_resources import DistributionNotFound, get_distribution
 
 import girder
 import large_image
@@ -44,8 +43,14 @@ from .rest.large_image_resource import LargeImageResource
 from .rest.tiles import TilesItemResource
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/girder/setup.py
+++ b/girder/setup.py
@@ -46,6 +46,7 @@ setup(
         'girder>=3.0.4',
         'girder-jobs>=3.0.3',
         'large_image>=1.0.0',
+        'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={
         'tasks': [

--- a/girder_annotation/girder_large_image_annotation/__init__.py
+++ b/girder_annotation/girder_large_image_annotation/__init__.py
@@ -24,8 +24,20 @@ from . import constants
 from .models.annotation import Annotation
 from .rest.annotation import AnnotationResource
 
-# Validators
+try:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
+    # package is not installed
+    pass
 
+
+# Validators
 
 @setting_utilities.validator({
     constants.PluginSettings.LARGE_IMAGE_ANNOTATION_HISTORY,

--- a/girder_annotation/setup.py
+++ b/girder_annotation/setup.py
@@ -46,6 +46,7 @@ setup(
         'jsonschema>=2.5.1',
         'girder-large-image',
         'ujson>=1.35',
+        'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={
         'tasks': [

--- a/large_image/__init__.py
+++ b/large_image/__init__.py
@@ -14,13 +14,17 @@
 #  limitations under the License.
 #############################################################################
 
-from pkg_resources import DistributionNotFound, get_distribution
-
 from . import tilesource  # noqa
 from .tilesource import canRead, getTileSource, open  # noqa
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass

--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -29,7 +29,6 @@ import threading
 import types
 
 import numpy
-from pkg_resources import DistributionNotFound, get_distribution
 
 import large_image.tilesource.base
 from large_image import config
@@ -39,8 +38,14 @@ from large_image.exceptions import TileSourceError, TileSourceFileNotFoundError
 from large_image.tilesource import FileTileSource, nearPowerOfTwo
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/sources/bioformats/setup.py
+++ b/sources/bioformats/setup.py
@@ -46,6 +46,7 @@ setup(
         'large-image',
         'python-bioformats>=1.5.2',
         'scikit-image',
+        'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={
         'girder': 'girder-large-image',

--- a/sources/dummy/large_image_source_dummy/__init__.py
+++ b/sources/dummy/large_image_source_dummy/__init__.py
@@ -14,14 +14,18 @@
 #  limitations under the License.
 ##############################################################################
 
-from pkg_resources import DistributionNotFound, get_distribution
-
 from large_image.constants import SourcePriority
 from large_image.tilesource import TileSource
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/sources/dummy/setup.py
+++ b/sources/dummy/setup.py
@@ -44,6 +44,7 @@ setup(
     ],
     install_requires=[
         'large-image',
+        'importlib-metadata ; python_version < "3.8"',
     ],
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -28,7 +28,6 @@ from osgeo import gdal, gdal_array, gdalconst, osr  # noqa I001
 # if on those older versions of python if it is imported before gdal, there can
 # be a database version conflect; importing after gdal avoids this.
 import pyproj  # noqa I001
-from pkg_resources import DistributionNotFound, get_distribution
 
 import large_image
 from large_image.cache_util import CacheProperties, LruCacheMetaclass, methodcache
@@ -40,11 +39,16 @@ from large_image.tilesource import FileTileSource
 from large_image.tilesource.utilities import getPaletteColors
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
-
 
 TileInputUnits['projection'] = 'projection'
 TileInputUnits['proj'] = 'projection'

--- a/sources/gdal/setup.py
+++ b/sources/gdal/setup.py
@@ -46,6 +46,7 @@ setup(
         'large-image',
         'gdal',
         'pyproj>=2.2.0',
+        'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={
         'girder': 'girder-large-image',

--- a/sources/mapnik/large_image_source_mapnik/__init__.py
+++ b/sources/mapnik/large_image_source_mapnik/__init__.py
@@ -20,15 +20,20 @@ import mapnik
 import PIL.Image
 from large_image_source_gdal import GDALFileTileSource, InitPrefix
 from osgeo import gdal, gdalconst
-from pkg_resources import DistributionNotFound, get_distribution
 
 from large_image.cache_util import LruCacheMetaclass, methodcache
 from large_image.constants import TILE_FORMAT_PIL, SourcePriority
 from large_image.exceptions import TileSourceError
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/sources/mapnik/setup.py
+++ b/sources/mapnik/setup.py
@@ -46,6 +46,7 @@ setup(
         'large-image',
         'large-image-source-gdal',
         'mapnik',
+        'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={
         'girder': 'girder-large-image',

--- a/sources/multi/large_image_source_multi/__init__.py
+++ b/sources/multi/large_image_source_multi/__init__.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import jsonschema
 import numpy
 import yaml
-from pkg_resources import DistributionNotFound, get_distribution
 
 import large_image
 from large_image.cache_util import LruCacheMetaclass, methodcache
@@ -21,8 +20,14 @@ from large_image.tilesource import FileTileSource
 from large_image.tilesource.utilities import _makeSameChannelDepth
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/sources/multi/setup.py
+++ b/sources/multi/setup.py
@@ -47,6 +47,7 @@ setup(
         'large-image>=1.0.0',
         'pyyaml',
         'scipy',
+        'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={
         'girder': 'girder-large-image>=1.0.0',

--- a/sources/nd2/large_image_source_nd2/__init__.py
+++ b/sources/nd2/large_image_source_nd2/__init__.py
@@ -23,7 +23,6 @@ import warnings
 
 import cachetools
 import numpy
-from pkg_resources import DistributionNotFound, get_distribution
 
 from large_image.cache_util import LruCacheMetaclass, methodcache
 from large_image.constants import TILE_FORMAT_NUMPY, SourcePriority
@@ -33,8 +32,14 @@ from large_image.tilesource import FileTileSource
 nd2reader = None
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/sources/ometiff/large_image_source_ometiff/__init__.py
+++ b/sources/ometiff/large_image_source_ometiff/__init__.py
@@ -26,15 +26,20 @@ from large_image_source_tiff.tiff_reader import (InvalidOperationTiffException,
                                                  IOTiffException,
                                                  TiffException,
                                                  TiledTiffDirectory)
-from pkg_resources import DistributionNotFound, get_distribution
 
 from large_image.cache_util import LruCacheMetaclass, methodcache
 from large_image.constants import TILE_FORMAT_NUMPY, TILE_FORMAT_PIL, SourcePriority
 from large_image.exceptions import TileSourceError, TileSourceFileNotFoundError
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/sources/ometiff/setup.py
+++ b/sources/ometiff/setup.py
@@ -44,7 +44,8 @@ setup(
     ],
     install_requires=[
         'large-image',
-        'large-image-source-tiff>=1.0.0',
+        'large-image-source-tiff',
+        'importlib-metadata ; python_version < "3.8"'
     ],
     extras_require={
         'girder': 'girder-large-image',

--- a/sources/openjpeg/large_image_source_openjpeg/__init__.py
+++ b/sources/openjpeg/large_image_source_openjpeg/__init__.py
@@ -26,7 +26,6 @@ from xml.etree import ElementTree
 
 import glymur
 import PIL.Image
-from pkg_resources import DistributionNotFound, get_distribution
 
 from large_image.cache_util import LruCacheMetaclass, methodcache
 from large_image.constants import TILE_FORMAT_NUMPY, SourcePriority
@@ -34,8 +33,14 @@ from large_image.exceptions import TileSourceError, TileSourceFileNotFoundError
 from large_image.tilesource import FileTileSource, etreeToDict
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/sources/openjpeg/setup.py
+++ b/sources/openjpeg/setup.py
@@ -46,6 +46,7 @@ setup(
         'large-image',
         'glymur>=0.8.18 ; python_version >= "3.7"',
         'glymur>=0.8.18,<0.9.4 ; python_version < "3.7"',
+        'importlib-metadata ; python_version < "3.8"'
     ],
     extras_require={
         'girder': 'girder-large-image',

--- a/sources/openslide/large_image_source_openslide/__init__.py
+++ b/sources/openslide/large_image_source_openslide/__init__.py
@@ -20,7 +20,6 @@ import os
 import openslide
 import PIL
 import tifftools
-from pkg_resources import DistributionNotFound, get_distribution
 
 from large_image.cache_util import LruCacheMetaclass, methodcache
 from large_image.constants import TILE_FORMAT_PIL, SourcePriority
@@ -34,8 +33,14 @@ except ImportError:
 
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/sources/openslide/setup.py
+++ b/sources/openslide/setup.py
@@ -46,6 +46,7 @@ setup(
         'large-image',
         'openslide-python>=1.1.0',
         'tifftools>=1.2.0',
+        'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={
         'girder': 'girder-large-image',

--- a/sources/pil/large_image_source_pil/__init__.py
+++ b/sources/pil/large_image_source_pil/__init__.py
@@ -20,7 +20,6 @@ import os
 
 import numpy
 import PIL.Image
-from pkg_resources import DistributionNotFound, get_distribution
 
 from large_image import config
 from large_image.cache_util import LruCacheMetaclass, methodcache, strhash
@@ -29,8 +28,14 @@ from large_image.exceptions import TileSourceError, TileSourceFileNotFoundError
 from large_image.tilesource import FileTileSource
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/sources/pil/setup.py
+++ b/sources/pil/setup.py
@@ -44,6 +44,7 @@ setup(
     ],
     install_requires=[
         'large-image',
+        'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={
         'girder': 'girder-large-image',

--- a/sources/test/large_image_source_test/__init__.py
+++ b/sources/test/large_image_source_test/__init__.py
@@ -19,7 +19,6 @@ import itertools
 import math
 
 from PIL import Image, ImageDraw, ImageFont
-from pkg_resources import DistributionNotFound, get_distribution
 
 from large_image.cache_util import LruCacheMetaclass, methodcache, strhash
 from large_image.constants import TILE_FORMAT_PIL, SourcePriority
@@ -27,8 +26,14 @@ from large_image.exceptions import TileSourceError
 from large_image.tilesource import TileSource
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/sources/test/setup.py
+++ b/sources/test/setup.py
@@ -44,6 +44,7 @@ setup(
     ],
     install_requires=[
         'large-image',
+        'importlib-metadata ; python_version < "3.8"',
     ],
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),

--- a/sources/tiff/large_image_source_tiff/__init__.py
+++ b/sources/tiff/large_image_source_tiff/__init__.py
@@ -24,7 +24,6 @@ import os
 import numpy
 import PIL.Image
 import tifftools
-from pkg_resources import DistributionNotFound, get_distribution
 
 from large_image import config
 from large_image.cache_util import LruCacheMetaclass, methodcache
@@ -37,8 +36,14 @@ from .tiff_reader import (InvalidOperationTiffException, IOTiffException,
                           ValidationTiffException)
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/sources/tiff/setup.py
+++ b/sources/tiff/setup.py
@@ -46,6 +46,7 @@ setup(
         'large-image',
         'libtiff>=0.4.1',
         'tifftools>=1.2.0',
+        'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={
         'girder': 'girder-large-image',

--- a/utilities/converter/large_image_converter/__init__.py
+++ b/utilities/converter/large_image_converter/__init__.py
@@ -14,7 +14,6 @@ from tempfile import TemporaryDirectory
 import numpy
 import psutil
 import tifftools
-from pkg_resources import DistributionNotFound, get_distribution
 
 import large_image
 
@@ -23,8 +22,14 @@ from . import format_aperio
 pyvips = None
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/utilities/converter/setup.py
+++ b/utilities/converter/setup.py
@@ -54,6 +54,7 @@ setup(
         'psutil',
         'pyvips',
         'tifftools',
+        'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={
         'jp2k': [

--- a/utilities/tasks/large_image_tasks/__init__.py
+++ b/utilities/tasks/large_image_tasks/__init__.py
@@ -5,11 +5,16 @@ __email__ = 'kitware@kitware.com'
 
 
 from girder_worker import GirderWorkerPluginABC
-from pkg_resources import DistributionNotFound, get_distribution
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _importlib_version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError
+    from importlib_metadata import version as _importlib_version
+try:
+    __version__ = _importlib_version(__name__)
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/utilities/tasks/setup.py
+++ b/utilities/tasks/setup.py
@@ -50,6 +50,7 @@ setup(
     install_requires=[
         # Packages required by both producer and consumer side installations
         'girder-worker-utils>=0.8.5',
+        'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={
         'girder': [


### PR DESCRIPTION
importlib is significantly faster, which results in speeding up importing the library.