### PR TITLE
Mark vsi extensions as being preferred by the bioformats source.

### DIFF
--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -150,10 +150,12 @@ class BioformatsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
     extensions = {
         None: SourcePriority.FALLBACK,
         'czi': SourcePriority.PREFERRED,
+        'vsi': SourcePriority.PREFERRED,
     }
     mimeTypes = {
         None: SourcePriority.FALLBACK,
         'image/czi': SourcePriority.PREFERRED,
+        'image/vsi': SourcePriority.PREFERRED,
     }
 
     # If frames are smaller than this they are served as single tiles, which

--- a/sources/pil/large_image_source_pil/__init__.py
+++ b/sources/pil/large_image_source_pil/__init__.py
@@ -106,7 +106,7 @@ class PILFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         # Some formats shouldn't be read this way, even if they could.  For
         # instances, mirax (mrxs) files look like JPEGs, but opening them as
         # such misses most of the data.
-        if os.path.splitext(largeImagePath)[1] in ('.mrxs', ):
+        if os.path.splitext(largeImagePath)[1] in {'.mrxs', '.vsi'}:
             raise TileSourceError('File cannot be opened via PIL.')
         try:
             self._pilImage = PIL.Image.open(largeImagePath)


### PR DESCRIPTION
This avoids having the PIL tilesource open them if the bioformats tilesource can do so.