### PR TITLE
Change how we do a version check.

### DIFF
--- a/sources/gdal/large_image_source_gdal/girder_source.py
+++ b/sources/gdal/large_image_source_gdal/girder_source.py
@@ -15,8 +15,8 @@
 #############################################################################
 
 import re
-from distutils.version import StrictVersion
 
+import packaging.version
 from girder_large_image.girder_tilesource import GirderTileSource
 from osgeo import gdal
 
@@ -48,7 +48,7 @@ class GDALGirderTileSource(GDALFileTileSource, GirderTileSource):
         try:
             largeImageFileId = self.item['largeImage']['fileId']
             largeImageFile = File().load(largeImageFileId, force=True)
-            if (StrictVersion(gdal.__version__) >= StrictVersion('2.1.3') and
+            if (packaging.version.parse(gdal.__version__) >= packaging.version.parse('2.1.3') and
                     largeImageFile.get('linkUrl') and
                     not largeImageFile.get('assetstoreId') and
                     re.match(r'(http(|s)|ftp)://', largeImageFile['linkUrl'])):

--- a/sources/gdal/setup.py
+++ b/sources/gdal/setup.py
@@ -45,6 +45,7 @@ setup(
     install_requires=[
         'large-image',
         'gdal',
+        'packaging',
         'pyproj>=2.2.0',
         'importlib-metadata ; python_version < "3.8"',
     ],


### PR DESCRIPTION
We had been using `distutils.version.StrictVersion`, but that is deprecated and `packaging.version.parse` is the preferred method.