### PR TITLE
Improve handling when a file vanishes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+### Improvements
+- Improve parsing OME TIFF channel names ([806](../../pull/806))
+- Improve handling when a file vanishes ([807](../../pull/807))
+
 ## Version 1.12.0
 
 ### Features

--- a/girder/girder_large_image/web_client/package.json
+++ b/girder/girder_large_image/web_client/package.json
@@ -177,7 +177,6 @@
         "eslint-plugin-node": "^9.1.0",
         "eslint-plugin-promise": "^4.1.1",
         "eslint-plugin-standard": "^4.0.0",
-        "eslint-plugin-underscore": "0.0.10",
         "@girder/pug-lint-config": "^3.0.0-rc1",
         "pug-lint": "^2.6.0",
         "stylint": "^1.5.9"

--- a/girder_annotation/girder_large_image_annotation/web_client/package.json
+++ b/girder_annotation/girder_large_image_annotation/web_client/package.json
@@ -174,7 +174,6 @@
         "eslint-plugin-node": "^9.1.0",
         "eslint-plugin-promise": "^4.1.1",
         "eslint-plugin-standard": "^4.0.0",
-        "eslint-plugin-underscore": "0.0.10",
         "@girder/pug-lint-config": "^3.0.0-rc1",
         "pug-lint": "^2.6.0",
         "stylint": "^1.5.9"

--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -191,10 +191,13 @@ class LruCacheMetaclass(type):
                     pass
             try:
                 instance = super().__call__(*args, **kwargs)
-            except Exception:
+            except Exception as exc:
                 with cacheLock:
-                    del cache[key]
-                raise
+                    try:
+                        del cache[key]
+                    except Exception:
+                        pass
+                raise exc
             instance._classkey = key
             with cacheLock:
                 cache[key] = instance

--- a/utilities/converter/large_image_converter/__init__.py
+++ b/utilities/converter/large_image_converter/__init__.py
@@ -738,7 +738,15 @@ def _is_multiframe(path):
     :returns: True if multiframe.
     """
     _import_pyvips()
-    image = pyvips.Image.new_from_file(path)
+    try:
+        image = pyvips.Image.new_from_file(path)
+    except Exception:
+        try:
+            open(path, 'rb').read(1)
+            raise
+        except Exception:
+            logger.warning('Is the file reachable and readable? (%r)', path)
+            raise IOError(path) from None
     pages = 1
     if 'n-pages' in image.get_fields():
         pages = image.get_value('n-pages')


### PR DESCRIPTION
In Girder, when we have an imported file that has been moved or deleted, the error messages were misleading.  This improves them to hopefully making it more obvious why a conversion or opening an image has failed.

Resolves #132.