### PR TITLE
Add canReadList function to show what sources could be used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 - Add a tifffile tile source ([885](../../pull/885))
+- Added a canReadList method to large_image to show which source can be used ([895](../../pull/895))
 
 ### Improvements
 - Pass options to the annotationLayer mode ([881](../../pull/881))

--- a/large_image/__init__.py
+++ b/large_image/__init__.py
@@ -15,7 +15,7 @@
 #############################################################################
 
 from . import tilesource  # noqa
-from .tilesource import canRead, getTileSource, new, open  # noqa
+from .tilesource import canRead, canReadList, getTileSource, new, open  # noqa
 
 try:
     from importlib.metadata import PackageNotFoundError

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -499,3 +499,9 @@ def testGetTileFramesQuadInfo(options, lensrc, lenquads, frame10, src0, srclast,
         crop10 = results['quads'][10]['crop']
         for key, value in quads10.items():
             assert crop10[key] == value
+
+
+def testCanReadList():
+    imagePath = datastore.fetch('sample_image.ptif')
+    assert len(large_image.canReadList(imagePath)) > 1
+    assert any(canRead for source, canRead in large_image.canReadList(imagePath))


### PR DESCRIPTION
```
import large_image, pprint

pprint.pprint(large_image.canReadList('TCGA-02-0010-01Z-00-DX4.07de2e55-a8fe-40ee-9e98-bcb78050b9f7.svs'))
```
results in
```
[('openslide', True),
 ('multi', False),
 ('openjpeg', False),
 ('tiff', True),
 ('deepzoom', False),
 ('nd2', False),
 ('ometiff', False),
 ('tifffile', True),
 ('vips', False),
 ('pil', False),
 ('bioformats', True),
 ('gdal', True),
 ('mapnik', True)]
```
showing the order and utility of each source.