### PR TITLE
Use open.read rather than download to access files in Girder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.17.4
+
+### Bug Fixes
+- Use open.read rather than download to access files in Girder ([#989](../../pull/989))
+
 ## 1.17.3
 
 ### Changes

--- a/girder_annotation/girder_large_image_annotation/handlers.py
+++ b/girder_annotation/girder_large_image_annotation/handlers.py
@@ -124,7 +124,7 @@ def process_annotations(event):  # noqa: C901
         logger.error('Could not load models from the database')
         return
     try:
-        data = orjson.loads(b''.join(File().download(file)()).decode())
+        data = orjson.loads(File().open(file).read().decode())
     except Exception:
         logger.error('Could not parse annotation file')
         raise


### PR DESCRIPTION
download returns a forward on S3 assetstores.