### PR TITLE
Add an option to including bounding box information with elements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.14.4
+
+### Improvements
+- Optionally include bounding box information with annotation queries ([851](../../pull/851))
+
 ## 1.14.3
 
 ### Improvements

--- a/girder_annotation/girder_large_image_annotation/rest/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/rest/annotation.py
@@ -142,6 +142,10 @@ class AnnotationResource(Resource):
         .param('centroids', 'If true, only return the centroids of each '
                'element.  The results are returned as a packed binary array '
                'with a json wrapper.', dataType='boolean', required=False)
+        .param('bbox', 'If true, add _bbox records to each element.  These '
+               'are computed when the annotation is stored and cannot be '
+               'modified.  Cannot be used with the centroids option.',
+               dataType='boolean', required=False)
         .pagingParams(defaultSort='_id', defaultLimit=None,
                       defaultSortDir=SortDir.ASCENDING)
         .errorResponse('ID was invalid.')

--- a/girder_annotation/test_annotation/test_annotations_rest.py
+++ b/girder_annotation/test_annotation/test_annotations_rest.py
@@ -128,6 +128,24 @@ class TestLargeImageAnnotationRest:
         elements = result.split(b'\x00', 1)[1].rsplit(b'\x00', 1)[0]
         assert len(elements) == 28 * len(largeSample['elements'])
 
+    def testGetAnnotationWithBoundingBox(self, server, admin):
+        publicFolder = utilities.namedFolder(admin, 'Public')
+        item = Item().createItem('sample', admin, publicFolder)
+        annot = Annotation().createAnnotation(item, admin, sampleAnnotation)
+        annotId = str(annot['_id'])
+        resp = server.request(
+            path='/annotation/%s' % annotId, user=admin)
+        assert utilities.respStatus(resp) == 200
+        assert 'bbox' not in resp.json['_elementQuery']
+        assert '_bbox' not in resp.json['annotation']['elements'][0]
+
+        resp = server.request(
+            path='/annotation/%s' % annotId, user=admin,
+            params={'bbox': 'true'})
+        assert utilities.respStatus(resp) == 200
+        assert 'bbox' in resp.json['_elementQuery']
+        assert '_bbox' in resp.json['annotation']['elements'][0]
+
     def testAnnotationCopy(self, server, admin):
         publicFolder = utilities.namedFolder(admin, 'Public')
         # create annotation on an item


### PR DESCRIPTION
This adds an option to the GET annotation/{id} endpoint and to the annotationelement.yieldElements method.  The annotationelement.getElements and annotation.load methods support passing the additional bbox=True argument as part of the region request.

The result that includes the _elementQuery record also has the bounding box for the specific query (it is of just the elements that are returned if they are paged or limited).

Closes #850.