### PR TITLE
Use functions in styles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
-## 1.16.3
+## 1.17.0
+
+### Features
+- Style functions ([960](../../pull/960))
 
 ### Improvements
 - Reduce rest calls to get settings ([953](../../pull/953))

--- a/docs/tilesource_options.rst
+++ b/docs/tilesource_options.rst
@@ -80,7 +80,7 @@ A band definition is an object which can contain the following keys:
 
   The function parameter can be a single function or a list of functions.  Items in a list of functions can, themselves, be lists of functions.  A single function can be an object or a string.  If a string, this is shorthand for ``{"name": <function>}``.  The function object contains (all but ``name`` are optional):
 
-  - ``name``: The name of a Python module and function that is installed in the same environment as large_image.  For instance, ``large_image.tilesource.utilities.maskPixelValues`` will use the function ``maskPixelValues`` in the ``large_image.tilesource.utilities`` module.  The function must be a Python function that takes a numpy array as the first parameter (the image) and has named parameters or kwargs for any passed parameters and possibly the style context.
+  - ``name``: The name of a Python module and function that is installed in the same environment as large_image.  For instance, ``large_image.tilesource.stylefuncs.maskPixelValues`` will use the function ``maskPixelValues`` in the ``large_image.tilesource.stylefuncs`` module.  The function must be a Python function that takes a numpy array as the first parameter (the image) and has named parameters or kwargs for any passed parameters and possibly the style context.
 
   - ``parameters``: A dictionary of parameters to pass to the function.
 

--- a/docs/tilesource_options.rst
+++ b/docs/tilesource_options.rst
@@ -64,6 +64,61 @@ A band definition is an object which can contain the following keys:
 
 - ``axis``: if specified, keep on the specified axis (channel) of the intermediate numpy array.  This is typically between 0 and 3 for the red, green, blue, and alpha channels.  Only the first such value is used, and this can be specified as a base key if ``bands`` is specified.
 
+- ``function``: if specified, call a function to modify the resulting image.  This can be specified as a base key and as a band key.  Style functions can be called at multiple stages in the styling pipeline:
+
+  - ``pre`` stage: this passes the original tile image to the function before any band data is applied.
+
+  - ``preband`` stage: this passes the band image (often the original tile image if a different frame is not specified) to the function before any scaling.
+
+  - ``band`` stage: this passes the band image after scaling (via ``min`` and ``max``) and generating a ``nodata`` mask.
+
+  - ``postband`` stage: this passes the in-progress output image after the band has been applied to it.
+
+  - ``main`` stage: this passes the in-progress output image after all bands have been applied but before it is adjusted for ``dtype``.
+
+  - ``post`` stage: this passes the output image just before the style function returns.
+
+  The function parameter can be a single function or a list of functions.  Items in a list of functions can, themselves, be lists of functions.  A single function can be an object or a string.  If a string, this is shorthand for ``{"name": <function>}``.  The function object contains (all but ``name`` are optional):
+
+  - ``name``: The name of a Python module and function that is installed in the same environment as large_image.  For instance, ``large_image.tilesource.utilities.maskPixelValues`` will use the function ``maskPixelValues`` in the ``large_image.tilesource.utilities`` module.  The function must be a Python function that takes a numpy array as the first parameter (the image) and has named parameters or kwargs for any passed parameters and possibly the style context.
+
+  - ``parameters``: A dictionary of parameters to pass to the function.
+
+  - ``stage``: A string for a single matching stage or a list of stages that this function should be applied to.  This defaults to ``["band", "main"]``.
+
+  - ``context``: If this is present and not falsy, pass the style context to the function.  If this is ``true``, the style context is passed as the ``context`` parameter.  Otherwise, this is the name of the parameter that is passed to the function.  The style context is a namespace that contains (depending on stage), a variety of information:
+
+    - ``image``: the source image as a numpy array.
+
+    - ``originalStyle``: the style object from the tile source.
+
+    - ``style``: the normalized style object (always an object with a ``bands`` key containing a list of bands).
+
+    - ``x``, ``y``, ``z``, and ``frame``: the tile position in the source.
+
+    - ``dtype``, ``axis``: the value specified from the style for these parameters.
+
+    - ``output``: the output image as a numpy array.
+
+    - ``stage``: the current stage of style processing.
+
+    - ``styleIndex``: if in a band stage, the 0-based index within the style bands.
+
+    - ``band``: the band numpy image in a band stage.
+
+    - ``mask``: a mask numpy image to use when applying the band.
+
+    - ``palette``: the normalized palette for a band.
+
+    - ``palettebase``: a numpy linear interpolation array for non-discrete paletes.
+    - ``discete``: True if the scheme is discrete.
+
+    - ``nodata``: the nodata value for the band or None.
+
+    - ``min``, ``max``: the resolved numerical minimum and maximum value for the band.
+
+    - ``clamp``: the clamp value for the band.
+
 Note that some tile sources add additional options to the ``style`` parameter.
 
 Examples

--- a/large_image/tilesource/stylefuncs.py
+++ b/large_image/tilesource/stylefuncs.py
@@ -1,0 +1,39 @@
+# This module contains functions for use in styles
+
+import numpy
+
+
+def maskPixelValues(image, context, values=None, negative=None, positive=None):
+    """
+    This is a style utility function that returns a black-and-white 8-bit image
+    where the image is white if the pixel of the source image is in a list of
+    values and black otherwise.  The values is a list where each entry can
+    either be a tuple the same length as the band dimension of the output image
+    or a single value which is handled as 0xBBGGRR.
+
+    :param image: a numpy array of Y, X, Bands.
+    :param context: the style context.  context.image is the source image
+    :param values: an array of values, each of which is either an array of the
+        same number of bands as the source image or a single value of the form
+        0xBBGGRR assuming uint8 data.
+    :param negative: None to use [0, 0, 0, 255], or an RGBA uint8 value for
+        pixels not in the value list.
+    :param positive: None to use [255, 255, 255, 0], or an RGBA uint8 value for
+        pixels in the value list.
+    :returns: an RGBA numpy image which is exactly black or transparent white.
+    """
+    src = context.image
+    mask = numpy.full(src.shape[:2], False)
+    for val in values:
+        if not isinstance(val, (list, tuple)):
+            if src.shape[-1] == 1:
+                val = [val]
+            else:
+                val = [val % 256, val // 256 % 256, val // 65536 % 256]
+        val = (list(val) + [255] * src.shape[2])[:src.shape[2]]
+        match = numpy.array(val)
+        mask = mask | (src == match).all(axis=-1)
+    image[mask != True] = negative or [0, 0, 0, 255]  # noqa E712
+    image[mask] = positive or [255, 255, 255, 0]
+    image = image.astype(numpy.uint8)
+    return image

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -935,42 +935,6 @@ def histogramThreshold(histogram, threshold, fromMax=False):
     return edges[-1]
 
 
-def maskPixelValues(image, context, values=None, negative=None, positive=None):
-    """
-    This is a style utility function that returns a black-and-white 8-bit image
-    where the image is white if the pixel of the source image is in a list of
-    values and black otherwise.  The values is a list where each entry can
-    either be a tuple the same length as the band dimension of the output image
-    or a single value which is handled as 0xBBGGRR.
-
-    :param image: a numpy array of Y, X, Bands.
-    :param context: the style context.  context.image is the source image
-    :param values: an array of values, each of which is either an array of the
-        same number of bands as the source image or a single value of the form
-        0xBBGGRR assuming uint8 data.
-    :param negative: None to use [0, 0, 0, 255], or an RGBA uint8 value for
-        pixels not in the value list.
-    :param positive: None to use [255, 255, 255, 0], or an RGBA uint8 value for
-        pixels in the value list.
-    :returns: an RGBA numpy image which is exactly black or transparent white.
-    """
-    src = context.image
-    mask = numpy.full(src.shape[:2], False)
-    for val in values:
-        if not isinstance(val, (list, tuple)):
-            if src.shape[-1] == 1:
-                val = [val]
-            else:
-                val = [val % 256, val // 256 % 256, val // 65536 % 256]
-        val = (list(val) + [255] * src.shape[2])[:src.shape[2]]
-        match = numpy.array(val)
-        mask = mask | (src == match).all(axis=-1)
-    image[mask != True] = negative or [0, 0, 0, 255]  # noqa E712
-    image[mask] = positive or [255, 255, 255, 0]
-    image = image.astype(numpy.uint8)
-    return image
-
-
 def addPILFormatsToOutputOptions():
     """
     Check PIL for available formats that be saved and add them to the lists of

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -935,6 +935,42 @@ def histogramThreshold(histogram, threshold, fromMax=False):
     return edges[-1]
 
 
+def maskPixelValues(image, context, values=None, negative=None, positive=None):
+    """
+    This is a style utility function that returns a black-and-white 8-bit image
+    where the image is white if the pixel of the source image is in a list of
+    values and black otherwise.  The values is a list where each entry can
+    either be a tuple the same length as the band dimension of the output image
+    or a single value which is handled as 0xBBGGRR.
+
+    :param image: a numpy array of Y, X, Bands.
+    :param context: the style context.  context.image is the source image
+    :param values: an array of values, each of which is either an array of the
+        same number of bands as the source image or a single value of the form
+        0xBBGGRR assuming uint8 data.
+    :param negative: None to use [0, 0, 0, 255], or an RGBA uint8 value for
+        pixels not in the value list.
+    :param positive: None to use [255, 255, 255, 0], or an RGBA uint8 value for
+        pixels in the value list.
+    :returns: an RGBA numpy image which is exactly black or transparent white.
+    """
+    src = context.image
+    mask = numpy.full(src.shape[:2], False)
+    for val in values:
+        if not isinstance(val, (list, tuple)):
+            if src.shape[-1] == 1:
+                val = [val]
+            else:
+                val = [val % 256, val // 256 % 256, val // 65536 % 256]
+        val = (list(val) + [255] * src.shape[2])[:src.shape[2]]
+        match = numpy.array(val)
+        mask = mask | (src == match).all(axis=-1)
+    image[mask != True] = negative or [0, 0, 0, 255]  # noqa E712
+    image[mask] = positive or [255, 255, 255, 0]
+    image = image.astype(numpy.uint8)
+    return image
+
+
 def addPILFormatsToOutputOptions():
     """
     Check PIL for available formats that be saved and add them to the lists of

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -574,7 +574,7 @@ def testStyleFunctions():
         format=large_image.constants.TILE_FORMAT_NUMPY)
     sourceFunc2 = large_image.open(imagePath, style={
         'function': {
-            'name': 'large_image.tilesource.utilities.maskPixelValues',
+            'name': 'large_image.tilesource.stylefuncs.maskPixelValues',
             'context': True,
             'parameters': {'values': [164, 165]}},
         'bands': []})
@@ -584,7 +584,7 @@ def testStyleFunctions():
     assert numpy.any(region2 != region1)
     sourceFunc3 = large_image.open(imagePath, style={
         'function': {
-            'name': 'large_image.tilesource.utilities.maskPixelValues',
+            'name': 'large_image.tilesource.stylefuncs.maskPixelValues',
             'context': True,
             'parameters': {'values': [[63, 63, 63]]}},
         'bands': []})
@@ -594,7 +594,7 @@ def testStyleFunctions():
     assert numpy.any(region3 != region2)
     sourceFunc4 = large_image.open(imagePath, style={
         'function': [{
-            'name': 'large_image.tilesource.utilities.maskPixelValues',
+            'name': 'large_image.tilesource.stylefuncs.maskPixelValues',
             'context': 'context',
             'parameters': {'values': [164, 165]}}],
         'bands': []})
@@ -608,7 +608,7 @@ def testStyleFunctionsWarnings():
     imagePath = datastore.fetch('extraoverview.tiff')
     source = large_image.open(imagePath, style={
         'function': {
-            'name': 'large_image.tilesource.utilities.maskPixelValues',
+            'name': 'large_image.tilesource.stylefuncs.maskPixelValues',
             'context': True,
             'parameters': {'values': ['bad value']}},
         'bands': []})
@@ -630,7 +630,7 @@ def testStyleFunctionsWarnings():
 
     source = large_image.open(imagePath, style={
         'function': {
-            'name': 'large_image.tilesource.utilities.noSuchFunction',
+            'name': 'large_image.tilesource.stylefuncs.noSuchFunction',
             'context': True,
             'parameters': {'values': [100]}},
         'bands': []})


### PR DESCRIPTION
Resolves #688.

This can be used, for instance, to get a mask from a superpixel image. For instance, suppose you want a mask for the superpixel with an index of 82, you'd use a style like:
`{"function":{"name":"large_image.tilesource.stylefuncs.maskPixelValues","context":true,"parameters":{"values":[82]}},"bands":[]}` (or, if you are using superpixels with boundaries, this would be `{"function":{"name":"large_image.tilesource.stylefuncs.maskPixelValues","context":true,"parameters":{"values":[164,165]}},"bands":[]}`). The resulting image (assuming you are returning a PNG), will be opaque black where this value is not present and transparent white where it is (or specify the `negative` and `positive` parameters to get different colors).

@naglepuff This should be useful in showing just the superpixels from an image.