### PR TITLE
When scaling heatmap annoations, use an appropriate value.

### DIFF
--- a/girder_annotation/docs/annotations.rst
+++ b/girder_annotation/docs/annotations.rst
@@ -176,7 +176,7 @@ near by values aggregate together when viewed.
       [10976, 93376, 0, 0.2],
       [42368, 65248, 0, 0.054]
     ],
-    "radius": 25,                      # Positive number.  Optional.  The size of the gaussian plot
+    "radius": 25,                      # Positive number.  Optional.  The size of the gaussian point
                                        # spread
     "colorRange": ["rgba(0, 0, 0, 0)", "rgba(255, 255, 0, 1)"],  # A list of colors corresponding to
                                        # the rangeValues.  Optional
@@ -186,7 +186,9 @@ near by values aggregate together when viewed.
                                        # false, the rangeValues are in the
                                        # value domain.  Defaults to true.  Optional
     "scaleWithZoom": true              # If true, scale the size of points with the zoom level of
-                                       # the map. Defaults to false. Optional
+                                       # the map. Defaults to false. In this case, radius is in
+                                       # pixels of the associated image.  If false or unspecified,
+                                       # radius is in screen pixels. Optional
   }
 
 Grid Data

--- a/girder_annotation/girder_large_image_annotation/web_client/annotations/convertFeatures.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/annotations/convertFeatures.js
@@ -73,11 +73,15 @@ function heatmapColorTable(record, values) {
 function convertHeatmap(record, properties, layer) {
     /* Heatmaps need to be in their own layer */
     const map = layer.map();
+    /* when scaleWithZoom is set, use the base pixel level of the first tile
+     * layer for scaling rather than the 0-resolution level. */
+    const tileLayer = map.layers().find((l) => l instanceof window.geo.tileLayer && l.options && l.options.maxLevel !== undefined);
+    const scaleZoomFactor = tileLayer ? 2 ** -tileLayer.options.maxLevel : 1;
     const heatmapLayer = map.createLayer('feature', {features: ['heatmap']});
     const colorTable = heatmapColorTable(record, record.points.map((d) => d[3]));
     const heatmap = heatmapLayer.createFeature('heatmap', {
         style: {
-            radius: record.radius || 25,
+            radius: (record.radius || 25) * (record.scaleWithZoom ? scaleZoomFactor : 1),
             blurRadius: 0,
             gaussian: true,
             color: colorTable.color,

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,10 @@ setup(
     name='large-image',
     use_scm_version={'local_scheme': prerelease_local_scheme,
                      'fallback_version': 'development'},
-    setup_requires=['setuptools-scm'],
+    setup_requires=[
+        'setuptools-scm<7 ; python_version < "3.7"',
+        'setuptools-scm ; python_version >= "3.7"',
+    ],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',


### PR DESCRIPTION
When scaleWithZoom is selected, make the radius in terms of the first tile layer's base pixel size.