### PR TITLE
Support a bands parameter for the test source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Reduce error messages and make canRead results more accurate ([918](../../pull/918), [919](../../pull/919), [920](../../pull/920))
 - Sort columns in item lists based ([925](../../pull/925), [928](../../pull/928))
 - Better handle tiffs with orientation flags in pil source ([924](../../pull/924))
+Support a bands parameter for the test source ([935](../../pull/935))
 
 ### Changes
 - Remove some extraneous values from metadata responses ([932](../../pull/932))

--- a/sources/multi/large_image_source_multi/__init__.py
+++ b/sources/multi/large_image_source_multi/__init__.py
@@ -676,6 +676,10 @@ class MultiFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                             self._nativeMagnification[key] or tsMag.get(key))
                 numChecked += 1
                 tsMeta = ts.getMetadata()
+                if 'bands' in tsMeta:
+                    if not hasattr(self, '_bands'):
+                        self._bands = {}
+                    self._bands.update(tsMeta['bands'])
             bbox = self._sourceBoundingBox(source, tsMeta['sizeX'], tsMeta['sizeY'])
             computedWidth = max(computedWidth, int(math.ceil(bbox['right'])))
             computedHeight = max(computedHeight, int(math.ceil(bbox['bottom'])))
@@ -774,6 +778,8 @@ class MultiFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 {k: v for k, v in frame.items() if k.startswith('Index')}
                 for frame in self._frames]
             self._addMetadataFrameInformation(result, self._channels)
+        if hasattr(self, '_bands'):
+            result['bands'] = self._bands.copy()
         return result
 
     def getInternalMetadata(self, **kwargs):

--- a/test/test_files/multi_band.yml
+++ b/test/test_files/multi_band.yml
@@ -1,0 +1,17 @@
+---
+sources:
+  - sourceName: test
+    path: __none__
+    params:
+      minLevel: 0
+      maxLevel: 6
+      tileWidth: 256
+      tileHeight: 256
+      sizeX: 10000
+      sizeY: 7500
+      fractal: True
+      # c,z,t,xy OR frames
+      frames: "4,6,1,1"
+      monochrome: False
+      # multiband
+      bands: "red,green,blue,ir1,ir2"

--- a/test/test_files/multi_channels.yml
+++ b/test/test_files/multi_channels.yml
@@ -1,5 +1,5 @@
 ---
-name: Multi orientationa
+name: Multi orientation
 sources:
   - path: ./test_orient1.tif
     channel: CY3

--- a/test/test_source_multi.py
+++ b/test/test_source_multi.py
@@ -146,3 +146,13 @@ def testCanRead():
     assert large_image_source_multi.canRead(imagePath) is True
     imagePath2 = os.path.join(testDir, 'test_files', 'test_orient1.tif')
     assert large_image_source_multi.canRead(imagePath2) is False
+
+
+def testMultiBand():
+    testDir = os.path.dirname(os.path.realpath(__file__))
+    imagePath = os.path.join(testDir, 'test_files', 'multi_band.yml')
+    source = large_image_source_multi.open(imagePath)
+    metadata = source.getMetadata()
+    assert len(metadata['bands']) == 5
+    image, mimeType = source.getThumbnail(encoding='PNG')
+    assert image[:len(utilities.PNGHeader)] == utilities.PNGHeader


### PR DESCRIPTION
This can help development of #498.

Specifically, upload the sample file `test/test_files/multi_band.yml` to a Girder instance to have a source with channels and bands.