### PR TITLE
Add _repr_png_ for Jupyter

### DIFF
--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -166,6 +166,9 @@ class TileSource:
     def __repr__(self):
         return self.getState()
 
+    def _repr_png_(self):
+        return self.getThumbnail(encoding='PNG')[0]
+
     @staticmethod
     def getLRUHash(*args, **kwargs):
         """


### PR DESCRIPTION
A simple addition to quickly preview a tile source in Jupyter:


| New | Classic |
|---|---|
| <img width="810" alt="Screen Shot 2023-02-14 at 9 40 26 PM" src="https://user-images.githubusercontent.com/22067021/218932515-a67e29f8-bd04-4211-a5f9-95e90bce9322.png"> |  <img width="857" alt="Screen Shot 2023-02-14 at 9 40 42 PM" src="https://user-images.githubusercontent.com/22067021/218932583-19dd6702-4aaf-4c1b-9f68-0865d4590a4d.png"> |


This is pretty standard for image-based libraries to create a user-friendly representation in Jupyter. See also https://github.com/python-pillow/Pillow/issues/1090

Note that this returns an `ImageBytes` object from #902 