### PR TITLE
Speed up rendering Girder item page metadata in some instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.19.3
+
+### Improvements
+- Speed up rendering Girder item page metadata in some instances ([#1031](../../pull/1031))
+
 ## 1.19.2
 
 ### Improvements

--- a/girder/girder_large_image/web_client/templates/itemView.pug
+++ b/girder/girder_large_image/web_client/templates/itemView.pug
@@ -28,7 +28,7 @@ mixin tableentry(value, depth, keyname)
     td.subtable.large_image_metadata_table(keyname=keyname)
       +maketable(value, (depth || 0) + 1, keyname)
   else if Array.isArray(value) || (value && value.constructor.name === 'Object')
-    if yaml.dump(value).split('\n').length <= 100
+    if ((Array.isArray(value) && value.length <= 25) || Object.keys(value).length <= 25) && yaml.dump(value).split('\n').length <= 100
       td.yaml.large_image_metadata_value(keyname=keyname) #{yaml.dump(value)}
     else
       td.json.large_image_metadata_value(keyname=keyname) #{JSON.stringify(value)}


### PR DESCRIPTION
When data was long, we needless checked its serialization length, which could be slow.