### PR TITLE
Use simplejpeg for jpeg encoding rather than PIL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Add options to threshold near min/max based on the histogram ([#798](../../pull/798))
 - Mark vsi extensions as being preferred by the bioformats source ([#793](../../pull/793))
 - Add mouse events to overlay annotations ([#794](../../pull/794))
-- Use orjson instead of ujson for annotationss ([#802](../../pull/802))
+- Use orjson instead of ujson for annotations ([#802](../../pull/802))
+- Use simplejpeg for jpeg encoding rather than PIL ([#800](../../pull/800))
 
 ## Version 1.11.2
 

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,22 @@ Modules
 Large Image consists of several Python modules designed to work together.  These include:
 
 - ``large-image``: The core module.
-  You can specify extras_require of the name of any tile source included with this repository, ``sources`` for all of the tile sources in the repository, a specific source name (e.g., ``tiff``), ``memcached`` for using memcached for tile caching, ``converter`` to include the converter module, ``colormap`` for using matplotlib for named color palettes used in styles, or ``all`` for all of the tile sources, memcached, the converter module, and better color map support.
+
+  You can specify extras_require of the name of any tile source included with this repository.  For instance, you can do ``pip install large-image[tiff]``.  THere are additional extras_require options:
+
+  - ``sources``: all of the tile sources in the repository, a specific source name (e.g., ``tiff``)
+
+  - ``memcached``: use memcached for tile caching
+
+  - ``converter``: include the converter module
+
+  - ``colormaps``: use matplotlib for named color palettes used in styles
+
+  - ``tiledoutput``: support for emitting large regions as tiled tiffs
+
+  - ``performance``: include optional modules that can improve performance
+
+  - ``all``: for all of the above
 
 - ``large-image-converter``: A utility for using pyvips and other libraries to convert images into pyramidal tiff files that can be read efficiently by large_image.
   You can specify extras_require of ``jp2k`` to include modules to allow output to JPEG2000 compression, ``sources`` to include all sources, and ``stats`` to include modules to allow computing compression noise statistics.

--- a/girder/girder_large_image/models/image_item.py
+++ b/girder/girder_large_image/models/image_item.py
@@ -196,6 +196,10 @@ class ImageItem(Item):
             if tileCacheLock is None:
                 tileData = tileCache[tileHash]
             else:
+                # Checking this outside the lock is sufficient for the cache
+                # miss condition and faster
+                if tileHash not in tileCache:
+                    return None
                 with tileCacheLock:
                     tileData = tileCache[tileHash]
             tileMime = TileOutputMimeTypes.get(kwargs.get('encoding'), 'image/jpeg')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,6 +27,7 @@ girder-jobs>=3.0.3
 # Extras from main setup.py
 pylibmc>=1.5.1
 matplotlib
+simplejpeg
 
 # External dependencies
 pip>=9

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ extraReqs = {
     'converter': ['large-image-converter'],
     'colormaps': ['matplotlib'],
     'tiledoutput': ['pyvips'],
+    'performance': ['simplejpeg'],
 }
 sources = {
     'bioformats': ['large-image-source-bioformats'],


### PR DESCRIPTION
This shaves more than 5 ms off of typical tile generation.  In one test, average tile generation time dropped from 17.4 ms to 12.1 ms.  This was with concurrent rest requests to Girder; the time was roughly twice this without concurrent requests.

This can be included with `pip install large_image[performance]` (or, of course `large_image[all]`).