### PR TITLE
Reduce time spend in some image tests.

### DIFF
--- a/girder/test_girder/web_client_specs/imageViewerSpec.js
+++ b/girder/test_girder/web_client_specs/imageViewerSpec.js
@@ -12,6 +12,7 @@ $(function () {
             girder.utilities.PluginUtils.wrap(GeojsViewer, 'initialize', function (initialize) {
                 this.once('g:beforeFirstRender', function () {
                     window.geo.util.mockWebglRenderer();
+                    window.geo.webgl.webglRenderer._maxTextureSize = 256;
                 });
                 initialize.apply(this, _.rest(arguments));
             });


### PR DESCRIPTION
Reduce a size used internally that affects how long tests in a non webgl context take to execute.