### PR TITLE
Add events to feature, not layer

### DIFF
--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -435,16 +435,20 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                     this.annotationLayer.moveToTop();
                     this.trigger('g:drawOverlayAnnotation', overlay, overlayLayer);
                     const featureEvents = geo.event.feature;
-                    overlayLayer.geoOn(
-                        [
-                            featureEvents.mouseclick,
-                            featureEvents.mouseoff,
-                            featureEvents.mouseon,
-                            featureEvents.mouseover,
-                            featureEvents.mouseout
-                        ],
-                        (evt) => this._onMouseFeature(evt, annotation.elements().get(overlay.id), overlayLayer)
-                    );
+                    _.each(overlayLayer.features(), (feature) => {
+                        if (feature.featureType !== 'quad') {
+                            feature.geoOn(
+                                [
+                                    featureEvents.mouseclick,
+                                    featureEvents.mouseoff,
+                                    featureEvents.mouseon,
+                                    featureEvents.mouseover,
+                                    featureEvents.mouseout
+                                ],
+                                (evt) => this._onMouseFeature(evt, annotation.elements().get(overlay.id), overlayLayer)
+                            );
+                        }
+                    });
                     this.viewer.scheduleAnimationFrame(this.viewer.draw, true);
                 }).fail((response) => {
                     console.error(`There was an error overlaying image with ID ${overlayItemId}`);


### PR DESCRIPTION
Previously, when rendering overlay layers, several geojs mouse events were added to the layer. This would cause double-firing of these events. Now, the events are only added to the non-quad features on the layer to prevent the double firing.