### PR TITLE
The cache could reuse a class inappropriately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Improvements
 - Allow ICC correction to specify intent ([#1066](../../pull/1066))
 
+### Bug Fixes
+- The cache could reuse a class inappropriately ([#1070](../../pull/1070))
+
 ## 1.20.1
 
 ### Bug Fixes

--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -1,4 +1,3 @@
-import copy
 import functools
 import threading
 
@@ -113,7 +112,6 @@ class LruCacheMetaclass(type):
         # Get metaclass parameters by finding and removing them from the class
         # namespace (necessary for Python 2), or preferentially as metaclass
         # arguments (only in Python 3).
-
         cacheName = namespace.get('cacheName', None)
         cacheName = kwargs.get('cacheName', cacheName)
 
@@ -192,12 +190,13 @@ class LruCacheMetaclass(type):
                         return result
                 except KeyError:
                     pass
-            # This conditionally copies a non-styled class and add a style.
+            # This conditionally copies a non-styled class and adds a style.
             if kwargs.get('style') and hasattr(cls, '_setStyle'):
                 subkwargs = kwargs.copy()
                 subkwargs.pop('style')
                 subresult = cls(*args, **subkwargs)
-                result = copy.copy(subresult)
+                result = subresult.__class__.__new__(subresult.__class__)
+                result.__dict__ = subresult.__dict__.copy()
                 result._setStyle(kwargs['style'])
                 result._classkey = key
                 with cacheLock:

--- a/test/test_cache_source.py
+++ b/test/test_cache_source.py
@@ -13,6 +13,8 @@ def testCacheSourceStyle():
     ts1 = large_image.open(imagePath)
     ts2 = large_image.open(imagePath, style={'max': 128})
     ts3 = large_image.open(imagePath, style={'max': 160})
+    assert id(ts1) != id(ts2)
+    assert id(ts2) != id(ts3)
     tile1 = ts1.getTile(0, 0, 4)
     assert ts1.getTile(0, 0, 4) is not None
     assert ts2.getTile(0, 0, 4) is not None
@@ -33,6 +35,7 @@ def testCacheSourceStyleFirst():
     imagePath = datastore.fetch('sample_image.ptif')
     ts2 = large_image.open(imagePath, style={'max': 128})
     ts1 = large_image.open(imagePath)
+    assert id(ts1) != id(ts2)
     tile1 = ts1.getTile(0, 0, 4)
     assert ts1.getTile(0, 0, 4) is not None
     assert ts2.getTile(0, 0, 4) is not None


### PR DESCRIPTION
This doesn't seem to be a problem in anything we are currently doing, but you can manually get a class instance that isn't distinct, so although this is listed as a bug fix, I don't think it has any external impact.