### PR TITLE
Add annotation creation access flag

### DIFF
--- a/girder_annotation/girder_large_image_annotation/__init__.py
+++ b/girder_annotation/girder_large_image_annotation/__init__.py
@@ -15,6 +15,7 @@
 #############################################################################
 
 from girder import events
+from girder.constants import registerAccessFlag
 from girder.exceptions import ValidationException
 from girder.plugin import GirderPlugin, getPlugin
 from girder.settings import SettingDefault
@@ -57,6 +58,10 @@ def validateBoolean(doc):
 SettingDefault.defaults.update({
     constants.PluginSettings.LARGE_IMAGE_ANNOTATION_HISTORY: True,
 })
+
+# Access flags
+
+registerAccessFlag('createAnnots', 'Create annotations', 'Allow user to create annotations')
 
 
 class LargeImageAnnotationPlugin(GirderPlugin):

--- a/girder_annotation/girder_large_image_annotation/__init__.py
+++ b/girder_annotation/girder_large_image_annotation/__init__.py
@@ -61,7 +61,8 @@ SettingDefault.defaults.update({
 
 # Access flags
 
-registerAccessFlag('createAnnots', 'Create annotations', 'Allow user to create annotations')
+registerAccessFlag(constants.ANNOTATION_ACCESS_FLAG, 'Create annotations',
+                   'Allow user to create annotations')
 
 
 class LargeImageAnnotationPlugin(GirderPlugin):

--- a/girder_annotation/girder_large_image_annotation/constants.py
+++ b/girder_annotation/girder_large_image_annotation/constants.py
@@ -18,3 +18,5 @@
 from girder_large_image.constants import PluginSettings
 
 PluginSettings.LARGE_IMAGE_ANNOTATION_HISTORY = 'large_image.annotation_history'
+
+ANNOTATION_ACCESS_FLAG = 'large_image_create_annotations'

--- a/girder_annotation/girder_large_image_annotation/rest/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/rest/annotation.py
@@ -34,6 +34,7 @@ from girder.models.user import User
 from girder.utility import JsonEncoder
 from girder.utility.progress import setResponseTimeLimit
 
+from .. import constants
 from ..models.annotation import Annotation, AnnotationSchema
 from ..models.annotationelement import Annotationelement
 
@@ -269,7 +270,7 @@ class AnnotationResource(Resource):
         user = self.getCurrentUser()
         folder = Folder().load(id=item['folderId'], user=user, level=AccessType.READ)
         if Folder().hasAccess(folder, user, AccessType.WRITE) or Folder(
-        ).hasAccessFlags(folder, user, 'createAnnots'):
+        ).hasAccessFlags(folder, user, constants.ANNOTATION_ACCESS_FLAG):
             try:
                 return Annotation().createAnnotation(
                     item, self.getCurrentUser(), self.getBodyJson())
@@ -690,7 +691,7 @@ class AnnotationResource(Resource):
     def canCreateFolderAnnotations(self, folder):
         user = self.getCurrentUser()
         return Folder().hasAccess(folder, user, AccessType.WRITE) or Folder().hasAccessFlags(
-            folder, user, 'createAnnots')
+            folder, user, constants.ANNOTATION_ACCESS_FLAG)
 
     @autoDescribeRoute(
         Description('Set the access for all the user-owned annotations from the items in a folder')

--- a/girder_annotation/girder_large_image_annotation/web_client/templates/annotationListWidget.pug
+++ b/girder_annotation/girder_large_image_annotation/web_client/templates/annotationListWidget.pug
@@ -5,7 +5,7 @@
     if annotations.length
       a.g-annotation-download(href=`${apiRoot}/annotation/item/${item.id}`, title='Download annotations', download=`${item.get('name')}_annotations.json`)
         i.icon-download
-    if accessLevel >= AccessType.WRITE
+    if creationAccess
       a.g-annotation-upload(title='Upload annotation')
         i.icon-upload
     if accessLevel >= AccessType.ADMIN && annotations.length

--- a/girder_annotation/girder_large_image_annotation/web_client/views/annotationListWidget.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/annotationListWidget.js
@@ -74,7 +74,7 @@ const AnnotationListWidget = View.extend({
                 apiRoot: getApiRoot(),
                 AccessType
             }));
-        })
+        });
         return this;
     },
 

--- a/girder_annotation/girder_large_image_annotation/web_client/views/annotationListWidget.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/annotationListWidget.js
@@ -59,16 +59,22 @@ const AnnotationListWidget = View.extend({
     },
 
     render() {
-        this.$el.html(annotationList({
-            item: this.model,
-            accessLevel: this.model.getAccessLevel(),
-            annotations: this.collection,
-            users: this.users,
-            canDraw: this._viewer && this._viewer.annotationAPI(),
-            drawn: this._drawn,
-            apiRoot: getApiRoot(),
-            AccessType
-        }));
+        restRequest({
+            type: 'GET',
+            url: 'annotation/folder/' + this.model.get('folderId') + '/create'
+        }).done((createResp) => {
+            this.$el.html(annotationList({
+                item: this.model,
+                accessLevel: this.model.getAccessLevel(),
+                creationAccess: createResp,
+                annotations: this.collection,
+                users: this.users,
+                canDraw: this._viewer && this._viewer.annotationAPI(),
+                drawn: this._drawn,
+                apiRoot: getApiRoot(),
+                AccessType
+            }));
+        })
         return this;
     },
 
@@ -185,7 +191,8 @@ const AnnotationListWidget = View.extend({
             type: 'annotation',
             hideRecurseOption: true,
             parentView: this,
-            model
+            model,
+            noAccessFlag: true
         }).on('g:accessListSaved', () => {
             this.collection.fetch(null, true);
         });

--- a/girder_annotation/girder_large_image_annotation/web_client/views/hierarchyWidget.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/hierarchyWidget.js
@@ -87,7 +87,8 @@ function editAnnotAccess() {
                     modelType: 'annotation',
                     model,
                     hideRecurseOption: false,
-                    parentView: this
+                    parentView: this,
+                    noAccessFlag: true
                 });
             });
     });


### PR DESCRIPTION
Adds a new girder access flag which demarcates whether or not a user has permission to create annotations, allowing users to create annotations without having write access to a folder/item.  Also creates a new endpoint indicating whether or not the user has creation permissions (via write access or the flag) and makes current annotation creation procedures check for the access flag.