### PR TITLE
Abstract caching and support entrypoints

### DIFF
--- a/large_image/cache_util/base.py
+++ b/large_image/cache_util/base.py
@@ -1,6 +1,7 @@
 import hashlib
 import threading
 import time
+from typing import Tuple
 
 import cachetools
 
@@ -75,6 +76,6 @@ class BaseCache(cachetools.Cache):
         raise NotImplementedError
 
     @staticmethod
-    def getCache() -> tuple['BaseCache', threading.Lock]:
+    def getCache() -> Tuple['BaseCache', threading.Lock]:
         # return cache, cacheLock
         raise NotImplementedError

--- a/large_image/cache_util/base.py
+++ b/large_image/cache_util/base.py
@@ -1,0 +1,79 @@
+import hashlib
+import time
+
+import cachetools
+
+
+class BaseCache(cachetools.Cache):
+    """Base interface to cachetools.Cache for use with large-image."""
+
+    def __init__(self, *args, getsizeof=None, **kwargs):
+        super().__init__(*args, getsizeof=getsizeof, **kwargs)
+        self.lastError = {}
+        self.throttleErrors = 10  # seconds between logging errors
+
+    def logError(self, err, func, msg):
+        """
+        Log errors, but throttle them so as not to spam the logs.
+
+        :param err: error to log.
+        :param func: function to use for logging.  This is something like
+            logprint.exception or logger.error.
+        :param msg: the message to log.
+        """
+        curtime = time.time()
+        key = (err, func)
+        if (curtime - self.lastError.get(key, {}).get('time', 0) > self.throttleErrors):
+            skipped = self.lastError.get(key, {}).get('skipped', 0)
+            if skipped:
+                msg += '  (%d similar messages)' % skipped
+            self.lastError[key] = {'time': curtime, 'skipped': 0}
+            func(msg)
+        else:
+            self.lastError[key]['skipped'] += 1
+
+    def __repr__(self):
+        raise NotImplementedError
+
+    def __iter__(self):
+        raise NotImplementedError
+
+    def __len__(self):
+       raise NotImplementedError
+
+    def __contains__(self, key):
+        raise NotImplementedError
+
+    def __delitem__(self, key):
+       raise NotImplementedError
+
+    def _hashKey(self, key):
+        return hashlib.sha256(key.encode()).hexdigest()
+
+    def __getitem__(self, key):
+        # hashedKey = self._hashKey(key)
+        raise NotImplementedError
+
+    def __setitem__(self, key, value):
+        # hashedKey = self._hashKey(key)
+        raise NotImplementedError
+
+    @property
+    def curritems(self):
+        raise NotImplementedError
+
+    @property
+    def currsize(self):
+        raise NotImplementedError
+
+    @property
+    def maxsize(self):
+       raise NotImplementedError
+
+    def clear(self):
+       raise NotImplementedError
+
+    @staticmethod
+    def getCache():
+        # return cache, cacheLock
+        raise NotImplementedError

--- a/large_image/cache_util/base.py
+++ b/large_image/cache_util/base.py
@@ -1,4 +1,5 @@
 import hashlib
+import threading
 import time
 
 import cachetools
@@ -39,13 +40,13 @@ class BaseCache(cachetools.Cache):
         raise NotImplementedError
 
     def __len__(self):
-       raise NotImplementedError
+        raise NotImplementedError
 
     def __contains__(self, key):
         raise NotImplementedError
 
     def __delitem__(self, key):
-       raise NotImplementedError
+        raise NotImplementedError
 
     def _hashKey(self, key):
         return hashlib.sha256(key.encode()).hexdigest()
@@ -68,12 +69,12 @@ class BaseCache(cachetools.Cache):
 
     @property
     def maxsize(self):
-       raise NotImplementedError
+        raise NotImplementedError
 
     def clear(self):
-       raise NotImplementedError
+        raise NotImplementedError
 
     @staticmethod
-    def getCache():
+    def getCache() -> tuple['BaseCache', threading.Lock]:
         # return cache, cacheLock
         raise NotImplementedError

--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -142,7 +142,11 @@ class LruCacheMetaclass(type):
             cacheName = cls
 
         if LruCacheMetaclass.namedCaches.get(cacheName) is None:
-            cache, cacheLock = CacheFactory().getCache(maxSize, cacheName=cacheName)
+            cache, cacheLock = CacheFactory().getCache(
+                numItems=maxSize,
+                cacheName=cacheName,
+                inProcess=True,
+            )
             LruCacheMetaclass.namedCaches[cacheName] = (cache, cacheLock)
             config.getConfig('logger').debug(
                 'Created LRU Cache for %r with %d maximum size' % (cacheName, cache.maxsize))

--- a/large_image/cache_util/memcache.py
+++ b/large_image/cache_util/memcache.py
@@ -16,6 +16,7 @@
 
 import threading
 import time
+from typing import Tuple
 
 from .. import config
 from .base import BaseCache
@@ -145,7 +146,7 @@ class MemCache(BaseCache):
         self._client.flush_all()
 
     @staticmethod
-    def getCache() -> tuple['MemCache', threading.Lock]:
+    def getCache() -> Tuple['MemCache', threading.Lock]:
         # lock needed because pylibmc(memcached client) is not threadsafe
         cacheLock = threading.Lock()
 

--- a/large_image/cache_util/memcache.py
+++ b/large_image/cache_util/memcache.py
@@ -145,7 +145,7 @@ class MemCache(BaseCache):
         self._client.flush_all()
 
     @staticmethod
-    def getCache():
+    def getCache() -> tuple['MemCache', threading.Lock]:
         # lock needed because pylibmc(memcached client) is not threadsafe
         cacheLock = threading.Lock()
 
@@ -162,7 +162,7 @@ class MemCache(BaseCache):
             memcachedPassword = None
         try:
             cache = MemCache(url, memcachedUsername, memcachedPassword,
-                                mustBeAvailable=True)
+                             mustBeAvailable=True)
         except Exception:
             config.getConfig('logger').info('Cannot use memcached for caching.')
             cache = None

--- a/large_image/config.py
+++ b/large_image/config.py
@@ -12,7 +12,7 @@ ConfigValues = {
     'logprint': fallbackLogger,
 
     # For tiles
-    'cache_backend': 'python',  # 'python' or 'memcached'
+    'cache_backend': None,  # 'python' or 'memcached'
     # 'python' cache can use 1/(val) of the available memory
     'cache_python_memory_portion': 32,
     # cache_memcached_url may be a list

--- a/large_image/exceptions.py
+++ b/large_image/exceptions.py
@@ -26,6 +26,14 @@ class TileSourceFileNotFoundError(TileSourceError, FileNotFoundError):
         return super().__init__(errno.ENOENT, *args, **kwargs)
 
 
+class TileCacheError(TileGeneralError):
+    pass
+
+
+class TileCacheConfigurationError(TileCacheError):
+    pass
+
+
 TileGeneralException = TileGeneralError
 TileSourceException = TileSourceError
 TileSourceAssetstoreException = TileSourceAssetstoreError


### PR DESCRIPTION
Abstracts the caching mechanism so that external projects can implement a cache interface and use entrypoints to make it available to large_image.

Generally, this is working for django-large-image with https://github.com/girder/django-large-image/pull/32

Todo:

- [x] Can the `MemCache` cache be chosen appropriately? Is it ignored when not available and is it chosen over `python` when available?
- [x] Should `loadCaches()` only be called once rather than on every `CacheFactory.getCache()` call?
- [x] Address inline TODO statements
- [x] What is `CacheFactory.getCacheSize()`and `pickAvailableCache()` and how are they affected by these changes?
- [ ] What happens if `BaseCache.getCache()` returns a `None` cache lock? can/should we support that?
- [x] Test downstream in `django-large-image`