### PR TITLE
Extract scale information from more bioformats files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 - Allow ICC correction to specify intent ([#1066](../../pull/1066))
 - Make tile sources pickleable ([#1071](../../pull/1071))
+- Extract scale information from more bioformats files ([#1073](../../pull/1073))
 
 ### Bug Fixes
 - The cache could reuse a class inappropriately ([#1070](../../pull/1070))

--- a/sources/vips/large_image_source_vips/__init__.py
+++ b/sources/vips/large_image_source_vips/__init__.py
@@ -544,7 +544,7 @@ class VipsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         xres = 0
         if self._image:
             xres = self._image.get('xres') or 0
-        return 1.0 / xres if xres else None
+        return 1.0 / xres if xres and xres != 1 else None
 
     @mm_x.setter
     def mm_x(self, value):
@@ -563,7 +563,7 @@ class VipsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         yres = 0
         if self._image:
             yres = self._image.get('yres') or 0
-        return 1.0 / yres if yres else None
+        return 1.0 / yres if yres and yres != 1 else None
 
     @mm_y.setter
     def mm_y(self, value):


### PR DESCRIPTION
Also, don't report a scale from vips if the values are the defaults.