### PR TITLE
Fix styling with nodata.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Inheritable config files ([897](../../pull/897))
 - Add geospatial property ([818](../../pull/818), [908](../../pull/908))
 - Improve repr of image bytes ([902](../../pull/902))
+- Handle nodata style when specified as a string ([914](../../pull/914))
 
 ### Changes
 - Be more consistent in source class name attribute assignment ([884](../../pull/884))

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1191,7 +1191,7 @@ class TileSource:
             clamp = entry.get('clamp', True)
             delta = max - min if max != min else 1
             if nodata is not None:
-                keep = band != nodata
+                keep = band != float(nodata)
             else:
                 keep = numpy.full(image.shape[:2], True)
             band = (band - min) / delta

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -568,3 +568,15 @@ def testVfsCogValidation():
         imagePath, projection='EPSG:3857', encoding='PNG')
     with pytest.raises(TileSourceInefficientError):
         source.validateCOG()
+
+
+def testNoData():
+    imagePath = datastore.get_url('TC_NG_SFBay_US_Geo_COG.tif')
+    source = large_image_source_gdal.open(
+        imagePath, projection='EPSG:3857',
+        style={'bands': [{'band': 1, 'max': '100', 'min': '5', 'nodata': '0'}]})
+    assert source.getThumbnail()[0] is not None
+    source = large_image_source_gdal.open(
+        imagePath, projection='EPSG:3857',
+        style={'bands': [{'band': 1, 'max': 100, 'min': 5, 'nodata': 0}]})
+    assert source.getThumbnail()[0] is not None

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -575,8 +575,8 @@ def testNoData():
     source = large_image_source_gdal.open(
         imagePath, projection='EPSG:3857',
         style={'bands': [{'band': 1, 'max': '100', 'min': '5', 'nodata': '0'}]})
-    assert source.getThumbnail()[0] is not None
+    assert source.getThumbnail()[0]
     source = large_image_source_gdal.open(
         imagePath, projection='EPSG:3857',
         style={'bands': [{'band': 1, 'max': 100, 'min': 5, 'nodata': 0}]})
-    assert source.getThumbnail()[0] is not None
+    assert source.getThumbnail()[0]


### PR DESCRIPTION
Handle nodata when passed as a string.

Fixes https://github.com/girder/large_image/issues/911.