### PR TITLE
Improve repr of image bytes

### DIFF
--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -81,13 +81,13 @@ def _encodeImageBinary(image, encoding, jpegQuality, jpegSubsampling, tiffCompre
         if image.mode not in ({'L', 'RGB', 'RGBA'} if simplejpeg else {'L', 'RGB'}):
             image = image.convert('RGB' if image.mode != 'LA' else 'L')
         if simplejpeg:
-            return simplejpeg.encode_jpeg(
+            return ImageBytes(simplejpeg.encode_jpeg(
                 _imageToNumpy(image)[0],
                 quality=jpegQuality,
                 colorspace=image.mode if image.mode in {'RGB', 'RGBA'} else 'GRAY',
                 colorsubsampling={-1: '444', 0: '444', 1: '422', 2: '420'}.get(
                     jpegSubsampling, str(jpegSubsampling).strip(':')),
-            )
+            ), mimetype='image/jpeg')
         params['quality'] = jpegQuality
         params['subsampling'] = jpegSubsampling
     elif encoding in {'TIFF', 'TILED'}:

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -34,6 +34,15 @@ colormap = {
 }
 
 
+class ImageBytes(bytes):
+    """Wrapper class to make repr of image bytes better in ipython."""
+    def _repr_png_(self):
+        return self
+
+    def _repr_jpeg_(self):
+        return self
+
+
 def _encodeImageBinary(image, encoding, jpegQuality, jpegSubsampling, tiffCompression):
     """
     Encode a PIL Image to a binary representation of the image (a jpeg, png, or
@@ -74,7 +83,10 @@ def _encodeImageBinary(image, encoding, jpegQuality, jpegSubsampling, tiffCompre
         params['compress_level'] = 2
     output = io.BytesIO()
     image.save(output, encoding, **params)
-    return output.getvalue()
+    btes = output.getvalue()
+    if encoding in ['PNG', 'JPEG']:
+        return ImageBytes(btes)
+    return btes
 
 
 def _encodeImage(image, encoding='JPEG', jpegQuality=95, jpegSubsampling=0,

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -47,10 +47,12 @@ class ImageBytes(bytes):
         return self._mime_type
 
     def _repr_png_(self):
-        return self
+        if self.mimetype == 'image/png':
+            return self
 
     def _repr_jpeg_(self):
-        return self
+        if self.mimetype == 'image/jpeg':
+            return self
 
     def __repr__(self):
         if self.mimetype:
@@ -98,10 +100,10 @@ def _encodeImageBinary(image, encoding, jpegQuality, jpegSubsampling, tiffCompre
         params['compress_level'] = 2
     output = io.BytesIO()
     image.save(output, encoding, **params)
-    btes = output.getvalue()
-    if encoding in ['PNG', 'JPEG']:
-        return ImageBytes(btes, mimetype=f'image/{encoding.lower()}')
-    return btes
+    return ImageBytes(
+        output.getvalue(),
+        mimetype=f'image/{encoding.lower().replace("tiled", "tiff")}'
+    )
 
 
 def _encodeImage(image, encoding='JPEG', jpegQuality=95, jpegSubsampling=0,

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -36,6 +36,7 @@ colormap = {
 
 class ImageBytes(bytes):
     """Wrapper class to make repr of image bytes better in ipython."""
+
     def __new__(cls, source: bytes, mimetype: str = None):
         self = super().__new__(cls, source)
         self._mime_type = mimetype

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -36,11 +36,25 @@ colormap = {
 
 class ImageBytes(bytes):
     """Wrapper class to make repr of image bytes better in ipython."""
+    def __new__(cls, source: bytes, mimetype: str = None):
+        self = super().__new__(cls, source)
+        self._mime_type = mimetype
+        return self
+
+    @property
+    def mimetype(self):
+        return self._mime_type
+
     def _repr_png_(self):
         return self
 
     def _repr_jpeg_(self):
         return self
+
+    def __repr__(self):
+        if self.mimetype:
+            return f'ImageBytes<{len(self)}> ({self.mimetype})'
+        return f'ImageBytes<{len(self)}> (wrapped image bytes)'
 
 
 def _encodeImageBinary(image, encoding, jpegQuality, jpegSubsampling, tiffCompression):
@@ -85,7 +99,7 @@ def _encodeImageBinary(image, encoding, jpegQuality, jpegSubsampling, tiffCompre
     image.save(output, encoding, **params)
     btes = output.getvalue()
     if encoding in ['PNG', 'JPEG']:
-        return ImageBytes(btes)
+        return ImageBytes(btes, mimetype=f'image/{encoding.lower()}')
     return btes
 
 

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -506,3 +506,28 @@ def testCanReadList():
     imagePath = datastore.fetch('sample_image.ptif')
     assert len(large_image.canReadList(imagePath)) > 1
     assert any(canRead for source, canRead in large_image.canReadList(imagePath))
+
+
+def testImageBytes():
+    ib = large_image.tilesource.utilities.ImageBytes(b'abc')
+    assert ib == b'abc'
+    assert isinstance(ib, bytes)
+    assert 'ImageBytes' in repr(ib)
+    assert ib.mimetype is None
+    assert ib._repr_jpeg_() is None
+    assert ib._repr_png_() is None
+    ib = large_image.tilesource.utilities.ImageBytes(b'abc', 'image/jpeg')
+    assert ib.mimetype == 'image/jpeg'
+    assert 'ImageBytes' in repr(ib)
+    assert ib._repr_jpeg_() == b'abc'
+    assert ib._repr_png_() is None
+    ib = large_image.tilesource.utilities.ImageBytes(b'abc', 'image/png')
+    assert ib.mimetype == 'image/png'
+    assert 'ImageBytes' in repr(ib)
+    assert ib._repr_jpeg_() is None
+    assert ib._repr_png_() == b'abc'
+    ib = large_image.tilesource.utilities.ImageBytes(b'abc', 'other')
+    assert ib.mimetype == 'other'
+    assert 'ImageBytes' in repr(ib)
+    assert ib._repr_jpeg_() is None
+    assert ib._repr_png_() is None

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -11,6 +11,7 @@ import pytest
 
 from large_image import constants
 from large_image.exceptions import TileSourceError, TileSourceInefficientError
+from large_image.tilesource.utilities import ImageBytes
 
 from . import utilities
 from .datastore import datastore
@@ -149,10 +150,12 @@ def testThumbnailFromGeotiffs():
     source = large_image_source_gdal.open(imagePath)
     # We get a thumbnail without a projection
     image, mimeType = source.getThumbnail(encoding='PNG')
+    assert isinstance(image, ImageBytes)
     assert image[:len(utilities.PNGHeader)] == utilities.PNGHeader
     # We get a different thumbnail with a projection
     source = large_image_source_gdal.open(imagePath, projection='EPSG:3857')
     image2, mimeType = source.getThumbnail(encoding='PNG')
+    assert isinstance(image2, ImageBytes)
     assert image2[:len(utilities.PNGHeader)] == utilities.PNGHeader
     assert image != image2
 

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -152,6 +152,9 @@ def testThumbnailFromGeotiffs():
     image, mimeType = source.getThumbnail(encoding='PNG')
     assert isinstance(image, ImageBytes)
     assert image[:len(utilities.PNGHeader)] == utilities.PNGHeader
+    image, mimeType = source.getThumbnail(encoding='JPEG')
+    assert isinstance(image, ImageBytes)
+    assert image[:len(utilities.PNGHeader)] == utilities.JPEGHeader
     # We get a different thumbnail with a projection
     source = large_image_source_gdal.open(imagePath, projection='EPSG:3857')
     image2, mimeType = source.getThumbnail(encoding='PNG')

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -154,7 +154,7 @@ def testThumbnailFromGeotiffs():
     assert image[:len(utilities.PNGHeader)] == utilities.PNGHeader
     image, mimeType = source.getThumbnail(encoding='JPEG')
     assert isinstance(image, ImageBytes)
-    assert image[:len(utilities.PNGHeader)] == utilities.JPEGHeader
+    assert image[:len(utilities.JPEGHeader)] == utilities.JPEGHeader
     # We get a different thumbnail with a projection
     source = large_image_source_gdal.open(imagePath, projection='EPSG:3857')
     image2, mimeType = source.getThumbnail(encoding='PNG')

--- a/test/test_source_tiff.py
+++ b/test/test_source_tiff.py
@@ -275,7 +275,7 @@ def testThumbnails():
     assert isinstance(image, ImageBytes)
     assert image[:len(utilities.PNGHeader)] == utilities.PNGHeader
     image, mimeType = source.getThumbnail(encoding='TIFF')
-    assert isinstance(image, bytes)
+    assert isinstance(image, ImageBytes)
     assert image[:len(utilities.TIFFHeader)] == utilities.TIFFHeader
     image, mimeType = source.getThumbnail(jpegQuality=10)
     assert isinstance(image, ImageBytes)

--- a/test/test_source_tiff.py
+++ b/test/test_source_tiff.py
@@ -9,6 +9,7 @@ import pytest
 import tifftools
 
 from large_image import constants
+from large_image.tilesource.utilities import ImageBytes
 
 from . import utilities
 from .datastore import datastore
@@ -271,19 +272,24 @@ def testThumbnails():
     assert image[:len(utilities.JPEGHeader)] == utilities.JPEGHeader
     defaultLength = len(image)
     image, mimeType = source.getThumbnail(encoding='PNG')
+    assert isinstance(image, ImageBytes)
     assert image[:len(utilities.PNGHeader)] == utilities.PNGHeader
     image, mimeType = source.getThumbnail(encoding='TIFF')
+    assert isinstance(image, bytes)
     assert image[:len(utilities.TIFFHeader)] == utilities.TIFFHeader
     image, mimeType = source.getThumbnail(jpegQuality=10)
+    assert isinstance(image, ImageBytes)
     assert image[:len(utilities.JPEGHeader)] == utilities.JPEGHeader
     assert len(image) < defaultLength
     image, mimeType = source.getThumbnail(jpegSubsampling=2)
+    assert isinstance(image, ImageBytes)
     assert image[:len(utilities.JPEGHeader)] == utilities.JPEGHeader
     assert len(image) < defaultLength
     with pytest.raises(Exception):
         source.getThumbnail(encoding='unknown')
     # Test width and height using PNGs
     image, mimeType = source.getThumbnail(encoding='PNG')
+    assert isinstance(image, ImageBytes)
     assert image[:len(utilities.PNGHeader)] == utilities.PNGHeader
     (width, height) = struct.unpack('!LL', image[16:24])
     assert max(width, height) == 256

--- a/utilities/converter/large_image_converter/__init__.py
+++ b/utilities/converter/large_image_converter/__init__.py
@@ -272,7 +272,7 @@ def _convert_via_vips(inputPathOrBuffer, outputPath, tempPath, forTiled=True,
     if type(inputPathOrBuffer) == pyvips.vimage.Image:
         source = 'vips image'
         image = inputPathOrBuffer
-    elif type(inputPathOrBuffer) == bytes:
+    elif isinstance(inputPathOrBuffer, bytes):
         source = 'buffer'
         image = pyvips.Image.new_from_buffer(inputPathOrBuffer, '')
     else:


### PR DESCRIPTION
When using `getThumbnail()` or `getTile()` in `ipython`/Jupyter, the `bytes` repr output can be overbearing and not all that useful as the image bytes can overtake the output with very long amounts of data.

These changes add a wrapper class to the `bytes` object for when we are returning PNG, JPEG, or TIFF image data (to give more user-friendly outputs in ipython and show an actual preview of the image in Jupyter

This is incredibly useful when trying to debug the graphical outputs of these methods.

## `master`

```py
In [1]: import large_image

In [2]: src = large_image.open('co_elevation.tif', projection='EPSG:3857')

In [3]: thumb, mime = src.getThumbnail()

In [4]: thumb
Out[4]: b'\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01\x01\x00\x00\x01\x00\x01\x00\x00\xff\xdb\x00C\x00\x02\x01\x01\x01\x01\x01\x02\x01\x01\x01\x02\x
... (really long bytes output)
```


## This branch
```py
In [1]: import large_image

In [2]: src = large_image.open('co_elevation.tif', projection='EPSG:3857')

In [3]: thumb, mime = src.getThumbnail()

In [4]: thumb
Out[4]: ImageBytes<16194> (image/jpeg)
```

## Jupyter

| `master` | this branch |
|---|---|
| <img width="1132" alt="Screen Shot 2022-07-30 at 2 11 46 PM" src="https://user-images.githubusercontent.com/22067021/181994814-a4ceaf86-629d-458f-a75c-08badfc94b2a.png"> | <img width="1132" alt="Screen Shot 2022-07-30 at 2 12 08 PM" src="https://user-images.githubusercontent.com/22067021/181994819-9fc4d4bd-ca1a-455b-9a53-cdf74fc50f9e.png"> |

Similarly works with `getTile()`:

```py
In [1]: import large_image

In [2]: src = large_image.open('co_elevation.tif',  encoding='PNG')

In [3]: tile = src.getTile(0,0,0)

In [4]: tile
Out[4]: ImageBytes<30086> (image/png)

In [5]:
```

<img width="1140" alt="Screen Shot 2022-07-30 at 2 13 25 PM" src="https://user-images.githubusercontent.com/22067021/181994847-77cba215-96c1-4416-885d-3aedecb6cc4d.png">


TIFF encodings simply repr out in Jupyter:
<img width="716" alt="Screen Shot 2022-07-30 at 2 29 08 PM" src="https://user-images.githubusercontent.com/22067021/181995219-a8362c2b-6936-4701-8fe4-3a7f8828d2af.png">


