### PR TITLE
Switch the default logger to the null handler.

### DIFF
--- a/large_image/config.py
+++ b/large_image/config.py
@@ -3,7 +3,7 @@ import logging
 # Default logger
 fallbackLogger = logging.getLogger('large_image')
 fallbackLogger.setLevel(logging.INFO)
-fallbackLogHandler = logging.StreamHandler()
+fallbackLogHandler = logging.NullHandler()
 fallbackLogHandler.setLevel(logging.NOTSET)
 fallbackLogger.addHandler(fallbackLogHandler)
 


### PR DESCRIPTION
This is more in line with other libraries.

With this, PR #819 should be changed to just convert a few entries to errors and leave the other log messages as is.