### PR TITLE
Copy tilesource instances to add styles

### DIFF
--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -1,3 +1,4 @@
+import copy
 import functools
 import threading
 
@@ -193,6 +194,17 @@ class LruCacheMetaclass(type):
                         return result
                 except KeyError:
                     pass
+            # This conditionally copies a non-styled class and add a style.
+            if kwargs.get('style') and hasattr(cls, '_setStyle'):
+                subkwargs = kwargs.copy()
+                subkwargs.pop('style')
+                subresult = cls(*args, **subkwargs)
+                result = copy.copy(subresult)
+                result._setStyle(kwargs['style'])
+                result._classkey = key
+                with cacheLock:
+                    cache[key] = result
+                    return result
             try:
                 instance = super().__call__(*args, **kwargs)
             except Exception as exc:

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -129,7 +129,6 @@ class TileSource:
         self.sizeX = None
         self.sizeY = None
         self._styleLock = threading.RLock()
-        self._bandRanges = {}
 
         if encoding not in TileOutputMimeTypes:
             raise ValueError('Invalid encoding "%s"' % encoding)
@@ -139,6 +138,15 @@ class TileSource:
         self.jpegSubsampling = int(jpegSubsampling)
         self.tiffCompression = tiffCompression
         self.edge = edge
+        self._setStyle(style)
+
+    def _setStyle(self, style):
+        """
+        Check and set the specified style from a json string or a dictionary.
+
+        :param style: The new style.
+        """
+        self._bandRanges = {}
         self._jsonstyle = style
         if style:
             if isinstance(style, dict):

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -183,6 +183,16 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         self._getTileLock = threading.Lock()
         self._setDefaultStyle()
 
+    def _setStyle(self, style):
+        """
+        Check and set the specified style from a json string or a dictionary.
+
+        :param style: The new style.
+        """
+        super()._setStyle(style)
+        if hasattr(self, '_getTileLock'):
+            self._setDefaultStyle()
+
     def _getLargeImagePath(self):
         """Get GDAL-compatible image path.
 

--- a/sources/mapnik/large_image_source_mapnik/__init__.py
+++ b/sources/mapnik/large_image_source_mapnik/__init__.py
@@ -176,7 +176,9 @@ class MapnikFileTileSource(GDALFileTileSource, metaclass=LruCacheMetaclass):
 
     def _setDefaultStyle(self):
         """Don't inherit from GDAL tilesource."""
-        pass
+        with self._getTileLock:
+            if hasattr(self, '_mapnikMap'):
+                del self._mapnikMap
 
     @staticmethod
     def interpolateMinMax(start, stop, count):

--- a/test/test_cache_source.py
+++ b/test/test_cache_source.py
@@ -1,0 +1,44 @@
+import pytest
+
+import large_image
+from large_image.cache_util import cachesClear
+
+from .datastore import datastore
+
+
+@pytest.mark.singular
+def testCacheSourceStyle():
+    cachesClear()
+    imagePath = datastore.fetch('sample_image.ptif')
+    ts1 = large_image.open(imagePath)
+    ts2 = large_image.open(imagePath, style={'max': 128})
+    ts3 = large_image.open(imagePath, style={'max': 160})
+    tile1 = ts1.getTile(0, 0, 4)
+    assert ts1.getTile(0, 0, 4) is not None
+    assert ts2.getTile(0, 0, 4) is not None
+    assert ts3.getTile(0, 0, 4) is not None
+    cachesClear()
+    assert ts1.getTile(0, 0, 4) == tile1
+    del ts1
+    assert ts2.getTile(1, 0, 4) is not None
+    cachesClear()
+    assert ts2.getTile(2, 0, 4) is not None
+    ts1 = large_image.open(imagePath)
+    assert ts1.getTile(0, 0, 4) == tile1
+
+
+@pytest.mark.singular
+def testCacheSourceStyleFirst():
+    cachesClear()
+    imagePath = datastore.fetch('sample_image.ptif')
+    ts2 = large_image.open(imagePath, style={'max': 128})
+    ts1 = large_image.open(imagePath)
+    tile1 = ts1.getTile(0, 0, 4)
+    assert ts1.getTile(0, 0, 4) is not None
+    assert ts2.getTile(0, 0, 4) is not None
+    del ts1
+    assert ts2.getTile(1, 0, 4) is not None
+    cachesClear()
+    assert ts2.getTile(2, 0, 4) is not None
+    ts1 = large_image.open(imagePath)
+    assert ts1.getTile(0, 0, 4) == tile1


### PR DESCRIPTION
Instead of reopening a tilesource when adding a style, copy the unstyled class and add the style information.

I've marked this as draft as I think it requires more tests to verify it does no harm.