### PR TITLE
Support a hasAlpha flag on image annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 - Vips tile source and tiled file writer ([816](../../pull/816))
 
 ### Improvements
-- Handle file URLs with GDAL  ([820](../../pull/820))
+- Handle file URLs with GDAL ([820](../../pull/820))
+- Add a hasAlpha flag to image annotations ([823](../../pull/823))
 
 ### Bug Fixes
 - Fix a range check for pixelmap annotations ([815](../../pull/815))
+- Harden checking if a PIL Image can be read directly from a file pointer ([822](../../pull/822))
 
 ## Version 1.13.0
 

--- a/girder_annotation/docs/annotations.rst
+++ b/girder_annotation/docs/annotations.rst
@@ -250,6 +250,8 @@ a ``2x2`` affine matrix.
     "girderId": <girder image id>,     # 24-character girder id pointing
                                        # to a large image object. Required
     "opacity": 1,                      # Default opacity for the overlay. Defaults to 1. Optional
+    "hasAlpha": false,                 # Boolean specifying if the image has an alpha channel
+                                       # that should be used in rendering.
     "transform": {                     # Object specifying additional overlay information. Optional
       "xoffset": 0,                    # How much to shift the overlaid image right.
       "yoffset": 0,                    # How much to shift the overlaid image down.

--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -416,6 +416,12 @@ class AnnotationSchema:
                 'description': 'Default opacity for this image overlay. Must '
                                'be between 0 and 1. Defaults to 1.'
             },
+            'hasAlpha': {
+                'type': 'boolean',
+                'description':
+                    'If true, the image is treated assuming it has an alpha '
+                    'channel.',
+            },
             'transform': {
                 'type': 'object',
                 'description': 'Specification for an affine transform of the '

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -136,7 +136,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             if (levelDifference !== 0) {
                 layerParams.url = (x, y, z) => 'api/v1/item/' + pixelmapElement.girderId + `/tiles/zxy/${z - levelDifference}/${x}/${y}?encoding=PNG`;
             } else {
-                layerParams.url = layerParams.url + `?encoding=PNG`;
+                layerParams.url = layerParams.url + '?encoding=PNG';
             }
             let pixelmapData = pixelmapElement.values;
             if (pixelmapElement.boundaries) {
@@ -213,6 +213,9 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             }
             if (overlay.type === 'pixelmap') {
                 params.layer = this._addPixelmapLayerParams(params.layer, overlay, levelDifference);
+            } else if (overlay.hasAlpha) {
+                params.layer.keepLower = false;
+                params.layer.url = (x, y, z) => 'api/v1/item/' + overlayImageId + `/tiles/zxy/${z - levelDifference}/${x}/${y}?encoding=PNG`;
             }
             return params.layer;
         },


### PR DESCRIPTION
This dictates whether the default renderer uses jpegs or pngs and whether lower level tiles are rendered.