### PR TITLE
Add some admin endpoints to check thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add metadata and annotation metadata search modes to Girder ([#974](../../pull/974))
 - Add the ability to show annotation metadata in item annotation lists ([#977](../../pull/977))
 - Support ETAG in annotation rest responses for better browser caching ([#978](../../pull/978))
+- Thumbnail maintenance endpoints ([#979](../../pull/979))
 
 ## 1.17.0
 

--- a/girder/girder_large_image/rest/tiles.py
+++ b/girder/girder_large_image/rest/tiles.py
@@ -147,6 +147,8 @@ class TilesItemResource(ItemResource):
         apiRoot.item.route('GET', (':itemId', 'tiles'), self.getTilesInfo)
         apiRoot.item.route('DELETE', (':itemId', 'tiles'), self.deleteTiles)
         apiRoot.item.route('GET', (':itemId', 'tiles', 'thumbnail'), self.getTilesThumbnail)
+        apiRoot.item.route('GET', (':itemId', 'tiles', 'thumbnails'), self.listTilesThumbnails)
+        apiRoot.item.route('DELETE', (':itemId', 'tiles', 'thumbnails'), self.deleteTilesThumbnails)
         apiRoot.item.route('GET', (':itemId', 'tiles', 'region'), self.getTilesRegion)
         apiRoot.item.route('GET', (':itemId', 'tiles', 'tile_frames'), self.tileFrames)
         apiRoot.item.route('GET', (':itemId', 'tiles', 'tile_frames', 'quad_info'),
@@ -1399,3 +1401,25 @@ class TilesItemResource(ItemResource):
                 result['scheduledJob'] = str(self.imageItemModel._scheduleTileFrames(
                     item, needed, self.getCurrentUser())['_id'])
         return result
+
+    @autoDescribeRoute(
+        Description('List all thumbnail and data files associated with a large_image item.')
+        .modelParam('itemId', model=Item, level=AccessType.READ)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Read access was denied for the item.', 403)
+    )
+    @access.admin
+    def listTilesThumbnails(self, item):
+        return self.imageItemModel.removeThumbnailFiles(item, onlyList=True)
+
+    @autoDescribeRoute(
+        Description('Delete thumbnail and data files associated with a large_image item.')
+        .modelParam('itemId', model=Item, level=AccessType.READ)
+        .param('keep', 'Number of thumbnails to keep.', dataType='integer',
+               required=False, default=10000)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Read access was denied for the item.', 403)
+    )
+    @access.admin
+    def deleteTilesThumbnails(self, item, keep):
+        return self.imageItemModel.removeThumbnailFiles(item, keep=keep or 0)


### PR DESCRIPTION
This lists thumbnails and data files associated with a specific large image and allows deletion of all such files.