### PR TITLE
Support a simple style for icc: true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.20.0
 
 ### Features
-- ICC color profile support ([#1037](../../pull/1037), [#1043](../../pull/1043), [#1046](../../pull/1046))
+- ICC color profile support ([#1037](../../pull/1037), [#1043](../../pull/1043), [#1046](../../pull/1046), [#1048](../../pull/1048))
 
 ### Improvements
 - Speed up generating tiles for some multi source files ([#1035](../../pull/1035), [#1047](../../pull/1047))

--- a/docs/tilesource_options.rst
+++ b/docs/tilesource_options.rst
@@ -64,7 +64,7 @@ A band definition is an object which can contain the following keys:
 
 - ``axis``: if specified, keep on the specified axis (channel) of the intermediate numpy array.  This is typically between 0 and 3 for the red, green, blue, and alpha channels.  Only the first such value is used, and this can be specified as a base key if ``bands`` is specified.
 
-- ``icc``: by default, sources that expose ICC color profiles will apply those profiles to the image data, converting the results to the sRGB profile.  To use the raw image data without ICC profile adjustments, specify an ``icc`` value of ``false``.  If the entire style is ``{"icc": false}``, the results will be the same as the default bands with only the adjustment being skipped.  Note that not all tile sources expose ICC color profile information, even if the base file format contains it.
+- ``icc``: by default, sources that expose ICC color profiles will apply those profiles to the image data, converting the results to the sRGB profile.  To use the raw image data without ICC profile adjustments, specify an ``icc`` value of ``false``.  If the entire style is ``{"icc": false}``, the results will be the same as the default bands with only the adjustment being skipped.  Similarly, if the entire style is ``{"icc": true}``, this is the same as the default style with where the adjustment is applied.  Note that not all tile sources expose ICC color profile information, even if the base file format contains it.
 
 - ``function``: if specified, call a function to modify the resulting image.  This can be specified as a base key and as a band key.  Style functions can be called at multiple stages in the styling pipeline:
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1280,7 +1280,7 @@ class TileSource:
         sc = types.SimpleNamespace(
             image=image, originalStyle=style, x=x, y=y, z=z, frame=frame,
             mainImage=image, mainFrame=frame, dtype=None, axis=None)
-        if style is None:
+        if style is None or style == {'icc': True}:
             sc.style = {'bands': []}
         else:
             sc.style = style if 'bands' in style else {'bands': [style]}

--- a/test/test_source_openslide.py
+++ b/test/test_source_openslide.py
@@ -336,6 +336,18 @@ def testGetPixel():
     assert 'tile' in pixel
 
 
+def testGetPixelWithICCCorrection():
+    imagePath = datastore.fetch(
+        'sample_jp2k_33003_TCGA-CV-7242-11A-01-TS1.1838afb1-9eee-'
+        '4a70-9ae3-50e3ab45e242.svs')
+    source = large_image_source_openslide.open(imagePath)
+    pixel = source.getPixel(region={'left': 12125, 'top': 10640})
+    assert pixel == {'r': 169, 'g': 99, 'b': 151, 'a': 255}
+    source = large_image_source_openslide.open(imagePath, style={'icc': True})
+    pixel2 = source.getPixel(region={'left': 12125, 'top': 10640})
+    assert pixel == pixel2
+
+
 def testTilesFromPowerOf3Tiles():
     imagePath = datastore.fetch('G10-3_pelvis_crop-powers-of-3.tif')
     source = large_image_source_openslide.open(imagePath)


### PR DESCRIPTION
This makes specifying ICC correction or not symmetric.  See the added docs.