### PR TITLE
Add token scopes to girder endpoints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Better control dtype on multi sources ([#993](../../pull/993))
 - Don't use dask threads when using nd2 to fetch tiles ([#994](../../pull/994))
 - Set mime type for imported girder files ([#995](../../pull/995))
+- Specify token scopes for girder endpoint  ([#999](../../pull/999))
 
 ### Bug Fixes
 - Use open.read rather than download to access files in Girder ([#989](../../pull/989))

--- a/girder/girder_large_image/rest/large_image_resource.py
+++ b/girder/girder_large_image/rest/large_image_resource.py
@@ -34,6 +34,7 @@ from girder import logger
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute, describeRoute
 from girder.api.rest import Resource
+from girder.constants import TokenScope
 from girder.exceptions import RestException
 from girder.models.file import File
 from girder.models.item import Item
@@ -263,7 +264,7 @@ class LargeImageResource(Resource):
     @describeRoute(
         Description('Get public settings for large image display.')
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     def getPublicSettings(self, params):
         keys = [getattr(constants.PluginSettings, key)
                 for key in dir(constants.PluginSettings)
@@ -450,7 +451,7 @@ class LargeImageResource(Resource):
                     'higher priority for an extension of mime type with that '
                     'source.')
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     def listSources(self, params):
         results = {}
         for key, source in girder_tilesource.AvailableGirderTileSources.items():
@@ -565,7 +566,7 @@ class LargeImageResource(Resource):
         config = config.read().decode('utf8')
         return self._configValidate(config)
 
-    @autoDescribeRoute(
+    @autoDescribeRoute(  # noqa
         Description('Reformat a Girder config file')
         .param('config', 'The contents of config file to format.',
                paramType='body')

--- a/girder/girder_large_image/rest/tiles.py
+++ b/girder/girder_large_image/rest/tiles.py
@@ -29,7 +29,7 @@ from girder.api import access, filter_logging
 from girder.api.describe import Description, autoDescribeRoute, describeRoute
 from girder.api.rest import filtermodel, loadmodel, setRawResponse, setResponseHeader
 from girder.api.v1.item import Item as ItemResource
-from girder.constants import AccessType
+from girder.constants import AccessType, TokenScope
 from girder.exceptions import RestException
 from girder.models.file import File
 from girder.models.item import Item
@@ -218,7 +218,7 @@ class TilesItemResource(ItemResource):
                'number of logical cpus less that value.  Default is -2.',
                dataType='int', required=False)
     )
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.WRITE)
     @filtermodel(model='job', plugin='jobs')
     def createTiles(self, item, params):
@@ -283,7 +283,7 @@ class TilesItemResource(ItemResource):
                'number of logical cpus less that value.  Default is -2.',
                dataType='int', required=False)
     )
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     @filtermodel(model='job', plugin='jobs')
     def convertImage(self, item, params):
@@ -421,7 +421,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def getTilesInfo(self, item, params):
         return self._getTilesInfo(item, params)
@@ -432,7 +432,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def getInternalMetadata(self, item, params):
         try:
@@ -443,7 +443,7 @@ class TilesItemResource(ItemResource):
     @describeRoute(
         Description('Get test large image metadata.')
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     def getTestTilesInfo(self, params):
         item = {'largeImage': {'sourceName': 'test'}}
         imageArgs = self._parseTestParams(params)
@@ -459,7 +459,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def getDZIInfo(self, item, params):
         if 'encoding' in params and params['encoding'] not in ('JPEG', 'PNG'):
@@ -606,7 +606,7 @@ class TilesItemResource(ItemResource):
                paramType='path')
         .produces(ImageMimeTypes)
     )
-    @access.public(cookie=True)
+    @access.public(cookie=True, scope=TokenScope.DATA_READ)
     def getTestTile(self, z, x, y, params):
         item = {'largeImage': {'sourceName': 'test'}}
         imageArgs = self._parseTestParams(params)
@@ -624,7 +624,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
-    @access.public(cookie=True)
+    @access.public(cookie=True, scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def getDZITile(self, item, level, xandy, params):
         _adjustParams(params)
@@ -680,7 +680,7 @@ class TilesItemResource(ItemResource):
         Description('Remove a large image from this item.')
         .param('itemId', 'The ID of the item.', paramType='path')
     )
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.WRITE)
     def deleteTiles(self, item, params):
         deleted = self.imageItemModel.delete(item)
@@ -725,7 +725,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
-    @access.public(cookie=True)
+    @access.public(cookie=True, scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def getTilesThumbnail(self, item, params):
         _adjustParams(params)
@@ -852,7 +852,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('Read access was denied for the item.', 403)
         .errorResponse('Insufficient memory.')
     )
-    @access.public(cookie=True)
+    @access.public(cookie=True, scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def getTilesRegion(self, item, params):
         _adjustParams(params)
@@ -933,7 +933,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
-    @access.public(cookie=True)
+    @access.public(cookie=True, scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def getTilesPixel(self, item, params):
         params = self._parseParams(params, True, [
@@ -988,7 +988,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def getHistogram(self, item, params):
         _adjustParams(params)
@@ -1045,7 +1045,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def getBandInformation(self, item, params):
         _adjustParams(params)
@@ -1062,7 +1062,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def getAssociatedImagesList(self, item, params):
         try:
@@ -1091,7 +1091,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
-    @access.public(cookie=True)
+    @access.public(cookie=True, scope=TokenScope.DATA_READ)
     def getAssociatedImage(self, itemId, image, params):
         _adjustParams(params)
         # We can't use the loadmodel decorator, as we want to allow cookies
@@ -1130,7 +1130,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     def getAssociatedImageMetadata(self, item, image, params):
         _handleETag('getAssociatedImageMetadata', item, image)
         tilesource = self.imageItemModel._loadTileSource(item, **params)
@@ -1264,7 +1264,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('Read access was denied for the item.', 403)
         .errorResponse('Insufficient memory.')
     )
-    @access.public(cookie=True)
+    @access.public(cookie=True, scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def tileFrames(self, item, params):
         cache = params.pop('cache', False)
@@ -1362,7 +1362,7 @@ class TilesItemResource(ItemResource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
-    @access.public(cookie=True)
+    @access.public(cookie=True, scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def tileFramesQuadInfo(self, item, params):
         metadata = self.imageItemModel.getMetadata(item)

--- a/girder_annotation/girder_large_image_annotation/rest/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/rest/annotation.py
@@ -87,7 +87,7 @@ class AnnotationResource(Resource):
         .errorResponse()
         .errorResponse('Read access was denied on the parent item.', 403)
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     @filtermodel(model='annotation', plugin='large_image')
     def find(self, params):
         limit, offset, sort = self.getPagingParameters(params, 'lowerName')
@@ -123,7 +123,7 @@ class AnnotationResource(Resource):
                'all IDs must be unique.')
         .errorResponse()
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     def getAnnotationSchema(self, params):
         return AnnotationSchema.annotationSchema
 
@@ -166,7 +166,7 @@ class AnnotationResource(Resource):
         .errorResponse('Read access was denied for the annotation.', 403)
         .notes('Use "size" or "details" as possible sort keys.')
     )
-    @access.public(cookie=True)
+    @access.public(cookie=True, scope=TokenScope.DATA_READ)
     def getAnnotation(self, id, params):
         user = self.getCurrentUser()
         annotation = Annotation().load(
@@ -269,7 +269,7 @@ class AnnotationResource(Resource):
         .errorResponse('Invalid JSON passed in request body.')
         .errorResponse("Validation Error: JSON doesn't follow schema.")
     )
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(map={'itemId': 'item'}, model='item', level=AccessType.READ)
     @filtermodel(model='annotation', plugin='large_image')
     def createAnnotation(self, item, params):
@@ -298,7 +298,7 @@ class AnnotationResource(Resource):
         .errorResponse('ID was invalid.')
         .errorResponse('Write access was denied for the item.', 403)
     )
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='annotation', plugin='large_image', level=AccessType.READ)
     @filtermodel(model='annotation', plugin='large_image')
     def copyAnnotation(self, annotation, params):
@@ -324,7 +324,7 @@ class AnnotationResource(Resource):
         .errorResponse('Invalid JSON passed in request body.')
         .errorResponse("Validation Error: JSON doesn't follow schema.")
     )
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='annotation', plugin='large_image', level=AccessType.WRITE)
     @filtermodel(model='annotation', plugin='large_image')
     def updateAnnotation(self, annotation, params):
@@ -366,7 +366,7 @@ class AnnotationResource(Resource):
         .errorResponse('ID was invalid.')
         .errorResponse('Write access was denied for the annotation.', 403)
     )
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     # Load with a limit of 1 so that we don't bother getting most annotations
     @loadmodel(model='annotation', plugin='large_image', getElements=False, level=AccessType.WRITE)
     def deleteAnnotation(self, annotation, params):
@@ -391,7 +391,7 @@ class AnnotationResource(Resource):
         .pagingParams(defaultSort='updated', defaultSortDir=-1)
         .errorResponse()
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     def findAnnotatedImages(self, params):
         limit, offset, sort = self.getPagingParameters(
             params, 'updated', SortDir.DESCENDING)
@@ -412,7 +412,7 @@ class AnnotationResource(Resource):
         .errorResponse('ID was invalid.')
         .errorResponse('Admin access was denied for the annotation.', 403)
     )
-    @access.user
+    @access.user(scope=TokenScope.DATA_OWN)
     @loadmodel(model='annotation', plugin='large_image', getElements=False, level=AccessType.ADMIN)
     def getAnnotationAccess(self, annotation, params):
         return Annotation().getFullAccessList(annotation)
@@ -426,7 +426,7 @@ class AnnotationResource(Resource):
         .errorResponse('ID was invalid.')
         .errorResponse('Admin access was denied for the annotation.', 403)
     )
-    @access.user
+    @access.user(scope=TokenScope.DATA_OWN)
     @loadmodel(model='annotation', plugin='large_image', getElements=False, level=AccessType.ADMIN)
     @filtermodel(model=Annotation, addFields={'access'})
     def updateAnnotationAccess(self, annotation, params):
@@ -448,7 +448,7 @@ class AnnotationResource(Resource):
                       defaultSortDir=SortDir.DESCENDING)
         .errorResponse('Read access was denied for the annotation.', 403)
     )
-    @access.public(cookie=True)
+    @access.public(cookie=True, scope=TokenScope.DATA_READ)
     def getAnnotationHistoryList(self, id, limit, offset, sort):
         return list(Annotation().versionList(id, self.getCurrentUser(), limit, offset, sort))
 
@@ -460,7 +460,7 @@ class AnnotationResource(Resource):
         .errorResponse('Annotation history version not found.')
         .errorResponse('Read access was denied for the annotation.', 403)
     )
-    @access.public(cookie=True)
+    @access.public(cookie=True, scope=TokenScope.DATA_READ)
     def getAnnotationHistory(self, id, version):
         result = Annotation().getVersion(id, version, self.getCurrentUser())
         if result is None:
@@ -479,7 +479,7 @@ class AnnotationResource(Resource):
         .errorResponse('Annotation history version not found.')
         .errorResponse('Read access was denied for the annotation.', 403)
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_WRITE)
     def revertAnnotationHistory(self, id, version):
         setResponseTimeLimit(86400)
         annotation = Annotation().revertVersion(id, version, self.getCurrentUser())
@@ -497,7 +497,7 @@ class AnnotationResource(Resource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
     )
-    @access.public(cookie=True)
+    @access.public(cookie=True, scope=TokenScope.DATA_READ)
     def getItemAnnotations(self, item):
         user = self.getCurrentUser()
         query = {'_active': {'$ne': False}, 'itemId': item['_id']}
@@ -535,7 +535,7 @@ class AnnotationResource(Resource):
         .errorResponse('Invalid JSON passed in request body.')
         .errorResponse("Validation Error: JSON doesn't follow schema.")
     )
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def createItemAnnotations(self, item, annotations):
         user = self.getCurrentUser()
         if hasattr(annotations, 'read'):
@@ -566,7 +566,7 @@ class AnnotationResource(Resource):
         .errorResponse('ID was invalid.')
         .errorResponse('Write access was denied for the item.', 403)
     )
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def deleteItemAnnotations(self, item):
         setResponseTimeLimit(86400)
         user = self.getCurrentUser()
@@ -650,7 +650,7 @@ class AnnotationResource(Resource):
                'subfolders for annotations', required=False, default=True, dataType='boolean')
         .errorResponse()
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     def existFolderAnnotations(self, id, recurse):
         user = self.getCurrentUser()
         if not user:
@@ -670,7 +670,7 @@ class AnnotationResource(Resource):
         .pagingParams(defaultSort='created', defaultSortDir=-1)
         .errorResponse()
     )
-    @access.public
+    @access.public(scope=TokenScope.DATA_READ)
     def returnFolderAnnotations(self, id, recurse, limit, offset, sort):
         user = self.getCurrentUser()
         if not user:
@@ -694,7 +694,7 @@ class AnnotationResource(Resource):
         .param('id', 'The ID of the folder', required=True, paramType='path')
         .errorResponse('ID was invalid.')
     )
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     @loadmodel(model='folder', level=AccessType.READ)
     def canCreateFolderAnnotations(self, folder):
         user = self.getCurrentUser()
@@ -711,7 +711,7 @@ class AnnotationResource(Resource):
                'annotations from subfolders', required=False, default=False, dataType='boolean')
         .errorResponse('ID was invalid.')
     )
-    @access.user
+    @access.user(scope=TokenScope.DATA_OWN)
     def setFolderAnnotationAccess(self, id, params):
         setResponseTimeLimit(86400)
         user = self.getCurrentUser()
@@ -740,7 +740,7 @@ class AnnotationResource(Resource):
                'annotations from subfolders', required=False, default=False, dataType='boolean')
         .errorResponse('ID was invalid.')
     )
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def deleteFolderAnnotations(self, id, params):
         setResponseTimeLimit(86400)
         user = self.getCurrentUser()
@@ -762,7 +762,7 @@ class AnnotationResource(Resource):
                'annotation.', required=False, dataType='int', default=10)
         .errorResponse()
     )
-    @access.admin
+    @access.admin(scope=TokenScope.DATA_READ)
     def getOldAnnotations(self, age, versions):
         setResponseTimeLimit(86400)
         return Annotation().removeOldAnnotations(False, age, versions)
@@ -775,7 +775,7 @@ class AnnotationResource(Resource):
                'annotation.', required=False, dataType='int', default=10)
         .errorResponse()
     )
-    @access.admin
+    @access.admin(scope=TokenScope.DATA_WRITE)
     def deleteOldAnnotations(self, age, versions):
         setResponseTimeLimit(86400)
         return Annotation().removeOldAnnotations(True, age, versions)


### PR DESCRIPTION
Without this, a token often needs user_auth access to do things where only read or read/write access is actually needed.