### PR TITLE
Don't use dask threads when using nd2 to fetch tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 - Better control dtype on multi sources ([#993](../../pull/993))
+- Don't use dask threads when using nd2 to fetch tiles ([#994](../../pull/994))
 
 ### Bug Fixes
 - Use open.read rather than download to access files in Girder ([#989](../../pull/989))


### PR DESCRIPTION
We have to lock when fetching tiles anyway, and the dask threadpool adds needless overhead.