### PR TITLE
Speed up loading or parsing some sources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Improvements
 - Better release file handles ([#1007](../../pull/1007))
 - Support tiny images from the test source ([#1013](../../pull/1013))
+- Speed up loading or parsing some multi sources ([#1015](../../pull/1015))
 
 ### Changes
 - Don't report filename in internal PIL metadata ([#1006](../../pull/1006))

--- a/sources/multi/large_image_source_multi/__init__.py
+++ b/sources/multi/large_image_source_multi/__init__.py
@@ -403,7 +403,12 @@ class MultiFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                     if start[:1] not in ('{', '#', '-') and (start[:1] < 'a' or start[:1] > 'z'):
                         raise TileSourceError('File cannot be opened via multi-source reader.')
                     fptr.seek(0)
-                    self._info = yaml.safe_load(fptr)
+                    try:
+                        import orjson
+                        self._info = orjson.loads(fptr.read())
+                    except Exception:
+                        fptr.seek(0)
+                        self._info = yaml.safe_load(fptr)
             except (json.JSONDecodeError, yaml.YAMLError, UnicodeDecodeError):
                 raise TileSourceError('File cannot be opened via multi-source reader.')
             self._validator.validate(self._info)

--- a/sources/nd2/large_image_source_nd2/__init__.py
+++ b/sources/nd2/large_image_source_nd2/__init__.py
@@ -218,24 +218,26 @@ class ND2FileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
 
         :returns: metadata dictionary.
         """
-        result = super().getMetadata()
+        if not hasattr(self, '_computedMetadata'):
+            result = super().getMetadata()
 
-        sizes = self._nd2.sizes
-        axes = self._nd2order[:self._nd2order.index('Y')][::-1]
-        sizes = self._nd2.sizes
-        result['frames'] = frames = []
-        for idx in range(self._frameCount):
-            frame = {'Frame': idx}
-            basis = 1
-            ref = {}
-            for axis in axes:
-                ref[axis] = (idx // basis) % sizes[axis]
-                frame['Index' + (axis.upper() if axis.upper() != 'P' else 'XY')] = (
-                    idx // basis) % sizes[axis]
-                basis *= sizes.get(axis, 1)
-            frames.append(frame)
-        self._addMetadataFrameInformation(result, self._channels)
-        return result
+            sizes = self._nd2.sizes
+            axes = self._nd2order[:self._nd2order.index('Y')][::-1]
+            sizes = self._nd2.sizes
+            result['frames'] = frames = []
+            for idx in range(self._frameCount):
+                frame = {'Frame': idx}
+                basis = 1
+                ref = {}
+                for axis in axes:
+                    ref[axis] = (idx // basis) % sizes[axis]
+                    frame['Index' + (axis.upper() if axis.upper() != 'P' else 'XY')] = (
+                        idx // basis) % sizes[axis]
+                    basis *= sizes.get(axis, 1)
+                frames.append(frame)
+            self._addMetadataFrameInformation(result, self._channels)
+            self._computedMetadata = result
+        return self._computedMetadata
 
     def getInternalMetadata(self, **kwargs):
         """


### PR DESCRIPTION
For nd2 files, this caches metadata computation.

For multi sources, this prefers a fast json parser if the file permits it.