### PR TITLE
When converting girder images locally, prefer mount paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Improvements
 - Pass options to the annotationLayer mode ([881](../../pull/881))
 - Support more style range options ([883](../../pull/883))
+- When converting girder images locally, prefer mount paths ([886](../../pull/886))
 
 ### Changes
 - Be more consistent in source class name attribute assignment ([884](../../pull/884))

--- a/utilities/tasks/large_image_tasks/tasks.py
+++ b/utilities/tasks/large_image_tasks/tasks.py
@@ -118,9 +118,16 @@ def convert_image_job(job):
     # We could increase the default logging level here
     # logger.setLevel(logging.DEBUG)
     try:
+        inputPath = None
+        if not fileObj.get('imported'):
+            try:
+                inputPath = File().getGirderMountFilePath(fileObj)
+            except Exception:
+                pass
+        inputPath = inputPath or File().getLocalFilePath(fileObj)
         with tempfile.TemporaryDirectory() as tempdir:
             dest = create_tiff(
-                inputFile=File().getLocalFilePath(fileObj),
+                inputFile=inputPath,
                 inputName=fileObj['name'],
                 outputDir=tempdir,
                 **kwargs,


### PR DESCRIPTION
This improves local job support for converting uploaded multi-file images.