### PR TITLE
Tile overlaps on subset regions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## Version 1.11.0
 
 ### Improvements
-- Release memory associated with a lazy tile if it has been loaded
+- Release memory associated with a lazy tile if it has been loaded ([#780](../../pull/780))
+
+### Bug Fixes
+- Tile overlaps on subset regions could be wrong ([#781](../../pull/781))
 
 ## Version 1.11.0
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -732,12 +732,18 @@ class TileSource:
                     'left': max(0, x * tileSize['width'] + tileOverlap['offset_x'] - left - posX),
                     'top': max(0, y * tileSize['height'] + tileOverlap['offset_y'] - top - posY),
                 }
-                overlap['right'] = max(0, tileWidth - tileSize['width'] - overlap['left'])
-                overlap['bottom'] = max(0, tileHeight - tileSize['height'] - overlap['top'])
-                if tileOverlap['offset_x']:
+                overlap['right'] = (
+                    max(0, tileWidth - tileSize['width'] - overlap['left'])
+                    if x != xmin or not tileOverlap['range_x'] else
+                    min(tileWidth, tileOverlap['range_x'] - tileOverlap['offset_x']))
+                overlap['bottom'] = (
+                    max(0, tileHeight - tileSize['height'] - overlap['top'])
+                    if y != ymin or not tileOverlap['range_y'] else
+                    min(tileHeight, tileOverlap['range_y'] - tileOverlap['offset_y']))
+                if tileOverlap['range_x']:
                     overlap['left'] = 0 if x == tileOverlap['xmin'] else overlap['left']
                     overlap['right'] = 0 if x + 1 == tileOverlap['xmax'] else overlap['right']
-                if tileOverlap['offset_y']:
+                if tileOverlap['range_y']:
                     overlap['top'] = 0 if y == tileOverlap['ymin'] else overlap['top']
                     overlap['bottom'] = 0 if y + 1 == tileOverlap['ymax'] else overlap['bottom']
                 tile = LazyTileDict({

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -274,3 +274,14 @@ def testLazyTileRelease():
     assert super(large_image.tilesource.tiledict.LazyTileDict, tiles[5]).__getitem__(
         'tile') is None
     assert tiles[5]['tile'] == data
+
+
+def testTileOverlapWithRegionOffset():
+    imagePath = datastore.fetch('sample_image.ptif')
+    ts = large_image.open(imagePath)
+    tileIter = ts.tileIterator(
+        region=dict(left=10000, top=10000, width=6000, height=6000),
+        tile_size=dict(width=1936, height=1936),
+        tile_overlap=dict(x=400, y=400))
+    firstTile = next(tileIter)
+    assert firstTile['tile_overlap']['right'] == 200


### PR DESCRIPTION
Fix an issue with reported tile overlap values when a region is a subset of the whole image (not at top-left).  Before the top and left tiles, if partial, reported the wrong right and bottom overlaps.