### PR TITLE
Add a convenience function to release tile resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Version 1.11.0
 
+### Improvements
+- Release memory associated with a lazy tile if it has been loaded
+
+## Version 1.11.0
+
 ### Features
 - Initial implementation of multi-source tile source ([#764](../../pull/764))
 - Added pixelmap annotation element ([#767](../../pull/767), [#776](../../pull/776))

--- a/large_image/tilesource/tiledict.py
+++ b/large_image/tilesource/tiledict.py
@@ -220,3 +220,14 @@ class LazyTileDict(dict):
             self['tile'] = tileData
             self['format'] = tileFormat
         return super().__getitem__(key, *args, **kwargs)
+
+    def release(self):
+        """
+        If the tile has been loaded, unload it.  It can be loaded again.  This
+        is useful if you want to keep tiles available in memory but not their
+        actual tile data.
+        """
+        if self.loaded:
+            self.loaded = False
+            for key in self.deferredKeys:
+                self[key] = None

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -253,3 +253,24 @@ def testTileOverlap():
         (60, 120, 60, 30, 15),
         (75, 120, 45, 30, 0),
     ]
+
+
+def testLazyTileRelease():
+    imagePath = datastore.fetch('sample_image.ptif')
+    ts = large_image.open(imagePath)
+
+    tiles = list(ts.tileIterator(
+        scale={'magnification': 2.5},
+        format=large_image.constants.TILE_FORMAT_IMAGE,
+        encoding='PNG'))
+    assert isinstance(tiles[5], large_image.tilesource.tiledict.LazyTileDict)
+    assert super(large_image.tilesource.tiledict.LazyTileDict, tiles[5]).__getitem__(
+        'tile') is None
+    data = tiles[5]['tile']
+    assert len(tiles[5]['tile']) > 0
+    assert super(large_image.tilesource.tiledict.LazyTileDict, tiles[5]).__getitem__(
+        'tile') is not None
+    tiles[5].release()
+    assert super(large_image.tilesource.tiledict.LazyTileDict, tiles[5]).__getitem__(
+        'tile') is None
+    assert tiles[5]['tile'] == data

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,8 @@ commands =
 deps = {[testenv:server]deps}
 commands = {[testenv:server]commands}
 
+# For running just one test, it is often clearer to do
+#  tox -e <env> -- --numprocesses 0 --no-cov -k <test name>
 [testenv:core]
 description = Run core tests.  This is all but Girder
 deps =


### PR DESCRIPTION
This allows keeping a tile's properties in memory without its actual data, which might be useful if one processes the data and then collects it using subprocessing.