### PR TITLE
Use orjson instead of ujson for annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add options to threshold near min/max based on the histogram ([#798](../../pull/798))
 - Mark vsi extensions as being preferred by the bioformats source ([#793](../../pull/793))
 - Add mouse events to overlay annotations ([#794](../../pull/794))
+- Use orjson instead of ujson for annotationss ([#802](../../pull/802))
 
 ## Version 1.11.2
 

--- a/girder_annotation/setup.py
+++ b/girder_annotation/setup.py
@@ -45,7 +45,7 @@ setup(
     install_requires=[
         'jsonschema>=2.5.1',
         'girder-large-image',
-        'ujson>=1.35',
+        'orjson',
         'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={


### PR DESCRIPTION
orjson is faster and is supposed to use less memory.

It is measurably faster on large annotations (by about 30% on ingest on one sample).