### PR TITLE
Support pickle output of numpy arrays for endpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 - Add support for ellipse and circle annotations ([811](../../pull/811))
+- Support pickle output of numpy arrays for region, thumbnail, and tile_frames endpoints ([812](../../pull/812))
 
 ### Improvements
 - Improve parsing OME TIFF channel names ([806](../../pull/806))


### PR DESCRIPTION
The region, thumbnail, and tile_frames endpoints can returned pickled numpy arrays.

This facilitates getting numpy data from a tile source through Girder Client.  For instance, `numpyarray = pickle.loads(gc.get('item/5c3e0590e45e326a5e2fb252/tiles/region', parameters={'encoding': 'pickle:' + str(pickle.HIGHEST_PROTOCOL), 'width': 2000}, jsonResp=False).content)` would fetch a numpy array as efficiently as possible.  The protocol will be the lower of that specified in the request and the maximum for the python version of the server.  Just using 'pickle' will use protocol 4, which will work with any supported version of Python 3 -- specifying an explicit number is more efficient and adapts to clients using a Python version not otherwise supported.