### PR TITLE
Add an option to flatten girder item lists.

### DIFF
--- a/girder/girder_large_image/web_client/stylesheets/itemList.styl
+++ b/girder/girder_large_image/web_client/stylesheets/itemList.styl
@@ -72,3 +72,11 @@ ul.g-item-list
   .modal-dialog.li-item-list-dialog
     width 70%
     max-width 1000px
+
+.li-flatten-item-list
+  font-size 14px
+  display inline-block
+  margin-left 20px
+  label
+    padding-left 5px
+    font-weight normal

--- a/girder/test_girder/web_client_specs/imageViewerSpec.js
+++ b/girder/test_girder/web_client_specs/imageViewerSpec.js
@@ -253,6 +253,22 @@ $(function () {
                 expect(!$('.g-item-list-entry').length);
             });
         });
+        it('flatten the item list', function () {
+            runs(function () {
+                $('.li-flatten-item-list #flattenitemlist').click();
+            });
+            girderTest.waitForLoad();
+            runs(function () {
+                expect($('.li-flatten-item-list #flattenitemlist:checked').length);
+            });
+            runs(function () {
+                $('.li-flatten-item-list #flattenitemlist').click();
+            });
+            girderTest.waitForLoad();
+            runs(function () {
+                expect(!$('.li-flatten-item-list #flattenitemlist:checked').length);
+            });
+        });
         it('navigate back to image', function () {
             waitsFor(function () {
                 return $('span.g-item-list-link').filter(function () { return $(this).text() !== '.large_image_config.yaml'; }).length > 0;


### PR DESCRIPTION
This will still list the folders.  All items within any of the child folders will be listed.  When a flat list of items is shown, selecting the "Check all" checkbox will only select items.