### PR TITLE
Reduce the strictness of version checks in dev branches

### DIFF
--- a/girder/setup.py
+++ b/girder/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/girder_annotation/setup.py
+++ b/girder_annotation/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/sources/bioformats/setup.py
+++ b/sources/bioformats/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/sources/deepzoom/setup.py
+++ b/sources/deepzoom/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/sources/dummy/setup.py
+++ b/sources/dummy/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/sources/gdal/setup.py
+++ b/sources/gdal/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/sources/mapnik/setup.py
+++ b/sources/mapnik/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/sources/multi/setup.py
+++ b/sources/multi/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/sources/nd2/setup.py
+++ b/sources/nd2/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/sources/ometiff/setup.py
+++ b/sources/ometiff/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/sources/openjpeg/setup.py
+++ b/sources/openjpeg/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/sources/openslide/setup.py
+++ b/sources/openslide/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/sources/pil/setup.py
+++ b/sources/pil/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/sources/test/setup.py
+++ b/sources/test/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/sources/tiff/setup.py
+++ b/sources/tiff/setup.py
@@ -27,7 +27,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/utilities/converter/setup.py
+++ b/utilities/converter/setup.py
@@ -30,7 +30,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 

--- a/utilities/tasks/setup.py
+++ b/utilities/tasks/setup.py
@@ -30,7 +30,7 @@ try:
     from setuptools_scm import get_version
 
     version = get_version(root='../..', local_scheme=prerelease_local_scheme)
-    limit_version = f'>={version}'
+    limit_version = f'>={version}' if '+' not in version else ''
 except (ImportError, LookupError):
     limit_version = ''
 


### PR DESCRIPTION
Otherwise, you pretty much have to do `tox -r` after every change if you want to test the results.