### PR TITLE
Better release file handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## 1.18.1
 
+### Improvements
+- Better release file handles ([#1007](../../pull/1007))
+
 ### Changes
-Don't report filename in internal PIL metadata ([#1006](../../pull/1006))
+- Don't report filename in internal PIL metadata ([#1006](../../pull/1006))
 
 ## 1.18.0
 

--- a/girder/girder_large_image/rest/large_image_resource.py
+++ b/girder/girder_large_image/rest/large_image_resource.py
@@ -244,6 +244,8 @@ class LargeImageResource(Resource):
     )
     @access.admin(scope=TokenScope.DATA_WRITE)
     def cacheClear(self, params):
+        import gc
+
         before = cache_util.cachesInfo()
         cache_util.cachesClear()
         after = cache_util.cachesInfo()
@@ -252,6 +254,7 @@ class LargeImageResource(Resource):
         while time.time() < stoptime and any(after[key]['used'] for key in after):
             time.sleep(0.1)
             after = cache_util.cachesInfo()
+        gc.collect()
         return {'cacheCleared': datetime.datetime.utcnow(), 'before': before, 'after': after}
 
     @describeRoute(

--- a/large_image/cache_util/__init__.py
+++ b/large_image/cache_util/__init__.py
@@ -26,6 +26,8 @@ except ImportError:
 
 from .cachefactory import CacheFactory, pickAvailableCache
 
+_cacheClearFuncs = []
+
 
 @atexit.register
 def cachesClear(*args, **kwargs):
@@ -44,6 +46,8 @@ def cachesClear(*args, **kwargs):
                 tileCache.clear()
         except Exception:
             pass
+    for func in _cacheClearFuncs:
+        func()
 
 
 def cachesInfo(*args, **kwargs):

--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -61,7 +61,7 @@ _openImages = []
 
 # Default to ignoring files with no extension and some specific extensions.
 config.ConfigValues['source_bioformats_ignored_names'] = \
-    r'(^[^.]*|\.(jpg|jpeg|jpe|png|tif|tiff|ndpi|nd2))$'
+    r'(^[^.]*|\.(jpg|jpeg|jpe|png|tif|tiff|ndpi|nd2|ome|nc|json))$'
 
 
 def _monitor_thread():

--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -28,6 +28,7 @@ import math
 import os
 import threading
 import types
+import weakref
 
 import numpy
 
@@ -71,6 +72,7 @@ def _monitor_thread():
             javabridge.attach()
             while len(_openImages):
                 source = _openImages.pop()
+                source = source()
                 try:
                     source._bioimage.close()
                 except Exception:
@@ -195,7 +197,7 @@ class BioformatsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                     raise TileSourceFileNotFoundError(largeImagePath) from None
                 self.logger.debug('File cannot be opened via Bioformats. (%r)' % exc)
                 raise TileSourceError('File cannot be opened via Bioformats (%r)' % exc)
-            _openImages.append(self)
+            _openImages.append(weakref.ref(self))
 
             rdr = self._bioimage.rdr
             # Bind additional functions not done by bioformats module.
@@ -295,7 +297,8 @@ class BioformatsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             try:
                 javabridge.attach()
                 self._bioimage.close()
-                _openImages.remove(self)
+                del self._bioimage
+                _openImages.remove(weakref.ref(self))
             finally:
                 if javabridge.get_env():
                     javabridge.detach()


### PR DESCRIPTION
After opening some tile sources and then clearing cache and doing a gc.collect(), some file handles were still open (this can be checked via /proc/<pid>/fd).  This cures the test cases I've found _except_ for nd2 files that start to open and then fail.  I filed an issue with the nd2 reader about that.

The bioformats reader also has issues in this regard, which probably has something to do with the java library (not the python side of things).