### PR TITLE
Use the girder client build time for cache control.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.15.1
+
+### Improvements
+- When scaling heatmap annoations, use an appropriate value ([878](../../pull/878))
+- Use the girder client build time for cache control ([879](../../pull/879))
+
 ## 1.15.0
 
 ### Features

--- a/girder/girder_large_image/web_client/package.json
+++ b/girder/girder_large_image/web_client/package.json
@@ -21,7 +21,8 @@
         "hammerjs": "^2.0.8",
         "js-yaml": "^3.14.0",
         "sinon": "^2.1.0",
-        "slideatlas-viewer": "^4.4.1"
+        "slideatlas-viewer": "^4.4.1",
+        "webpack": "^2.7.0"
     },
     "main": "./index.js",
     "girderPlugin": {

--- a/girder/girder_large_image/web_client/views/imageViewerWidget/geojs.js
+++ b/girder/girder_large_image/web_client/views/imageViewerWidget/geojs.js
@@ -1,3 +1,5 @@
+/* global BUILD_TIMESTAMP */
+
 import $ from 'jquery';
 import _ from 'underscore';
 // Import hammerjs for geojs touch events
@@ -42,7 +44,7 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
                 return this;
             }),
             $.ajax({ // like $.getScript, but allow caching
-                url: root + '/plugins/large_image/extra/geojs.js',
+                url: root + '/plugins/large_image/extra/geojs.js' + (BUILD_TIMESTAMP ? '?_=' + BUILD_TIMESTAMP : ''),
                 dataType: 'script',
                 cache: true
             }))

--- a/girder/girder_large_image/web_client/webpack.helper.js
+++ b/girder/girder_large_image/web_client/webpack.helper.js
@@ -1,5 +1,7 @@
 const path = require('path');
 
+const webpack = require('webpack');
+
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 module.exports = function (config) {
@@ -15,6 +17,11 @@ module.exports = function (config) {
             from: path.join(path.resolve(__dirname), 'node_modules', 'sinon', 'pkg', 'sinon.js'),
             to: path.join(config.output.path, 'extra', 'sinon.js')
         }])
+    );
+    config.plugins.push(
+        new webpack.DefinePlugin({
+            BUILD_TIMESTAMP: Date.now()
+        })
     );
     return config;
 };


### PR DESCRIPTION
Prior to this, browsers often would cache a version of geojs and not load a new one, even if the client was otherwise loaded.