### PR TITLE
Refactor the nd2 source to use the nd2 library.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import itertools
 import os
+import sys
 
 from setuptools import setup
 
@@ -21,7 +22,6 @@ sources = {
     'gdal': ['large-image-source-gdal'],
     'mapnik': ['large-image-source-mapnik'],
     'multi': ['large-image-source-multi'],
-    'nd2': ['large-image-source-nd2'],
     'ometiff': ['large-image-source-ometiff'],
     'openjpeg': ['large-image-source-openjpeg'],
     'openslide': ['large-image-source-openslide'],
@@ -29,6 +29,10 @@ sources = {
     'test': ['large-image-source-test'],
     'tiff': ['large-image-source-tiff'],
 }
+if sys.version_info >= (3, 7):
+    sources.update({
+        'nd2': ['large-image-source-nd2'],
+    })
 extraReqs.update(sources)
 extraReqs['sources'] = list(set(itertools.chain.from_iterable(sources.values())))
 extraReqs['all'] = list(set(itertools.chain.from_iterable(extraReqs.values())))

--- a/sources/nd2/setup.py
+++ b/sources/nd2/setup.py
@@ -36,7 +36,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -44,7 +43,8 @@ setup(
     ],
     install_requires=[
         'large-image',
-        'nd2reader>=3.3',
+        'dask[array]',
+        'nd2[legacy] ; python_version >= "3.7"',
         'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 from pathlib import Path
 
 import pytest
@@ -37,7 +38,6 @@ SourceAndFiles = {
         'read': r'\.(yml|yaml)$',
         'skip': r'(multi_source\.yml)$',
     },
-    'nd2': {'read': r'\.(nd2)$'},
     'ometiff': {'read': r'\.(ome\.tif.*)$'},
     'openjpeg': {'read': r'\.(jp2)$'},
     'openslide': {
@@ -54,6 +54,10 @@ SourceAndFiles = {
                   r'd042-353\.crop\.small\.float|landcover_sample)',
         'skipTiles': r'(sample_image\.ptif|one_layer_missing_tiles)'},
 }
+if sys.version_info >= (3, 7):
+    SourceAndFiles.update({
+        'nd2': {'read': r'\.(nd2)$'},
+    })
 
 
 def testNearPowerOfTwo():

--- a/test/test_source_multi.py
+++ b/test/test_source_multi.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 
 import large_image_source_multi
 import pytest
@@ -72,6 +73,7 @@ def testTilesFromMultiSimpleScaling():
         utilities.checkTilesZXY(source, tileMetadata, tileParams={'frame': frame})
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason='requires python >= 3.7 for a sub-source')
 def testTilesFromMultiMultiSource(multiSourceImagePath):
     imagePath = multiSourceImagePath
     source = large_image_source_multi.open(imagePath)
@@ -121,6 +123,7 @@ def testTilesFromMultiString():
         large_image_source_multi.open('invalid' + sourceString)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason='requires python >= 3.7 for a sub-source')
 def testInternalMetadata(multiSourceImagePath):
     imagePath = multiSourceImagePath
     source = large_image_source_multi.open(imagePath)
@@ -128,6 +131,7 @@ def testInternalMetadata(multiSourceImagePath):
     assert 'frames' in metadata
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason='requires python >= 3.7 for a sub-source')
 def testAssociatedImages(multiSourceImagePath):
     imagePath = multiSourceImagePath
     source = large_image_source_multi.open(imagePath)

--- a/test/test_source_nd2.py
+++ b/test/test_source_nd2.py
@@ -1,3 +1,5 @@
+import sys
+
 import large_image_source_nd2
 import pytest
 
@@ -5,6 +7,7 @@ from . import utilities
 from .datastore import datastore
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason='requires python3.7 or higher')
 def testTilesFromND2():
     imagePath = datastore.fetch('ITGA3Hi_export_crop2.nd2')
     source = large_image_source_nd2.open(imagePath)
@@ -27,6 +30,7 @@ def testTilesFromND2():
     utilities.checkTilesZXY(source, tileMetadata)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7), reason='requires python3.7 or higher')
 def testInternalMetadata():
     imagePath = datastore.fetch('ITGA3Hi_export_crop2.nd2')
     source = large_image_source_nd2.open(imagePath)


### PR DESCRIPTION
This should be more consistent than the nd2reader library.

The only downside of this is that the nd2 module is Python 3.7 or later.

Closes #796.