### PR TITLE
Clear the source cache on some tests to reduce memory use.

### DIFF
--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -9,6 +9,7 @@ import PIL.Image
 import pytest
 
 import large_image
+from large_image.cache_util import cachesClear
 from large_image.tilesource import nearPowerOfTwo
 
 from . import utilities
@@ -142,6 +143,8 @@ def testSourcesCanRead(source, filename):
     mod = sys.modules[sourceClass.__module__]
     assert bool(mod.canRead(imagePath)) is bool(canRead)
 
+    cachesClear()
+
 
 @pytest.mark.parametrize('filename', registry)
 @pytest.mark.parametrize('source', SourceAndFiles)
@@ -156,6 +159,8 @@ def testSourcesCanReadPath(source, filename):
     large_image.tilesource.loadTileSources()
     sourceClass = large_image.tilesource.AvailableTileSources[source]
     assert bool(sourceClass.canRead(Path(imagePath))) is bool(canRead)
+
+    cachesClear()
 
 
 @pytest.mark.parametrize('filename', registry)
@@ -202,6 +207,8 @@ def testSourcesTilesAndMethods(source, filename):
     mod = sys.modules[sourceClass.__module__]
     assert mod.open(imagePath) is not None
 
+    cachesClear()
+
 
 @pytest.mark.parametrize('filename,isgeo', [
     ('04091217_ruc.nc', True),
@@ -213,6 +220,8 @@ def testSourcesTilesAndMethods(source, filename):
 def testIsGeospatial(filename, isgeo):
     imagePath = datastore.fetch(filename)
     assert large_image.tilesource.isGeospatial(imagePath) == isgeo
+
+    cachesClear()
 
 
 @pytest.mark.parametrize('palette', [

--- a/test/test_source_hdf5.py
+++ b/test/test_source_hdf5.py
@@ -6,6 +6,7 @@ import numpy
 import pytest
 
 import large_image
+from large_image.cache_util import cachesClear
 
 possible_axes = {
     'x': [1, 10],
@@ -189,6 +190,9 @@ def testImageGeneration(data_range):
     # print(resultFromFile.shape, result.shape)
     # assert numpy.array_equal(result, resultFromFile)
     print(f'Success; result matrix {result.shape} equals expected matrix {expected.shape}.')
+
+    source = None
+    cachesClear()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It seems to sometimes exhaust memory on CircleCI instances.