### PR TITLE
Adjust how we invoke the test worker for celery 5.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
           version: 3.11.0
           node: v12
       - tox:
-          env: core-py311
+          env: test-py311
       - coverage
       - store_artifacts:
           path: build/test/artifacts

--- a/girder/test_girder/conftest.py
+++ b/girder/test_girder/conftest.py
@@ -33,8 +33,8 @@ def girderWorkerProcess():
     env = os.environ.copy()
     env['C_FORCE_ROOT'] = 'true'
     proc = subprocess.Popen([
-        'celery', '-A', 'girder_worker.app', 'worker', '--broker', broker,
-        '--result-backend', backend, '--concurrency=1'],
+        'celery', '-A', 'girder_worker.app', '--broker', broker,
+        '--result-backend', backend, 'worker', '--concurrency=1'],
         close_fds=True, env=env)
     yield True
     proc.terminate()


### PR DESCRIPTION
This also enables full server tests on CI for Python 3.11.