### PR TITLE
Do not raise an unneeded error.

### DIFF
--- a/girder_annotation/girder_large_image_annotation/web_client/views/annotationListWidget.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/annotationListWidget.js
@@ -53,7 +53,8 @@ const AnnotationListWidget = View.extend({
 
         restRequest({
             type: 'GET',
-            url: 'annotation/folder/' + this.model.get('folderId') + '/create'
+            url: 'annotation/folder/' + this.model.get('folderId') + '/create',
+            error: null
         }).done((createResp) => {
             this.createResp = createResp;
             restRequest({


### PR DESCRIPTION
Do not raise a login request when checking if the user can write annotations.