### PR TITLE
Add scaleWithZoom property to heatmaps

### DIFF
--- a/girder_annotation/docs/annotations.rst
+++ b/girder_annotation/docs/annotations.rst
@@ -185,6 +185,9 @@ near by values aggregate together when viewed.
     "normalizeRange": true             # If true, the rangeValues are normalized to [0, 1].  If
                                        # false, the rangeValues are in the
                                        # value domain.  Defaults to true.  Optional
+    "scaleWithZoom": true              # If true, scale the size of points with the zoom level of
+                                       # the map. In this case, the radius property refers to the
+                                       # size of points at zoom level 0. Defaults to false. Optional
   }
 
 Grid Data

--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -330,6 +330,14 @@ class AnnotationSchema:
                     'data.  If false (the default), the rangeValues '
                     'are the actual data values.',
             },
+            'scaleWithZoom': {
+                'type': 'boolean',
+                'description':
+                    'If true, scale the size of points with the '
+                    'zoom level of the map. In this case, the '
+                    'radius property refers to the size of points '
+                    'at zoom level 0.'
+            }
         },
         'required': ['type', 'points'],
         'additionalProperties': False,

--- a/girder_annotation/girder_large_image_annotation/web_client/annotations/convertFeatures.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/annotations/convertFeatures.js
@@ -80,7 +80,8 @@ function convertHeatmap(record, properties, layer) {
             radius: record.radius || 25,
             blurRadius: 0,
             gaussian: true,
-            color: colorTable.color
+            color: colorTable.color,
+            scaleWithZoom: record.scaleWithZoom || false
         },
         position: (d) => ({x: d[0], y: d[1], z: d[2]}),
         intensity: (d) => d[3] || 0,


### PR DESCRIPTION
This PR updates the annotation schema for heatmap elements to include a `scaleWithZoom` property. It also updates documentation to reflect this change and sets the property in the style dict when creating new heatmaps.