### PR TITLE
Change `libtiff` dependency to `pylibtiff`

### DIFF
--- a/sources/tiff/setup.py
+++ b/sources/tiff/setup.py
@@ -44,7 +44,7 @@ setup(
     ],
     install_requires=[
         'large-image',
-        'libtiff>=0.4.1',
+        'pylibtiff>=0.4.1',
         'tifftools>=1.2.0',
         'importlib-metadata ; python_version < "3.8"',
     ],

--- a/sources/tiff/setup.py
+++ b/sources/tiff/setup.py
@@ -44,7 +44,7 @@ setup(
     ],
     install_requires=[
         'large-image',
-        'pylibtiff>=0.4.1',
+        'pylibtiff',
         'tifftools>=1.2.0',
         'importlib-metadata ; python_version < "3.8"',
     ],


### PR DESCRIPTION
This PR updates the package name for [pearu/pylibtiff](https://github.com/pearu/pylibtiff).

It seems the official PyPI project name for [pearu/pylibtiff](https://github.com/pearu/pylibtiff) changed from [`libtiff`](https://pypi.org/project/libtiff) to [`pylibtiff`](https://pypi.org/project/pylibtiff) as of October 21, 2021.