### PR TITLE
Remove an unneeded dependency.

### DIFF
--- a/sources/bioformats/setup.py
+++ b/sources/bioformats/setup.py
@@ -54,7 +54,6 @@ setup(
     install_requires=[
         f'large-image{limit_version}',
         'python-bioformats>=1.5.2',
-        'scikit-image',
         'importlib-metadata ; python_version < "3.8"',
     ],
     extras_require={


### PR DESCRIPTION
We had added scikit-image as a requirement to avoid a warning in PIMS, but the packages no longer pull that in, so this is no longer needed.