### PR TITLE
Honor the highlight size limit with centroid annotations.

### DIFF
--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -447,7 +447,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                         if (annotation._centroids) {
                             annotation._shownIds = new Set(feature.data().map((d) => d.id));
                         }
-                        if (data.length <= this._highlightFeatureSizeLimit) {
+                        if (data.length <= this._highlightFeatureSizeLimit && !annotation._centroids) {
                             this._featureOpacity[annotation.id][feature.featureType] = feature.data()
                                 .map(({id, properties}) => {
                                     return {


### PR DESCRIPTION
This makes the interface more consistent, but still has the surprise that there is a threshold where the behavior changes.  We may want to revisit highlighting in large sets of annotations, in which case we need to adjust centroid annotations, too.

See https://github.com/DigitalSlideArchive/HistomicsUI/issues/45.