### PR TITLE
Add validate_cog method to GDALFileTileSource

### DIFF
--- a/large_image/exceptions.py
+++ b/large_image/exceptions.py
@@ -17,6 +17,10 @@ class TileSourceXYZRangeError(TileSourceError):
     pass
 
 
+class TileSourcePyramidFormatError(TileSourceError):
+    pass
+
+
 class TileSourceFileNotFoundError(TileSourceError, FileNotFoundError):
     def __init__(self, *args, **kwargs):
         return super().__init__(errno.ENOENT, *args, **kwargs)


### PR DESCRIPTION
This adds a `validate_cog` method to `GDALFileTileSource` to use the `osgeo_utils` script that will verify a COG.

I'm wondering if we should add another `validate_*` method to the `TiledTiffDirectory` that uses `tifftools` to check the IFDs and tiling of an image