### PR TITLE
Fix an issue with non-square tiles in the multi source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Improvements
 - Speed up rendering Girder item page metadata in some instances ([#1031](../../pull/1031))
 
+### Bug Fixes
+- Fix an issue with non-square tiles in the multi source ([#1032](../../pull/1032))
+
 ## 1.19.2
 
 ### Improvements

--- a/sources/multi/large_image_source_multi/__init__.py
+++ b/sources/multi/large_image_source_multi/__init__.py
@@ -1024,7 +1024,7 @@ class MultiFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         if fill:
             colors = self._info.get('backgroundColor')
             if colors:
-                tile = numpy.full((self.tileWidth, self.tileHeight, len(colors)), colors)
+                tile = numpy.full((self.tileHeight, self.tileWidth, len(colors)), colors)
         # Add each source to the tile
         for sourceEntry in sourceList:
             tile = self._addSourceToTile(tile, sourceEntry, corners, scale)
@@ -1032,7 +1032,7 @@ class MultiFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             # TODO number of channels?
             colors = self._info.get('backgroundColor', [0])
             if colors:
-                tile = numpy.full((self.tileWidth, self.tileHeight, len(colors)), colors)
+                tile = numpy.full((self.tileHeight, self.tileWidth, len(colors)), colors)
         # We should always have a tile
         return self._outputTile(tile, TILE_FORMAT_NUMPY, x, y, z,
                                 pilImageAllowed, numpyAllowed, **kwargs)


### PR DESCRIPTION
When there was a background color, the axes were confused.