### PR TITLE
Add a vips tilesource

### DIFF
--- a/.circleci/make_wheels.sh
+++ b/.circleci/make_wheels.sh
@@ -47,3 +47,5 @@ cd "$ROOTPATH/sources/test"
 pip wheel . --no-deps -w ~/wheels && rm -rf build
 cd "$ROOTPATH/sources/tiff"
 pip wheel . --no-deps -w ~/wheels && rm -rf build
+cd "$ROOTPATH/sources/vips"
+pip wheel . --no-deps -w ~/wheels && rm -rf build

--- a/.circleci/release_pypi.sh
+++ b/.circleci/release_pypi.sh
@@ -112,3 +112,9 @@ cp "$ROOTPATH/LICENSE" .
 python setup.py sdist
 pip wheel . --no-deps -w dist
 twine upload --verbose dist/*
+cd "$ROOTPATH/sources/vips"
+cp "$ROOTPATH/README.rst" .
+cp "$ROOTPATH/LICENSE" .
+python setup.py sdist
+pip wheel . --no-deps -w dist
+twine upload --verbose dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## Unreleased
+
+### Features
+- Vips tile source and tiled file writer ([816](../../pull/816))
+
+### Improvements
+- Handle file URLs with GDAL  ([820](../../pull/820))
+
+### Bug Fixes
+- Fix a range check for pixelmap annotations ([815](../../pull/815))
+
 ## Version 1.13.0
 
 ### Features

--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,8 @@ Large Image consists of several Python modules designed to work together.  These
 
   - ``large-image-source-multi``: A tile source for compisiting other tile sources into a single multi-frame source.
 
+  - ``large-image-source-vips``: A tile source for reading any files handled by libvips.  This also can be used for writing tiled images from numpy arrays.
+
   - ``large-image-source-test``: A tile source that generates test tiles, including a simple fractal pattern.  Useful for testing extreme zoom levels.
 
   - ``large-image-source-dummy``: A tile source that does nothing.

--- a/docs/config_options.rst
+++ b/docs/config_options.rst
@@ -25,7 +25,7 @@ Configuration parameters:
 
 - ``max_small_image_size``: The PIL tilesource is used for small images if they are no more than this many pixels along their maximum dimension.
 
-- ``source_bioformats_ignored_names``, ``source_pil_ignored_names``: Some tile sources can read some files that are better read by other tilesources.  Since reading these files is suboptimal, these tile sources have a setting that, by default, ignores files without extensions or with particular extensions.  This setting is a Python regular expressions.  For bioformats this defaults to ``r'(^[!.]*|\.(jpg|jpeg|jpe|png|tif|tiff|ndpi))$'``.
+- ``source_bioformats_ignored_names``, ``source_pil_ignored_names``, ``source_vips_ignored_names``: Some tile sources can read some files that are better read by other tilesources.  Since reading these files is suboptimal, these tile sources have a setting that, by default, ignores files without extensions or with particular extensions.  This setting is a Python regular expressions.  For bioformats this defaults to ``r'(^[!.]*|\.(jpg|jpeg|jpe|png|tif|tiff|ndpi))$'``.
 
 
 Configuration from Python

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@
    _build/large_image_source_pil/modules
    _build/large_image_source_test/modules
    _build/large_image_source_tiff/modules
+   _build/large_image_source_vips/modules
    _build/large_image_converter/modules
    _build/large_image_tasks/modules
    _build/girder_large_image/modules

--- a/docs/make_docs.sh
+++ b/docs/make_docs.sh
@@ -31,6 +31,7 @@ sphinx-apidoc -f -o _build/large_image_source_openslide ../sources/openslide/lar
 sphinx-apidoc -f -o _build/large_image_source_pil ../sources/pil/large_image_source_pil
 sphinx-apidoc -f -o _build/large_image_source_test ../sources/test/large_image_source_test
 sphinx-apidoc -f -o _build/large_image_source_tiff ../sources/tiff/large_image_source_tiff
+sphinx-apidoc -f -o _build/large_image_source_vips ../sources/vips/large_image_source_vips
 sphinx-apidoc -f -o _build/large_image_converter ../utilities/converter/large_image_converter
 sphinx-apidoc -f -o _build/large_image_tasks ../utilities/tasks/large_image_tasks
 sphinx-apidoc -f -o _build/girder_large_image ../girder/girder_large_image

--- a/large_image/constants.py
+++ b/large_image/constants.py
@@ -33,6 +33,9 @@ TILE_FORMAT_PIL = 'PIL'
 TILE_FORMAT_NUMPY = 'numpy'
 
 
+NEW_IMAGE_PATH_FLAG = '__new_image__'
+
+
 TileOutputMimeTypes = {
     # JFIF forces conversion to JPEG through PIL to ensure the image is in a
     # common colorspace.  JPEG colorspace is complex: see
@@ -79,3 +82,4 @@ dtypeToGValue = {
     'i': 'int',
     'I': 'uint',
 }
+GValueToDtype = {v: k for k, v in dtypeToGValue.items()}

--- a/requirements-dev-core.txt
+++ b/requirements-dev-core.txt
@@ -10,6 +10,7 @@
 -e sources/pil
 -e sources/test
 -e sources/tiff
+-e sources/vips
 # must be after sources/tiff
 -e sources/ometiff
 # must be after source/gdal

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ girder-jobs>=3.0.3
 -e sources/pil
 -e sources/test
 -e sources/tiff
+-e sources/vips
 # must be after sources/tiff
 -e sources/ometiff
 # must be after source/gdal

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -9,6 +9,7 @@
 -e sources/pil
 -e sources/test
 -e sources/tiff
+-e sources/vips
 # must be after sources/tiff
 -e sources/ometiff
 # must be after source/gdal

--- a/sources/vips/large_image_source_vips/__init__.py
+++ b/sources/vips/large_image_source_vips/__init__.py
@@ -1,0 +1,440 @@
+# -*- coding: utf-8 -*-
+
+import math
+import os
+import threading
+import uuid
+
+import cachetools
+import numpy
+import pyvips
+
+from large_image import config
+from large_image.cache_util import LruCacheMetaclass, methodcache
+from large_image.constants import (NEW_IMAGE_PATH_FLAG, TILE_FORMAT_NUMPY,
+                                   GValueToDtype, SourcePriority,
+                                   dtypeToGValue)
+from large_image.exceptions import TileSourceError, TileSourceFileNotFoundError
+from large_image.tilesource import FileTileSource
+from large_image.tilesource.utilities import _imageToNumpy
+
+# Default to ignoring files with no extension and some specific extensions.
+config.ConfigValues['source_vips_ignored_names'] = \
+    r'(^[^.]*|\.(yml|yaml|json|png|svs))$'
+
+
+class VipsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
+    """
+    Provides tile access to any libvips compatible file.
+    """
+
+    cacheName = 'tilesource'
+    name = 'vipsfile'
+    extensions = {
+        None: SourcePriority.LOW,
+    }
+    mimeTypes = {
+        None: SourcePriority.FALLBACK,
+    }
+
+    _tileSize = 256
+
+    def __init__(self, path, **kwargs):
+        """
+        Initialize the tile class.  See the base class for other available
+        parameters.
+
+        :param path: a filesystem path for the tile source.
+        """
+        super().__init__(path, **kwargs)
+
+        if str(path).startswith(NEW_IMAGE_PATH_FLAG):
+            return self._initNew(**kwargs)
+        self._largeImagePath = str(self._getLargeImagePath())
+        self._editable = False
+
+        self._ignoreSourceNames('vips', self._largeImagePath)
+        try:
+            self._image = pyvips.Image.new_from_file(self._largeImagePath)
+        except pyvips.error.Error:
+            if not os.path.isfile(self._largeImagePath):
+                raise TileSourceFileNotFoundError(self._largeImagePath) from None
+            raise TileSourceError('File cannot be opened via pyvips')
+        self.sizeX = self._image.width
+        self.sizeY = self._image.height
+        self.tileWidth = self.tileHeight = self._tileSize
+        pages = 1
+        if 'n-pages' in self._image.get_fields():
+            pages = self._image.get('n-pages')
+        self._frames = [0]
+        for page in range(1, pages):
+            subInputPath = self._largeImagePath + '[page=%d]' % page
+            subImage = pyvips.Image.new_from_file(subInputPath)
+            if subImage.width == self.sizeX and subImage.height == self.sizeY:
+                self._frames.append(page)
+                continue
+            if subImage.width * subImage.height < self.sizeX * self.sizeY:
+                continue
+            self._frames = [page]
+            self.sizeX = subImage.width
+            self.sizeY = subImage.height
+            self._image = subImage
+        self.levels = int(max(1, math.ceil(math.log(
+            float(max(self.sizeX, self.sizeY)) / self.tileWidth) / math.log(2)) + 1))
+        if len(self._frames) > 1:
+            self._recentFrames = cachetools.LRUCache(maxsize=6)
+            self._frameLock = threading.RLock()
+
+    def _initNew(self, **kwargs):
+        """
+        Initialize the tile class for creating a new image.
+        """
+        self._largeImagePath = None
+        self._image = None
+        self.sizeX = self.sizeY = self.levels = 0
+        self.tileWidth = self.tileHeight = self._tileSize
+        self._frames = [0]
+        self._cacheValue = str(uuid.uuid4())
+        self._output = None
+        self._editable = True
+        self._bandRanges = None
+        self._addLock = threading.Lock()
+
+    def getState(self):
+        # Use the _cacheValue to avoid caching the source and tiles if we are
+        # creating something new.
+        if not hasattr(self, '_cacheValue'):
+            return super().getState()
+        return super().getState() + ',%s' % (self._cacheValue, )
+
+    def getInternalMetadata(self, **kwargs):
+        """
+        Return additional known metadata about the tile source.  Data returned
+        from this method is not guaranteed to be in any particular format or
+        have specific values.
+
+        :returns: a dictionary of data or None.
+        """
+        result = {}
+        if not self._image:
+            return result
+        for key in self._image.get_fields():
+            try:
+                result[key] = self._image.get(key)
+            except Exception:
+                pass
+        if len(self._frames) > 1:
+            result['frames'] = []
+            for idx in range(1, len(self._frames)):
+                frameresult = {}
+                result['frames'].append(frameresult)
+                img = self._getFrameImage(idx)
+                for key in img.get_fields():
+                    try:
+                        frameresult[key] = img.get(key)
+                    except Exception:
+                        pass
+        return result
+
+    def getMetadata(self):
+        """
+        Return a dictionary of metadata containing levels, sizeX, sizeY,
+        tileWidth, tileHeight, magnification, mm_x, mm_y, and frames.
+
+        :returns: metadata dictionary.
+        """
+        result = super().getMetadata()
+        if len(self._frames) > 1:
+            result['frames'] = [{} for _ in self._frames]
+            self._addMetadataFrameInformation(result)
+        return result
+
+    def _getFrameImage(self, frame=0):
+        """
+        Get the vips image associated with a specific frame.
+
+        :param frame: the 0-based frame to get.
+        :returns: a vips image.
+        """
+        if self._image is None and self._output:
+            self._outputToImage()
+        img = self._image
+        if frame > 0:
+            with self._frameLock:
+                if frame not in self._recentFrames:
+                    subpath = self._largeImagePath + '[page=%d]' % self._frames[frame]
+                    img = pyvips.Image.new_from_file(subpath)
+                    self._recentFrames[frame] = img
+                else:
+                    img = self._recentFrames[frame]
+        return img
+
+    def getNativeMagnification(self):
+        """
+        Get the magnification at a particular level.
+
+        :return: magnification, width of a pixel in mm, height of a pixel in mm.
+        """
+        if self._image:
+            xres = self._image.get('xres') or 0
+            yres = self._image.get('yres') or 0
+        else:
+            xres = yres = 0
+        return {
+            'mm_x': 1.0 / xres if xres else None,
+            'mm_y': 1.0 / yres if yres else None,
+            'magnification': 0.01 * xres if xres else None,
+        }
+
+    @methodcache()
+    def getTile(self, x, y, z, pilImageAllowed=False, numpyAllowed=False, **kwargs):
+        frame = int(kwargs.get('frame') or 0)
+        self._xyzInRange(x, y, z, frame, len(self._frames))
+        img = self._getFrameImage(frame)
+        x0, y0, x1, y1, step = self._xyzToCorners(x, y, z)
+        tileimg = img.crop(x0, y0, x1 - x0, y1 - y0)
+        tileimg = tileimg.reduce(step, step, kernel=pyvips.enums.Kernel.NEAREST)
+        tile = numpy.ndarray(
+            buffer=tileimg.write_to_memory(),
+            dtype=GValueToDtype[tileimg.format],
+            shape=[tileimg.height, tileimg.width, tileimg.bands])
+        return self._outputTile(tile, TILE_FORMAT_NUMPY, x, y, z,
+                                pilImageAllowed, numpyAllowed, **kwargs)
+
+    def _checkEditable(self):
+        """
+        Raise an exception if this is not an editable image.
+        """
+        if not self._editable:
+            raise TileSourceError('Not an editable image')
+
+    def _updateBandRanges(self, tile):
+        """
+        Given a 3-d numpy array, update the tracked band ranges.
+
+        :param tile: a numpy array.
+        """
+        amin = numpy.amin(tile, axis=(0, 1))
+        amax = numpy.amax(tile, axis=(0, 1))
+        if self._bandRanges is None:
+            self._bandRanges = {
+                'min': amin,
+                'max': amax,
+            }
+        else:
+            delta = len(self._bandRanges['min']) - len(amin)
+            if delta > 0:
+                amin = numpy.array(list(amin) + [0] * delta)
+                amax = numpy.array(list(amax) + [0] * delta)
+            elif delta < 0:
+                self._bandRanges['min'] = numpy.array(list(self._bandRanges['min']) + [0] * -delta)
+                self._bandRanges['max'] = numpy.array(list(self._bandRanges['max']) + [0] * -delta)
+            self._bandRanges = {
+                'min': numpy.minimum(self._bandRanges['min'], amin),
+                'max': numpy.maximum(self._bandRanges['max'], amax),
+            }
+
+    def _addVipsImage(self, vimg, x=0, y=0):
+        """
+        Add a vips image to the output image.
+
+        :param vimg: a vips image.
+        :param x: location in destination for upper-left corner.
+        :param y: location in destination for upper-left corner.
+        """
+        # Allow vips to persist the new tile to a temp file.  Otherwise, it may
+        # try to hold all tiles in memory.
+        vimgTemp = pyvips.Image.new_temp_file('%s.v')
+        vimg.write(vimgTemp)
+        vimg = vimgTemp
+        with self._addLock():
+            if self._output is None:
+                self._output = {
+                    'images': [],
+                    'interp': vimg.interpretation,
+                    'bands': vimg.bands,
+                    'width': 0,
+                    'height': 0,
+                }
+            self._output['images'].append({'image': vimg, 'x': x, 'y': y})
+            if (self._output['interp'] != vimg.interpretation and
+                    self._output['interp'] != pyvips.Interpretation.MULTIBAND):
+                if vimg.interpretation in {
+                        pyvips.Interpretation.MULTIBAND, pyvips.Interpretation.RGB}:
+                    self._output['interp'] = vimg.interpretation
+                if vimg.interpretation == pyvips.Interpretation.RGB and self._output['bands'] == 2:
+                    self._output['bands'] = 4
+            self._output['bands'] = max(self._output['bands'], vimg.bands)
+            self._output['width'] = max(self._output['width'], x + vimg.width)
+            self._output['height'] = max(self._output['height'], y + vimg.height)
+            # Invalidate the tile and class cache
+            self._image = None
+            self.sizeX = self._output['width']
+            self.sizeY = self._output['height']
+            self.levels = int(max(1, math.ceil(math.log(
+                float(max(self.sizeX, self.sizeY)) / self.tileWidth) / math.log(2)) + 1))
+            self._cacheValue = str(uuid.uuid4())
+
+    def addTile(self, tile, x=0, y=0, mask=None, interpretation=None):
+        """
+        Add a numpy or image tile to the image, expanding the image as needed
+        to accommodate it.
+
+        :param tile: a numpy array, PIL Image, vips image, or a binary string
+            with an image.  The numpy array can have 2 or 3 dimensions.
+        :param x: location in destination for upper-left corner.
+        :param y: location in destination for upper-left corner.
+        :param mask: a 2-d numpy array (or 3-d if the last dimension is 1).
+            If specified, areas where the mask is false will not be altered.
+        :param interpretation: one of the pyvips.enums.Interpretation or 'L',
+            'LA', 'RGB', "RGBA'.  This defaults to RGB/RGBA for 3/4 channel
+            images and L/LA for 1/2 channels.  The special value 'pixelmap'
+            will convert a 1 channel integer to a 3 channel RGB map.  For
+            images which are not 1 or 3 bands with an optional alpha, specify
+            MULTIBAND.  In this case, the mask option cannot be used.
+        """
+        self._checkEditable()
+        if type(tile) != pyvips.vimage.Image:
+            tile, mode = _imageToNumpy(tile)
+            interpretation = interpretation or mode
+        with self._addLock():
+            self._updateBandRanges(tile)
+        if interpretation == 'pixelmap':
+            with self._addLock():
+                self._interpretation = 'pixelmap'
+            tile = numpy.dstack((
+                (tile % 256).astype(int),
+                (tile / 256).astype(int) % 256,
+                (tile / 65536).astype(int) % 256)).astype('B')
+            interpretation = pyvips.enums.Interpretation.RGB
+        if interpretation != pyvips.Interpretation.MULTIBAND and tile.shape[2] in {1, 3}:
+            newarr = numpy.zeros(
+                (tile.shape[0], tile.shape[1], tile.shape[2] + 1), dtype=tile.dtype)
+            newarr[:, :, :tile.shape[2]] = tile
+            newarr[:, :, -1] = 255
+            tile = newarr
+        if mask:
+            if tile.shape[2] in {2, 4}:
+                tile[:, :, -1] *= mask.astype(numpy.dtype.bool)
+            else:
+                raise TileSourceError('Cannot apply a mask if the source is not 1 or 3 channels.')
+
+        vimg = pyvips.Image.new_from_memory(
+            numpy.ascontiguousarray(tile).data,
+            tile.shape[1], tile.shape[0], tile.shape[2],
+            dtypeToGValue[tile.dtype.char])
+        interpretation = interpretation if any(
+            v == interpretation for k, v in pyvips.enums.Interpretation.__dict__.items()
+            if not k.startswith('_')) else (
+            pyvips.Interpretation.B_W if tile.shape[2] <= 2 else (
+                pyvips.Interpretation.RGB if tile.shape[2] <= 4 else
+                pyvips.Interpretation.MULTIBAND))
+        vimg = vimg.copy(interpretation=interpretation)
+        # The alpha channel is [0, 255] if we created it (which is true if the
+        # band range doesn't include it)
+        self._addVipsImage(vimg, x, y)
+
+    def _outputToImage(self):
+        """
+        Create a vips image that pipelines all of the pieces we have into a
+        single image.  This makes an image that is large enough to hold all of
+        the pieces and is an appropriate datatype to represent the range of
+        values that are present.  For pixelmaps, this will be RGB 8-bit.  An
+        alpha channel is always included unless the intrepretation is
+        multichannel.
+        """
+        with self._addLock():
+            bands = self._output['bands']
+            if bands in {1, 3}:
+                bands += 1
+            img = pyvips.Image.black(self._output['width'], self._output['height'], bands=bands)
+            bmin, bmax = min(self._bandRanges['min']), max(self._bandRanges['max'])
+            if getattr(self, '_interpretation', None) == 'pixelmap':
+                format = pyvips.enums.BandFormat.UCHAR
+            elif bmin >= -1 and bmax <= 1:
+                format = pyvips.enums.BandFormat.FLOAT
+            elif bmin >= 0 and bmax < 2 ** 8:
+                format = pyvips.enums.BandFormat.UCHAR
+            elif bmin >= 0 and bmax < 2 ** 16:
+                format = pyvips.enums.BandFormat.USHORT
+            elif bmin >= 0 and bmax < 2 ** 32:
+                format = pyvips.enums.BandFormat.UINT
+            elif bmin < 0 and bmin >= -(2 ** 7) and bmax < 2 ** 7:
+                format = pyvips.enums.BandFormat.CHAR
+            elif bmin < 0 and bmin >= -(2 ** 15) and bmax < 2 ** 15:
+                format = pyvips.enums.BandFormat.SHORT
+            elif bmin < 0 and bmin >= -(2 ** 31) and bmax < 2 ** 31:
+                format = pyvips.enums.BandFormat.INT
+            else:
+                format = pyvips.enums.BandFormat.FLOAT
+            baseimg = img.copy(interpretation=self._output['interp'], format=format)
+
+            leaves = math.ceil(len(self._output['images']) ** (1. / 3))
+            img = baseimg.copy()
+            trunk = baseimg.copy()
+            branch = baseimg.copy()
+            for idx, entry in enumerate(self._output['images']):
+                branch = branch.composite(
+                    entry['image'], pyvips.BlendMode.OVER, x=entry['x'], y=entry['y'])
+                if not ((idx + 1) % leaves) or idx + 1 == len(self._output['images']):
+                    trunk = trunk.composite(branch, pyvips.BlendMode.OVER, x=0, y=0)
+                    branch = baseimg.copy()
+                if not ((idx + 1) % (leaves * leaves)) or idx + 1 == len(self._output['images']):
+                    img = img.composite(trunk, pyvips.BlendMode.OVER, x=0, y=0)
+                    trunk = baseimg.copy()
+            self._image = img
+
+    def write(self, path, lossy=True, alpha=True, overwriteAllowed=True):
+        """
+        Output the current image to a file.
+
+        :param path: output path.
+        :param lossy: if false, emit a lossless file.
+        :param alpha: True if an alpha channel is allowed.
+        :param overwriteAllowed: if False, raise an exception if the output
+            path exists.
+        """
+        if not overwriteAllowed and os.path.exists(path):
+            raise TileSourceError('Output path exists (%s)' % str(path))
+        with self._addLock():
+            img = self._getFrameImage(0)
+            # TODO: set image description: e.g.,
+            # img.set_type(
+            #   pyvips.GValue.gstr_type, 'image-description',
+            #   json.dumps(dict(vars(opts), indexCount=found)))
+            if getattr(self, '_interpretation', None) == 'pixelmap':
+                img = img[:3]
+            elif not alpha and self._output['interp'] != pyvips.Interpretation.MULTIBAND:
+                img = img[:-1]
+        if not lossy:
+            img.write_to_file(
+                path, tile_width=self.tileWidth, tile_height=self.tileHieght,
+                pyramid=True, bigtiff=True,
+                region_shrink='nearest', compression='lzw', predictor='horizontal')
+        else:
+            img.write_to_file(
+                path, tile_width=self.tileWidth, tile_height=self.tileHeight,
+                pyramid=True, bigtiff=True,
+                compression='jpeg', Q=90)
+
+    # TODO: set scale (magnfication or mm_x/y), specify bit depth explicitly,
+    # report recommended bit depth, allow cropping or setting a minimum image
+    # size, get band ranges
+
+
+def open(*args, **kwargs):
+    """Create an instance of the module class."""
+    return VipsFileTileSource(*args, **kwargs)
+
+
+def canRead(*args, **kwargs):
+    """Check if an input can be read by the module class."""
+    return VipsFileTileSource.canRead(*args, **kwargs)
+
+
+def new(*args, **kwargs):
+    """
+    Create a new image, collecting the results from patches of numpy arrays or
+    smaller images.
+    """
+    return VipsFileTileSource(NEW_IMAGE_PATH_FLAG + str(uuid.uuid4()), *args, **kwargs)

--- a/sources/vips/large_image_source_vips/girder_source.py
+++ b/sources/vips/large_image_source_vips/girder_source.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from girder_large_image.girder_tilesource import GirderTileSource
+
+from . import VipsFileTileSource
+
+
+class VipsGirderTileSource(VipsFileTileSource, GirderTileSource):
+    """
+    Vips large_image tile source for Girder.
+    """
+
+    cacheName = 'tilesource'
+    name = 'vips'
+
+    # vips uses extensions and adjacent files for some formats
+    _mayHaveAdjacentFiles = True

--- a/sources/vips/setup.py
+++ b/sources/vips/setup.py
@@ -1,0 +1,67 @@
+import os
+
+from setuptools import find_packages, setup
+
+description = 'A libvips tilesource for large_image.'
+long_description = description + '\n\nSee the large-image package for more details.'
+
+
+def prerelease_local_scheme(version):
+    """
+    Return local scheme version unless building on master in CircleCI.
+
+    This function returns the local scheme version number
+    (e.g. 0.0.0.dev<N>+g<HASH>) unless building on CircleCI for a
+    pre-release in which case it ignores the hash and produces a
+    PEP440 compliant pre-release version number (e.g. 0.0.0.dev<N>).
+    """
+    from setuptools_scm.version import get_local_node_and_date
+
+    if os.getenv('CIRCLE_BRANCH') in ('master', ):
+        return ''
+    else:
+        return get_local_node_and_date(version)
+
+
+setup(
+    name='large-image-source-vips',
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    setup_requires=['setuptools-scm'],
+    description=description,
+    long_description=long_description,
+    license='Apache Software License 2.0',
+    author='Kitware, Inc.',
+    author_email='kitware@kitware.com',
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+    ],
+    install_requires=[
+        'large-image',
+        'numpy',
+        'packaging',
+        'pyvips',
+        'importlib-metadata ; python_version < "3.8"',
+    ],
+    extras_require={
+        'girder': 'girder-large-image',
+    },
+    keywords='large_image, tile source',
+    packages=find_packages(exclude=['test', 'test.*']),
+    url='https://github.com/girder/large_image',
+    python_requires='>=3.6',
+    entry_points={
+        'large_image.source': [
+            'vips = large_image_source_vips:VipsFileTileSource'
+        ],
+        'girder_large_image.source': [
+            'vips = large_image_source_vips.girder_source:VipsGirderTileSource'
+        ]
+    },
+)

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -53,6 +53,10 @@ SourceAndFiles = {
         'noread': r'(oahu|DDX58_AXL|G10-3_pelvis_crop|'
                   r'd042-353\.crop\.small\.float|landcover_sample)',
         'skipTiles': r'(sample_image\.ptif|one_layer_missing_tiles)'},
+    'vips': {
+        'read': r'',
+        'noread': r'\.(nc|nd2|yml|yaml|json|czi|png|svs|scn)$',
+        'skipTiles': r'(sample_image\.ptif|one_layer_missing_tiles|JK-kidney_B-gal_H3_4C_1-500sec\.jp2)'},  # noqa
 }
 if sys.version_info >= (3, 7):
     SourceAndFiles.update({

--- a/test/test_source_vips.py
+++ b/test/test_source_vips.py
@@ -3,7 +3,6 @@ import shutil
 import tempfile
 
 import large_image_source_vips
-import pytest
 
 import large_image
 
@@ -12,21 +11,20 @@ from .datastore import datastore
 
 
 def testTilesFromVips():
-    imagePath = datastore.fetch('sample_image.ptif')
+    imagePath = datastore.fetch('d042-353.crop.small.float32.tif')
     source = large_image_source_vips.open(imagePath)
     tileMetadata = source.getMetadata()
 
     assert tileMetadata['tileWidth'] == 256
     assert tileMetadata['tileHeight'] == 256
-    assert tileMetadata['sizeX'] == 58368
-    assert tileMetadata['sizeY'] == 12288
-    assert tileMetadata['levels'] == 9
-    assert tileMetadata['magnification'] == pytest.approx(40, 1)
+    assert tileMetadata['sizeX'] == 480
+    assert tileMetadata['sizeY'] == 320
+    assert tileMetadata['levels'] == 2
     utilities.checkTilesZXY(source, tileMetadata)
 
 
 def testInternalMetadata():
-    imagePath = datastore.fetch('sample_image.ptif')
+    imagePath = datastore.fetch('d042-353.crop.small.float32.tif')
     source = large_image_source_vips.open(imagePath)
     metadata = source.getInternalMetadata()
     assert 'vips-loader' in metadata
@@ -35,18 +33,42 @@ def testInternalMetadata():
 def testNewAndWrite():
     imagePath = datastore.fetch('sample_image.ptif')
     source = large_image.open(imagePath)
-    sourceMetadata = source.getMetadata()
     out = large_image_source_vips.new()
-    for tile in source.tileIterator(format=large_image.constants.TILE_FORMAT_NUMPY):
+    for tile in source.tileIterator(
+        format=large_image.constants.TILE_FORMAT_NUMPY,
+        region=dict(right=4000, bottom=2000),
+    ):
         out.addTile(tile['tile'], x=tile['x'], y=tile['y'])
 
     tmpdir = tempfile.mkdtemp()
     outputPath = os.path.join(tmpdir, 'temp.tiff')
     try:
         out.write(outputPath)
-        assert os.path.getsize(outputPath) > 500000
+        assert os.path.getsize(outputPath) > 50000
         result = large_image.open(outputPath)
         resultMetadata = result.getMetadata()
-        assert sourceMetadata['sizeX'] == resultMetadata['sizeX']
+        assert resultMetadata['sizeX'] == 4000
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def testNewAndWriteLossless():
+    imagePath = datastore.fetch('sample_image.ptif')
+    source = large_image.open(imagePath)
+    out = large_image_source_vips.new()
+    for tile in source.tileIterator(
+        format=large_image.constants.TILE_FORMAT_NUMPY,
+        region=dict(right=4000, bottom=2000),
+    ):
+        out.addTile(tile['tile'], x=tile['x'], y=tile['y'])
+
+    tmpdir = tempfile.mkdtemp()
+    outputPath = os.path.join(tmpdir, 'temp.tiff')
+    try:
+        out.write(outputPath, lossy=False)
+        assert os.path.getsize(outputPath) > 50000
+        result = large_image.open(outputPath)
+        resultMetadata = result.getMetadata()
+        assert resultMetadata['sizeX'] == 4000
     finally:
         shutil.rmtree(tmpdir)

--- a/test/test_source_vips.py
+++ b/test/test_source_vips.py
@@ -3,8 +3,11 @@ import shutil
 import tempfile
 
 import large_image_source_vips
+import pytest
+import pyvips
 
 import large_image
+from large_image.exceptions import TileSourceError
 
 from . import utilities
 from .datastore import datastore
@@ -20,6 +23,9 @@ def testTilesFromVips():
     assert tileMetadata['sizeX'] == 480
     assert tileMetadata['sizeY'] == 320
     assert tileMetadata['levels'] == 2
+    assert source.bandFormat == pyvips.enums.BandFormat.FLOAT
+    assert source.mm_x == pytest.approx(0.08467, 4)
+    assert source.mm_y == pytest.approx(0.08467, 4)
     utilities.checkTilesZXY(source, tileMetadata)
 
 
@@ -40,6 +46,14 @@ def testNewAndWrite():
     ):
         out.addTile(tile['tile'], x=tile['x'], y=tile['y'])
 
+    assert out.bandFormat == pyvips.enums.BandFormat.UCHAR
+    assert out.bandRanges['min'][0] > 10
+    assert out.mm_x is None
+    assert out.mm_y is None
+    out.mm_x = source.getNativeMagnification()['mm_x']
+    out.mm_y = source.getNativeMagnification()['mm_y']
+    assert out.mm_x == 0.00025
+    assert out.mm_y == 0.00025
     tmpdir = tempfile.mkdtemp()
     outputPath = os.path.join(tmpdir, 'temp.tiff')
     try:
@@ -70,5 +84,82 @@ def testNewAndWriteLossless():
         result = large_image.open(outputPath)
         resultMetadata = result.getMetadata()
         assert resultMetadata['sizeX'] == 4000
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def testNewAndWriteCrop():
+    imagePath = datastore.fetch('sample_image.ptif')
+    source = large_image.open(imagePath)
+    out = large_image_source_vips.new()
+    assert out.crop is None
+    out.crop = 10, 10, 2000, 2000
+    assert out.crop is not None
+    out.crop = None
+    assert out.crop is None
+    with pytest.raises(TileSourceError):
+        out.crop = -1, -1, -1, -1
+    out.crop = 10, 10, 2000, 2000
+    for tile in source.tileIterator(
+        format=large_image.constants.TILE_FORMAT_NUMPY,
+        region=dict(right=4000, bottom=2000),
+    ):
+        out.addTile(tile['tile'], x=tile['x'], y=tile['y'])
+
+    tmpdir = tempfile.mkdtemp()
+    outputPath = os.path.join(tmpdir, 'temp.tiff')
+    try:
+        out.write(outputPath)
+        result = large_image.open(outputPath)
+        resultMetadata = result.getMetadata()
+        assert resultMetadata['sizeX'] == 2000
+        assert resultMetadata['sizeY'] == 1990
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def testNewAndWriteMinSize():
+    imagePath = datastore.fetch('sample_image.ptif')
+    source = large_image.open(imagePath)
+    out = large_image_source_vips.new()
+    assert out.minWidth is None
+    assert out.minHeight is None
+    out.minWidth = 4030
+    out.minHeight = 2030
+    assert out.minWidth is not None
+    assert out.minHeight is not None
+    out.minWidth = None
+    out.minHeight = None
+    assert out.minWidth is None
+    assert out.minHeight is None
+    with pytest.raises(TileSourceError):
+        out.minWidth = -1
+    with pytest.raises(TileSourceError):
+        out.minHeight = -1
+    out.minWidth = 4030
+    out.minHeight = 2030
+    for tile in source.tileIterator(
+        format=large_image.constants.TILE_FORMAT_NUMPY,
+        region=dict(right=4000, bottom=2000),
+    ):
+        out.addTile(tile['tile'], x=tile['x'], y=tile['y'])
+
+    tmpdir = tempfile.mkdtemp()
+    outputPath = os.path.join(tmpdir, 'temp.tiff')
+    try:
+        out.write(outputPath)
+        result = large_image.open(outputPath)
+        resultMetadata = result.getMetadata()
+        assert resultMetadata['sizeX'] == 4030
+        assert resultMetadata['sizeY'] == 2030
+
+        outputPath2 = os.path.join(tmpdir, 'temp2.tiff')
+        out.minWidth = 2000
+        out.minHeight = 1000
+        out.write(outputPath2)
+        result = large_image.open(outputPath2)
+        resultMetadata = result.getMetadata()
+        assert resultMetadata['sizeX'] == 4000
+        assert resultMetadata['sizeY'] == 2000
     finally:
         shutil.rmtree(tmpdir)

--- a/test/test_source_vips.py
+++ b/test/test_source_vips.py
@@ -1,0 +1,52 @@
+import os
+import shutil
+import tempfile
+
+import large_image_source_vips
+import pytest
+
+import large_image
+
+from . import utilities
+from .datastore import datastore
+
+
+def testTilesFromVips():
+    imagePath = datastore.fetch('sample_image.ptif')
+    source = large_image_source_vips.open(imagePath)
+    tileMetadata = source.getMetadata()
+
+    assert tileMetadata['tileWidth'] == 256
+    assert tileMetadata['tileHeight'] == 256
+    assert tileMetadata['sizeX'] == 58368
+    assert tileMetadata['sizeY'] == 12288
+    assert tileMetadata['levels'] == 9
+    assert tileMetadata['magnification'] == pytest.approx(40, 1)
+    utilities.checkTilesZXY(source, tileMetadata)
+
+
+def testInternalMetadata():
+    imagePath = datastore.fetch('sample_image.ptif')
+    source = large_image_source_vips.open(imagePath)
+    metadata = source.getInternalMetadata()
+    assert 'vips-loader' in metadata
+
+
+def testNewAndWrite():
+    imagePath = datastore.fetch('sample_image.ptif')
+    source = large_image.open(imagePath)
+    sourceMetadata = source.getMetadata()
+    out = large_image_source_vips.new()
+    for tile in source.tileIterator(format=large_image.constants.TILE_FORMAT_NUMPY):
+        out.addTile(tile['tile'], x=tile['x'], y=tile['y'])
+
+    tmpdir = tempfile.mkdtemp()
+    outputPath = os.path.join(tmpdir, 'temp.tiff')
+    try:
+        out.write(outputPath)
+        assert os.path.getsize(outputPath) > 500000
+        result = large_image.open(outputPath)
+        resultMetadata = result.getMetadata()
+        assert sourceMetadata['sizeX'] == resultMetadata['sizeX']
+    finally:
+        shutil.rmtree(tmpdir)


### PR DESCRIPTION
This class can be used to write files as well.  This is a new capability and should be regarded as somewhat in flux.  Specifically, you can do
```
import large_image_source_vips

newsrc = large_image_source_vips.new()
for chunk, x, y in chunk_generator: # some process that generates numpy arrays or images
    newsrc.addTile(chunk, x, y)
newsrc.write('output.tiff')
```