### PR TITLE
Reduce a restriction on reading some tiff files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Reduce rest calls to get settings ([953](../../pull/953))
 - Add an endpoint to delete all annotations in a folder ([954](../../pull/954))
 - Support relabeling axes in the multi source ([957](../../pull/957))
+- Reduce a restriction on reading some tiff files ([958](../../pull/958))
 
 ### Bug Fixes
 - Harden adding images to the item list ([955](../../pull/955))

--- a/sources/tiff/large_image_source_tiff/tiff_reader.py
+++ b/sources/tiff/large_image_source_tiff/tiff_reader.py
@@ -229,8 +229,7 @@ class TiledTiffDirectory:
         # should only be done if necessary, which would require the conversion
         # job to check output and perform subsequent processing as needed.
         if (not self._tiffInfo.get('samplesperpixel') or
-                (self._tiffInfo.get('samplesperpixel') != 1 and
-                 self._tiffInfo.get('samplesperpixel') < 3)):
+                self._tiffInfo.get('samplesperpixel') < 1):
             raise ValidationTiffException(
                 'Only RGB and greyscale TIFF files are supported')
 


### PR DESCRIPTION
The tiff tilesource will now read greyscale with alpha files.