### PR TITLE
Change where nd2 data gets copied.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 - Optionally include bounding box information with annotation queries ([851](../../pull/851))
+- Reduce memory copying in the nd2 reader ([853](../../pull/853))
 
 ## 1.14.3
 


### PR DESCRIPTION
We are using the dask interface with nd2 to avoid loading all of a file into memory.  When we read anything other then an entire frame, the default is to copy the entire frame in memory and THEN apply whatever index and step is being used.  The nd2 library docs caution that if copy isn't done, there can be a segfault.  Instead, use our own lock, get the frame data, subset it with our index and step and THEN copy it; since this is in a singular lock, it won't have any greater risk that the nd2 library.  Since the copy only applies to the actual data we are using, much less memory is copied.

In a simple example with a file with large tiles, this saves close to 2 seconds per tile.