### PR TITLE
Better pick the largest image from bioformats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Speed up generating tiles for some multi source files ([#1035](../../pull/1035))
 - Render item lists faster ([#1036](../../pull/1036))
 - Reduce bioformats source memory usage ([#1038](../../pull/1038))
+- Better pick the largest image from bioformats ([#1039](../../pull/1039))
 
 ## 1.19.3
 


### PR DESCRIPTION
This improves how a sample LIF file gets displayed.  It still doesn't seem complete -- bioformats doesn't normalize image metadata very well, so the reader might eventually need more options to better handle different sub-formats.