### PR TITLE
Add scm version fallback.

### DIFF
--- a/girder/setup.py
+++ b/girder/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='girder-large-image',
-    use_scm_version={'root': '..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description=description,
     long_description=long_description,

--- a/girder_annotation/setup.py
+++ b/girder_annotation/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='girder-large-image-annotation',
-    use_scm_version={'root': '..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm', 'setuptools-git'],
     description=description,
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image',
-    use_scm_version={'local_scheme': prerelease_local_scheme},
+    use_scm_version={'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/sources/bioformats/setup.py
+++ b/sources/bioformats/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-source-bioformats',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/sources/deepzoom/setup.py
+++ b/sources/deepzoom/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-source-deepzoom',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/sources/dummy/setup.py
+++ b/sources/dummy/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-source-dummy',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/sources/gdal/setup.py
+++ b/sources/gdal/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-source-gdal',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/sources/mapnik/setup.py
+++ b/sources/mapnik/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-source-mapnik',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/sources/multi/setup.py
+++ b/sources/multi/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-source-multi',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/sources/nd2/setup.py
+++ b/sources/nd2/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-source-nd2',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/sources/ometiff/setup.py
+++ b/sources/ometiff/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-source-ometiff',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/sources/openjpeg/setup.py
+++ b/sources/openjpeg/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-source-openjpeg',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/sources/openslide/setup.py
+++ b/sources/openslide/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-source-openslide',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/sources/pil/setup.py
+++ b/sources/pil/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-source-pil',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/sources/test/setup.py
+++ b/sources/test/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-source-test',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/sources/tiff/setup.py
+++ b/sources/tiff/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-source-tiff',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/sources/vips/setup.py
+++ b/sources/vips/setup.py
@@ -25,7 +25,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-source-vips',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/utilities/converter/setup.py
+++ b/utilities/converter/setup.py
@@ -28,7 +28,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-converter',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,

--- a/utilities/tasks/setup.py
+++ b/utilities/tasks/setup.py
@@ -28,7 +28,8 @@ def prerelease_local_scheme(version):
 
 setup(
     name='large-image-tasks',
-    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme},
+    use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
+                     'fallback_version': 'development'},
     setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,


### PR DESCRIPTION
If setuptools_scm is installed and a local deploy is made that isn't a github repo, then packages fail to install unless there is a fallback version.