### PR TITLE
Better output new vips images as float32.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 ### Changes
 - Don't report filename in internal PIL metadata ([#1006](../../pull/1006))
 
+### Bug Fixes
+- Better output new vips images as float32 ([#1016](../../pull/1016))
+
 ## 1.18.0
 
 ### Features

--- a/sources/vips/large_image_source_vips/__init__.py
+++ b/sources/vips/large_image_source_vips/__init__.py
@@ -420,8 +420,11 @@ class VipsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             trunk = baseimg.copy()
             branch = baseimg.copy()
             for idx, entry in enumerate(self._output['images']):
+                entryimage = entry['image']
+                if img.format == 'float' and entry['image'].format == 'double':
+                    entryimage = entryimage.cast(img.format)
                 branch = branch.composite(
-                    entry['image'], pyvips.BlendMode.OVER, x=entry['x'], y=entry['y'])
+                    entryimage, pyvips.BlendMode.OVER, x=entry['x'], y=entry['y'])
                 if not ((idx + 1) % leaves) or idx + 1 == len(self._output['images']):
                     trunk = trunk.composite(branch, pyvips.BlendMode.OVER, x=0, y=0)
                     branch = baseimg.copy()


### PR DESCRIPTION
When asking to output vips images as float32, they were being promoted to float64.