### PR TITLE
Add a tox command to format the client code.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ jobs:
     steps:
       - checkout
       - allservices:
-          version: 3.10.9
+          version: 3.10.10
           node: v12
       - tox:
           env: test-py310
@@ -188,7 +188,7 @@ jobs:
     steps:
       - checkout
       - allservices:
-          version: 3.11.1
+          version: 3.11.2
           node: v12
       - tox:
           env: test-py311
@@ -200,7 +200,7 @@ jobs:
     steps:
       - checkout
       - tox:
-          env: docs,flake8,lintclient,lintannotationclient
+          env: docs,flake8,lintclient
       - store_artifacts:
           path: build/docs
       - persist_to_workspace:

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -33,7 +33,7 @@ Tests are run via tox environments:
 
 .. code-block:: bash
 
-    tox -e test-py39,flake8,lintclient,lintannotationclient
+    tox -e test-py39,flake8,lintclient
 
 Or, without Girder:
 

--- a/girder/girder_large_image/web_client/eventStream.js
+++ b/girder/girder_large_image/web_client/eventStream.js
@@ -2,7 +2,7 @@
  * server. */
 
 import eventStream from '@girder/core/utilities/EventStream';
-import { restRequest } from '@girder/core/rest';
+import {restRequest} from '@girder/core/rest';
 
 import largeImageConfig from './views/configView';
 

--- a/girder/girder_large_image/web_client/main.js
+++ b/girder/girder_large_image/web_client/main.js
@@ -1,4 +1,4 @@
-import { registerPluginNamespace } from '@girder/core/pluginUtils';
+import {registerPluginNamespace} from '@girder/core/pluginUtils';
 import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
 
 // import modules for side effects

--- a/girder/girder_large_image/web_client/package.json
+++ b/girder/girder_large_image/web_client/package.json
@@ -43,7 +43,10 @@
             ],
             "no-alert": "error",
             "switch-colon-spacing": "error",
-            "object-curly-spacing": "off",
+            "object-curly-spacing": [
+                "error",
+                "never"
+            ],
             "import/exports-last": "error",
             "promise/no-native": "error",
             "promise/no-return-in-finally": "error",
@@ -172,19 +175,19 @@
     },
     "devDependencies": {
         "@girder/eslint-config": "^3.0.0-rc1",
-        "eslint": "^5.16.0",
-        "eslint-config-semistandard": "^13.0.0",
-        "eslint-config-standard": "^12.0.0",
+        "eslint": "^8.20.0",
+        "eslint-config-semistandard": "^17.0.0",
+        "eslint-config-standard": "^17.0.0",
         "eslint-plugin-backbone": "^2.1.1",
-        "eslint-plugin-import": "^2.17.3",
-        "eslint-plugin-node": "^9.1.0",
-        "eslint-plugin-promise": "^4.1.1",
-        "eslint-plugin-standard": "^4.0.0",
+        "eslint-plugin-import": "^2.25.3",
+        "eslint-plugin-n": "^15.2.4",
+        "eslint-plugin-promise": "^6.0.0",
         "@girder/pug-lint-config": "^3.0.0-rc1",
         "pug-lint": "^2.6.0",
-        "stylint": "^1.5.9"
+        "stylint": "^2"
     },
     "scripts": {
-        "lint": "eslint --cache . && pug-lint . && stylint"
+        "lint": "eslint --cache . && pug-lint . && stylint",
+        "format": "eslint --cache --fix ."
     }
 }

--- a/girder/girder_large_image/web_client/routes.js
+++ b/girder/girder_large_image/web_client/routes.js
@@ -2,9 +2,9 @@ import $ from 'jquery';
 import Backbone from 'backbone';
 
 import events from '@girder/core/events';
-import { parseQueryString, splitRoute } from '@girder/core/misc';
+import {parseQueryString, splitRoute} from '@girder/core/misc';
 import router from '@girder/core/router';
-import { exposePluginConfig } from '@girder/core/utilities/PluginUtils';
+import {exposePluginConfig} from '@girder/core/utilities/PluginUtils';
 
 import ConfigView from './views/configView';
 
@@ -43,7 +43,7 @@ function addToRoute(params) {
         // But backbone stores an unescaped fragment in the
         // Backbone.history.fragment, which causes a hash-variation trigger,
         // so this works around that.
-        let fragment = (routeParts.base + (paramStr ? '?' + paramStr : '')).replace(/#.*$/, '');
+        const fragment = (routeParts.base + (paramStr ? '?' + paramStr : '')).replace(/#.*$/, '');
         Backbone.history.fragment = fragment;
         Backbone.history._updateHash(Backbone.history.location, fragment);
     }

--- a/girder/girder_large_image/web_client/views/configView.js
+++ b/girder/girder_large_image/web_client/views/configView.js
@@ -1,9 +1,9 @@
 import $ from 'jquery';
 import View from '@girder/core/views/View';
 
-import { AccessType } from '@girder/core/constants';
+import {AccessType} from '@girder/core/constants';
 import events from '@girder/core/events';
-import { restRequest } from '@girder/core/rest';
+import {restRequest} from '@girder/core/rest';
 import BrowserWidget from '@girder/core/views/widgets/BrowserWidget';
 import PluginConfigBreadcrumbWidget from '@girder/core/views/widgets/PluginConfigBreadcrumbWidget';
 
@@ -79,7 +79,7 @@ var ConfigView = View.extend({
             helpText: 'Browse to a location to select it.',
             submitText: 'Select Location',
             validate: function (model) {
-                let isValid = $.Deferred();
+                const isValid = $.Deferred();
                 if (!model || model.get('_modelType') !== 'folder') {
                     isValid.reject('Please select a folder.');
                 } else {
@@ -93,7 +93,7 @@ var ConfigView = View.extend({
             restRequest({
                 url: `resource/${val.id}/path`,
                 method: 'GET',
-                data: { type: val.get('_modelType') }
+                data: {type: val.get('_modelType')}
             }).done((result) => {
                 // Only add the resource path if the value wasn't altered
                 if (this.$('#g-large-image-config-folder').val() === val.id) {
@@ -192,7 +192,7 @@ var ConfigView = View.extend({
             }).done((resp) => {
                 resp.extraInfo = {};
                 resp.extraItemInfo = {};
-                let extraList = [{
+                const extraList = [{
                     access: null,
                     extraInfo: 'large_image.show_extra_public',
                     extraItemInfo: 'large_image.show_item_extra_public'

--- a/girder/girder_large_image/web_client/views/fileList.js
+++ b/girder/girder_large_image/web_client/views/fileList.js
@@ -1,11 +1,11 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import { restRequest } from '@girder/core/rest';
+import {restRequest} from '@girder/core/rest';
 import events from '@girder/core/events';
 import FileListWidget from '@girder/core/views/widgets/FileListWidget';
-import { wrap } from '@girder/core/utilities/PluginUtils';
-import { AccessType } from '@girder/core/constants';
+import {wrap} from '@girder/core/utilities/PluginUtils';
+import {AccessType} from '@girder/core/constants';
 
 import largeImageFileAction from '../templates/largeImage_fileAction.pug';
 import '../stylesheets/fileList.styl';
@@ -26,8 +26,7 @@ wrap(FileListWidget, 'render', function (render) {
         if (!actions.length) {
             return;
         }
-        var fileAction = largeImageFileAction({
-            file: file, largeImage: largeImage});
+        var fileAction = largeImageFileAction({file: file, largeImage: largeImage});
         if (fileAction) {
             actions.prepend(fileAction);
             if (actions.has('.g-large-image-remove').length) {

--- a/girder/girder_large_image/web_client/views/imageViewerSelectWidget.js
+++ b/girder/girder_large_image/web_client/views/imageViewerSelectWidget.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import { wrap } from '@girder/core/utilities/PluginUtils';
+import {wrap} from '@girder/core/utilities/PluginUtils';
 import eventStream from '@girder/core/utilities/EventStream';
 import ItemView from '@girder/core/views/body/ItemView';
 import View from '@girder/core/views/View';

--- a/girder/girder_large_image/web_client/views/imageViewerWidget/base.js
+++ b/girder/girder_large_image/web_client/views/imageViewerWidget/base.js
@@ -1,12 +1,12 @@
 import $ from 'jquery';
 
-import { getApiRoot, restRequest } from '@girder/core/rest';
+import {getApiRoot, restRequest} from '@girder/core/rest';
 import View from '@girder/core/views/View';
 
 var ImageViewerWidget = View.extend({
     initialize: function (settings) {
         this.itemId = settings.itemId;
-        let item = (settings.model || {}).attributes || {};
+        const item = (settings.model || {}).attributes || {};
         this.updated = item.updated || item.created;
         if (this.updated) {
             this.updated = this.updated.replace(/:/g, '-').replace(/\+/g, '_');

--- a/girder/girder_large_image/web_client/views/imageViewerWidget/geojs.js
+++ b/girder/girder_large_image/web_client/views/imageViewerWidget/geojs.js
@@ -6,7 +6,7 @@ import _ from 'underscore';
 import Hammer from 'hammerjs';
 import d3 from 'd3';
 
-import { restRequest } from '@girder/core/rest';
+import {restRequest} from '@girder/core/rest';
 
 import ImageViewerWidget from './base';
 import setFrameQuad from './setFrameQuad.js';
@@ -97,7 +97,7 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
             params = {
                 keepLower: false,
                 attribution: null,
-                url: this._getTileUrl('{z}', '{x}', '{y}', {'encoding': 'PNG', 'projection': 'EPSG:3857'}),
+                url: this._getTileUrl('{z}', '{x}', '{y}', {encoding: 'PNG', projection: 'EPSG:3857'}),
                 useCredentials: true,
                 maxLevel: this.levels - 1
             };
@@ -152,7 +152,7 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
             }
             this._frame = 0;
             this._baseurl = this._layer.url();
-            let quadLoaded = ((this._layer.setFrameQuad || {}).status || {}).loaded;
+            const quadLoaded = ((this._layer.setFrameQuad || {}).status || {}).loaded;
             if (!quadLoaded) {
                 // use two layers to get smooth transitions until we load
                 // background quads.
@@ -166,7 +166,7 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
         if (frame !== this._frame && !this._updating) {
             this._frame = frame;
             this.trigger('g:imageFrameChanging', this, frame);
-            let quadLoaded = ((this._layer.setFrameQuad || {}).status || {}).loaded;
+            const quadLoaded = ((this._layer.setFrameQuad || {}).status || {}).loaded;
             if (quadLoaded) {
                 if (this._layer2) {
                     this.viewer.deleteLayer(this._layer2);

--- a/girder/girder_large_image/web_client/views/imageViewerWidget/openlayers.js
+++ b/girder/girder_large_image/web_client/views/imageViewerWidget/openlayers.js
@@ -1,6 +1,6 @@
 import $ from 'jquery';
 
-import { restRequest } from '@girder/core/rest';
+import {restRequest} from '@girder/core/rest';
 
 import ImageViewerWidget from './base';
 
@@ -87,7 +87,7 @@ var OpenlayersImageViewerWidget = ImageViewerWidget.extend({
                     new ol.layer.Tile({
                         source: new ol.source.XYZ({
                             tileSize: [this.tileWidth, this.tileHeight],
-                            url: this._getTileUrl('{z}', '{x}', '{y}', {'encoding': 'PNG', 'projection': 'EPSG:3857'}),
+                            url: this._getTileUrl('{z}', '{x}', '{y}', {encoding: 'PNG', projection: 'EPSG:3857'}),
                             crossOrigin: 'use-credentials',
                             maxZoom: this.levels - 1,
                             wrapX: true

--- a/girder/girder_large_image/web_client/views/imageViewerWidget/setFrameQuad.js
+++ b/girder/girder_large_image/web_client/views/imageViewerWidget/setFrameQuad.js
@@ -81,7 +81,7 @@ function setFrameQuad(tileinfo, layer, options) {
         framesToIdx: {},
         loadedCount: 0
     };
-    let qiOptions = Object.assign({}, options);
+    const qiOptions = Object.assign({}, options);
     ['restRequest', 'restUrl', 'baseUrl', 'crossOrigin', 'progress', 'redrawOnFirstLoad'].forEach((k) => delete qiOptions[k]);
     options.restRequest({
         type: 'GET',
@@ -101,8 +101,8 @@ function setFrameQuad(tileinfo, layer, options) {
             if (options.baseUrl.indexOf(':') >= 0 && options.baseUrl.indexOf('/') === options.baseUrl.indexOf(':') + 1) {
                 img.crossOrigin = options.crossOrigin || 'anonymous';
             }
-            let params = Object.keys(data.src[idx]).map((k) => encodeURIComponent(k) + '=' + encodeURIComponent(data.src[idx][k])).join('&');
-            let src = `${options.baseUrl}/tile_frames?` + params;
+            const params = Object.keys(data.src[idx]).map((k) => encodeURIComponent(k) + '=' + encodeURIComponent(data.src[idx][k])).join('&');
+            const src = `${options.baseUrl}/tile_frames?` + params;
             status.src.push(src);
             if (idx === data.src.length - 1) {
                 img.onload = function () {

--- a/girder/girder_large_image/web_client/views/imageViewerWidget/slideatlas.js
+++ b/girder/girder_large_image/web_client/views/imageViewerWidget/slideatlas.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 
 import Backbone from 'backbone';
-import { parseQueryString, splitRoute } from '@girder/core/misc';
+import {parseQueryString, splitRoute} from '@girder/core/misc';
 
 import ImageViewerWidget from './base';
 
@@ -95,7 +95,7 @@ var SlideAtlasImageViewerWidget = ImageViewerWidget.extend({
         this.girderGui = new window.SAM.LayerPanel(this.viewer, this.itemId);
         $(this.el).css({position: 'relative'});
         window.SA.SAFullScreenButton($(this.el))
-            .css({'position': 'absolute', 'left': '2px', 'top': '2px'});
+            .css({position: 'absolute', left: '2px', top: '2px'});
         window.SA.GirderView = this;
 
         // Set the view from the URL if bounds are specified.

--- a/girder/girder_large_image/web_client/views/itemList.js
+++ b/girder/girder_large_image/web_client/views/itemList.js
@@ -2,17 +2,17 @@ import $ from 'jquery';
 import _ from 'underscore';
 import Backbone from 'backbone';
 
-import { wrap } from '@girder/core/utilities/PluginUtils';
-import { getApiRoot, restRequest } from '@girder/core/rest';
-import { getCurrentUser } from '@girder/core/auth';
-import { AccessType } from '@girder/core/constants';
-import { formatSize, parseQueryString, splitRoute } from '@girder/core/misc';
+import {wrap} from '@girder/core/utilities/PluginUtils';
+import {getApiRoot, restRequest} from '@girder/core/rest';
+import {getCurrentUser} from '@girder/core/auth';
+import {AccessType} from '@girder/core/constants';
+import {formatSize, parseQueryString, splitRoute} from '@girder/core/misc';
 import HierarchyWidget from '@girder/core/views/widgets/HierarchyWidget';
 import FolderListWidget from '@girder/core/views/widgets/FolderListWidget';
 import ItemListWidget from '@girder/core/views/widgets/ItemListWidget';
 
 import largeImageConfig from './configView';
-import { addToRoute } from '../routes';
+import {addToRoute} from '../routes';
 
 import '../stylesheets/itemList.styl';
 import ItemListTemplate from '../templates/itemList.pug';
@@ -46,7 +46,7 @@ wrap(FolderListWidget, 'checkAll', function (checkAll, checked) {
 });
 
 wrap(ItemListWidget, 'initialize', function (initialize, settings) {
-    let result = initialize.call(this, settings);
+    const result = initialize.call(this, settings);
     delete this._hasAnyLargeImage;
 
     if (!settings.folderId) {
@@ -140,7 +140,7 @@ wrap(ItemListWidget, 'render', function (render) {
         var access = item.getAccessLevel();
         var extra = extraInfo[access] || extraInfo[AccessType.READ] || {};
         if (!getCurrentUser()) {
-            extra = extraInfo[null] || {};
+            extra = extraInfo.null || {};
         }
 
         /* Set the maximum number of columns we have so that we can let css
@@ -220,7 +220,7 @@ wrap(ItemListWidget, 'render', function (render) {
     };
 
     this._setFilter = () => {
-        let val = this._generalFilter;
+        const val = this._generalFilter;
         let filter;
         const usedPhrases = {};
         const columns = (this._confList() || {}).columns || [];
@@ -234,14 +234,14 @@ wrap(ItemListWidget, 'render', function (render) {
                 if (phrase[0] === phrase.substr(phrase.length - 1) && ['"', "'"].includes(phrase[0])) {
                     phrase = phrase.substr(1, phrase.length - 2);
                 }
-                let numval = +phrase;
+                const numval = +phrase;
                 /* If numval is a non-zero number not in exponential notation.
                  * delta is the value of one for the least significant digit.
                  * This will be NaN if phrase is not a number. */
-                let delta = Math.abs(+numval.toString().replace(/\d(?=.*[1-9](0*\.|)0*$)/g, '0').replace(/[1-9]/, '1'));
+                const delta = Math.abs(+numval.toString().replace(/\d(?=.*[1-9](0*\.|)0*$)/g, '0').replace(/[1-9]/, '1'));
                 // escape for regex
                 phrase = phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                let clause = [];
+                const clause = [];
                 columns.forEach((col) => {
                     let key;
 
@@ -251,18 +251,18 @@ wrap(ItemListWidget, 'render', function (render) {
                         key = 'meta.' + col.value;
                     }
                     if (key) {
-                        clause.push({[key]: {'$regex': phrase, '$options': 'i'}});
+                        clause.push({[key]: {$regex: phrase, $options: 'i'}});
                         if (!_.isNaN(numval)) {
-                            clause.push({[key]: {'$eq': numval}});
+                            clause.push({[key]: {$eq: numval}});
                             if (numval > 0 && delta) {
-                                clause.push({[key]: {'$gte': numval, '$lt': numval + delta}});
+                                clause.push({[key]: {$gte: numval, $lt: numval + delta}});
                             } else if (numval < 0 && delta) {
-                                clause.push({[key]: {'$lte': numval, '$gt': numval + delta}});
+                                clause.push({[key]: {$lte: numval, $gt: numval + delta}});
                             }
                         }
                     }
                 });
-                filter.push({'$or': clause});
+                filter.push({$or: clause});
             });
             if (filter.length === 0) {
                 filter = undefined;
@@ -270,7 +270,7 @@ wrap(ItemListWidget, 'render', function (render) {
                 if (filter.length === 1) {
                     filter = filter[0];
                 } else {
-                    filter = {'$and': filter};
+                    filter = {$and: filter};
                 }
                 filter = '_filter_:' + JSON.stringify(filter);
             }
@@ -287,7 +287,7 @@ wrap(ItemListWidget, 'render', function (render) {
     };
 
     function itemListRender() {
-        let root = this.$el.closest('.g-hierarchy-widget');
+        const root = this.$el.closest('.g-hierarchy-widget');
         if (!root.find('.li-item-list-filter').length) {
             let base = root.find('.g-hierarchy-actions-header .g-folder-header-buttons').eq(0);
             let func = 'after';
@@ -395,7 +395,7 @@ wrap(ItemListWidget, 'render', function (render) {
 });
 
 wrap(ItemListWidget, 'remove', function (remove) {
-    let root = this.$el.closest('.g-hierarchy-widget');
+    const root = this.$el.closest('.g-hierarchy-widget');
     root.remove('.li-item-list-filter');
     delete this.parentView.events['change .li-item-list-filter-input'];
     delete this.parentView.events['input .li-item-list-filter-input'];

--- a/girder/girder_large_image/web_client/views/itemView.js
+++ b/girder/girder_large_image/web_client/views/itemView.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
-import { AccessType } from '@girder/core/constants';
-import { restRequest } from '@girder/core/rest';
-import { wrap } from '@girder/core/utilities/PluginUtils';
+import {AccessType} from '@girder/core/constants';
+import {restRequest} from '@girder/core/rest';
+import {wrap} from '@girder/core/utilities/PluginUtils';
 import ItemView from '@girder/core/views/body/ItemView';
 
 import largeImageConfig from './configView';

--- a/girder/girder_large_image/web_client/views/itemViewCodemirror.js
+++ b/girder/girder_large_image/web_client/views/itemViewCodemirror.js
@@ -1,10 +1,10 @@
 import $ from 'jquery';
-import { getCurrentUser } from '@girder/core/auth';
-import { AccessType } from '@girder/core/constants';
-import { confirm } from '@girder/core/dialog';
+import {getCurrentUser} from '@girder/core/auth';
+import {AccessType} from '@girder/core/constants';
+import {confirm} from '@girder/core/dialog';
 import events from '@girder/core/events';
-import { restRequest } from '@girder/core/rest';
-import { wrap } from '@girder/core/utilities/PluginUtils';
+import {restRequest} from '@girder/core/rest';
+import {wrap} from '@girder/core/utilities/PluginUtils';
 import ItemView from '@girder/core/views/body/ItemView';
 import View from '@girder/core/views/View';
 
@@ -116,7 +116,7 @@ const Formats = {
         accessLevel: AccessType.ADMIN,
         adminOnly: true,
         validator: (val) => {
-            let promise = $.Deferred();
+            const promise = $.Deferred();
             restRequest({
                 method: 'POST',
                 url: 'large_image/config/validate',
@@ -136,7 +136,7 @@ const Formats = {
             return promise;
         },
         format: (val) => {
-            let promise = $.Deferred();
+            const promise = $.Deferred();
             restRequest({
                 method: 'POST',
                 url: 'large_image/config/format',
@@ -224,7 +224,7 @@ var CodemirrorEditWidget = View.extend({
             return;
         }
         this._informat = true;
-        let content = this.code.getValue();
+        const content = this.code.getValue();
         try {
             $.when(Formats[this.mimeType].validator(content)).done((validated) => {
                 try {

--- a/girder/girder_large_image/web_client/views/itemViewWidget.js
+++ b/girder/girder_large_image/web_client/views/itemViewWidget.js
@@ -1,5 +1,5 @@
 import yaml from 'js-yaml';
-import { getApiRoot } from '@girder/core/rest';
+import {getApiRoot} from '@girder/core/rest';
 import View from '@girder/core/views/View';
 
 import itemViewWidgetTemplate from '../templates/itemView.pug';

--- a/girder_annotation/girder_large_image_annotation/web_client/annotations/convert.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/annotations/convert.js
@@ -18,7 +18,7 @@ function convertOne(properties) {
         return {
             type: 'Feature',
             id: annotation.id,
-            geometry: { type: geom.type, coordinates: geom.coordinates },
+            geometry: {type: geom.type, coordinates: geom.coordinates},
             properties: _.extend({element: annotation, annotationType: geom.annotationType}, properties, style(annotation))
         };
     };

--- a/girder_annotation/girder_large_image_annotation/web_client/annotations/convertFeatures.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/annotations/convertFeatures.js
@@ -13,14 +13,14 @@ function heatmapColorTable(record, values) {
     let range1 = 1;
     let min = 0;
     let max = null;
-    let color = {
+    const color = {
         0: {r: 0, g: 0, b: 0, a: 0},
         1: {r: 1, g: 1, b: 0, a: 1}
     };
     if (record.colorRange && record.rangeValues) {
         if (record.normalizeRange || !values.length) {
             for (let i = 0; i < record.colorRange.length && i < record.rangeValues.length; i += 1) {
-                let val = Math.max(0, Math.min(1, record.rangeValues[i]));
+                const val = Math.max(0, Math.min(1, record.rangeValues[i]));
                 color[val] = record.colorRange[i];
                 if (val >= 1) {
                     break;
@@ -29,7 +29,7 @@ function heatmapColorTable(record, values) {
         } else if (record.colorRange.length >= 2 && record.rangeValues.length >= 2) {
             range0 = range1 = record.rangeValues[0] || 0;
             for (let i = 1; i < record.rangeValues.length; i += 1) {
-                let val = record.rangeValues[i] || 0;
+                const val = record.rangeValues[i] || 0;
                 if (val < range0) {
                     range0 = val;
                 }
@@ -125,7 +125,8 @@ function convertGridToHeatmap(record, properties, layer) {
         position: (d, i) => ({
             x: x0 + dx * (i % record.gridWidth),
             y: y0 + dy * Math.floor(i / record.gridWidth),
-            z: z}),
+            z: z
+        }),
         intensity: (d) => d || 0,
         minIntensity: colorTable.min,
         maxIntensity: colorTable.max,

--- a/girder_annotation/girder_large_image_annotation/web_client/annotations/geometry/polyline.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/annotations/geometry/polyline.js
@@ -11,7 +11,7 @@ export default function polyline(json) {
         coordinates = [points];
         if (json.holes) {
             const holes = (json.holes || []).map((hole) => {
-                let result = hole.map((p) => _.first(p, 2));
+                const result = hole.map((p) => _.first(p, 2));
                 result.push(result[0]);
                 return result;
             });

--- a/girder_annotation/girder_large_image_annotation/web_client/collections/AnnotationCollection.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/collections/AnnotationCollection.js
@@ -1,5 +1,5 @@
 import Collection from '@girder/core/collections/Collection';
-import { SORT_DESC } from '@girder/core/constants';
+import {SORT_DESC} from '@girder/core/constants';
 
 import AnnotationModel from '../models/AnnotationModel';
 

--- a/girder_annotation/girder_large_image_annotation/web_client/main.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/main.js
@@ -1,4 +1,4 @@
-import { registerPluginNamespace } from '@girder/core/pluginUtils';
+import {registerPluginNamespace} from '@girder/core/pluginUtils';
 import SearchFieldWidget from '@girder/core/views/widgets/SearchFieldWidget';
 
 // import modules for side effects

--- a/girder_annotation/girder_large_image_annotation/web_client/models/AnnotationModel.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/models/AnnotationModel.js
@@ -1,11 +1,11 @@
 import _ from 'underscore';
 import AccessControlledModel from '@girder/core/models/AccessControlledModel';
-import { restRequest } from '@girder/core/rest';
+import {restRequest} from '@girder/core/rest';
 import MetadataMixin from '@girder/core/models/MetadataMixin';
 
 import ElementCollection from '../collections/ElementCollection';
 import convert from '../annotations/convert';
-import { convertFeatures } from '../annotations/convertFeatures';
+import {convertFeatures} from '../annotations/convertFeatures';
 
 import style from '../annotations/style.js';
 
@@ -21,7 +21,7 @@ import style from '../annotations/style.js';
  * and updates its own attribute in response.  Users
  * should not modify the "elements" attribute directly.
  */
-let AnnotationModel = AccessControlledModel.extend({
+const AnnotationModel = AccessControlledModel.extend({
     resourceName: 'annotation',
 
     defaults: {
@@ -85,11 +85,11 @@ let AnnotationModel = AccessControlledModel.extend({
             if (z0 >= z1) {
                 throw new Error('invalid centroid data');
             }
-            let json = new Uint8Array(z0 + dv.byteLength - z1 - 1);
+            const json = new Uint8Array(z0 + dv.byteLength - z1 - 1);
             json.set(new Uint8Array(resp.slice(0, z0)), 0);
             json.set(new Uint8Array(resp.slice(z1 + 1)), z0);
-            let result = JSON.parse(decodeURIComponent(escape(String.fromCharCode.apply(null, json))));
-            let defaults = {
+            const result = JSON.parse(decodeURIComponent(escape(String.fromCharCode.apply(null, json))));
+            const defaults = {
                 default: {
                     fillColor: {r: 1, g: 120 / 255, b: 0},
                     fillOpacity: 0.8,
@@ -124,12 +124,12 @@ let AnnotationModel = AccessControlledModel.extend({
                 }
             };
             result.props = result._elementQuery.props.map((props) => {
-                let propsdict = {};
+                const propsdict = {};
                 result._elementQuery.propskeys.forEach((key, i) => {
                     propsdict[key] = props[i];
                 });
                 Object.assign(propsdict, style(propsdict));
-                let type = propsdict.type + (propsdict.closed ? '_closed' : '');
+                const type = propsdict.type + (propsdict.closed ? '_closed' : '');
                 ['fillColor', 'strokeColor', 'strokeWidth', 'fillOpacity', 'strokeOpacity'].forEach((key) => {
                     if (propsdict[key] === undefined) {
                         propsdict[key] = (defaults[type] || defaults.default)[key];
@@ -144,7 +144,7 @@ let AnnotationModel = AccessControlledModel.extend({
             if (dv.byteLength !== result._elementQuery.returned * 28) {
                 throw new Error('invalid centroid data size');
             }
-            let centroids = {
+            const centroids = {
                 id: new Array(result._elementQuery.returned),
                 x: new Float32Array(result._elementQuery.returned),
                 y: new Float32Array(result._elementQuery.returned),
@@ -282,7 +282,7 @@ let AnnotationModel = AccessControlledModel.extend({
         const data = _.extend({}, this.get('annotation'));
         let url;
         let method;
-        let isNew = this.isNew();
+        const isNew = this.isNew();
 
         if (isNew) {
             if (!this.get('itemId')) {

--- a/girder_annotation/girder_large_image_annotation/web_client/package.json
+++ b/girder_annotation/girder_large_image_annotation/web_client/package.json
@@ -37,11 +37,15 @@
             ],
             "no-alert": "error",
             "switch-colon-spacing": "error",
-            "object-curly-spacing": "off",
+            "object-curly-spacing": [
+                "error",
+                "never"
+            ],
             "import/exports-last": "error",
             "promise/no-native": "error",
             "promise/no-return-in-finally": "error",
-            "promise/no-return-wrap": "error"
+            "promise/no-return-wrap": "error",
+            "no-import-assign": "off"
         },
         "root": true
     },
@@ -166,19 +170,19 @@
     },
     "devDependencies": {
         "@girder/eslint-config": "^3.0.0-rc1",
-        "eslint": "^5.16.0",
-        "eslint-config-semistandard": "^13.0.0",
-        "eslint-config-standard": "^12.0.0",
+        "eslint": "^8.20.0",
+        "eslint-config-semistandard": "^17.0.0",
+        "eslint-config-standard": "^17.0.0",
         "eslint-plugin-backbone": "^2.1.1",
-        "eslint-plugin-import": "^2.17.3",
-        "eslint-plugin-node": "^9.1.0",
-        "eslint-plugin-promise": "^4.1.1",
-        "eslint-plugin-standard": "^4.0.0",
+        "eslint-plugin-import": "^2.25.3",
+        "eslint-plugin-n": "^15.2.4",
+        "eslint-plugin-promise": "^6.0.0",
         "@girder/pug-lint-config": "^3.0.0-rc1",
         "pug-lint": "^2.6.0",
-        "stylint": "^1.5.9"
+        "stylint": "^2"
     },
     "scripts": {
-        "lint": "eslint --cache . && pug-lint . && stylint"
+        "lint": "eslint --cache . && pug-lint . && stylint",
+        "format": "eslint --cache --fix ."
     }
 }

--- a/girder_annotation/girder_large_image_annotation/web_client/routes.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/routes.js
@@ -1,6 +1,6 @@
 import events from '@girder/core/events';
 import router from '@girder/core/router';
-import { exposePluginConfig } from '@girder/core/utilities/PluginUtils';
+import {exposePluginConfig} from '@girder/core/utilities/PluginUtils';
 
 import ConfigView from './views/configView';
 

--- a/girder_annotation/girder_large_image_annotation/web_client/views/annotationListWidget.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/annotationListWidget.js
@@ -1,11 +1,11 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import { AccessType } from '@girder/core/constants';
+import {AccessType} from '@girder/core/constants';
 import eventStream from '@girder/core/utilities/EventStream';
-import { getCurrentUser } from '@girder/core/auth';
-import { confirm } from '@girder/core/dialog';
-import { getApiRoot, restRequest } from '@girder/core/rest';
+import {getCurrentUser} from '@girder/core/auth';
+import {confirm} from '@girder/core/dialog';
+import {getApiRoot, restRequest} from '@girder/core/rest';
 import AccessWidget from '@girder/core/views/widgets/AccessWidget';
 import events from '@girder/core/events';
 import UserCollection from '@girder/core/collections/UserCollection';
@@ -39,8 +39,8 @@ const AnnotationListWidget = View.extend({
         this._drawn = new Set();
         this._viewer = null;
         this._sort = {
-            'field': 'name',
-            'direction': 1
+            field: 'name',
+            direction: 1
         };
 
         this.collection = this.collection || new AnnotationCollection([], {comparator: null});
@@ -223,12 +223,14 @@ const AnnotationListWidget = View.extend({
             parentType: 'item',
             parentView: this,
             multiFile: true,
-            otherParams: {reference: JSON.stringify({
-                identifier: 'LargeImageAnnotationUpload',
-                itemId: this.model.id,
-                fileId: this.model.get('largeImage') && this.model.get('largeImage').fileId,
-                userId: (getCurrentUser() || {}).id
-            })}
+            otherParams: {
+                reference: JSON.stringify({
+                    identifier: 'LargeImageAnnotationUpload',
+                    itemId: this.model.id,
+                    fileId: this.model.get('largeImage') && this.model.get('largeImage').fileId,
+                    userId: (getCurrentUser() || {}).id
+                })
+            }
         }).on('g:uploadFinished', () => {
             events.trigger('g:alert', {
                 icon: 'ok',
@@ -281,8 +283,8 @@ const AnnotationListWidget = View.extend({
 
     _fetchUsers() {
         this.collection.each((model) => {
-            this.users.add({'_id': model.get('creatorId')});
-            this.users.add({'_id': model.get('updatedId')});
+            this.users.add({_id: model.get('creatorId')});
+            this.users.add({_id: model.get('updatedId')});
         });
         $.when.apply($, this.users.map((model) => {
             return model.fetch();

--- a/girder_annotation/girder_large_image_annotation/web_client/views/configView.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/configView.js
@@ -1,7 +1,7 @@
 import View from '@girder/core/views/View';
 
 import PluginConfigBreadcrumbWidget from '@girder/core/views/widgets/PluginConfigBreadcrumbWidget';
-import { restRequest } from '@girder/core/rest';
+import {restRequest} from '@girder/core/rest';
 import events from '@girder/core/events';
 import largeImageConfig from '@girder/large_image/views/configView';
 

--- a/girder_annotation/girder_large_image_annotation/web_client/views/hierarchyWidget.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/hierarchyWidget.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 
-import { wrap } from '@girder/core/utilities/PluginUtils';
-import { restRequest } from '@girder/core/rest';
+import {wrap} from '@girder/core/utilities/PluginUtils';
+import {restRequest} from '@girder/core/rest';
 import AccessWidget from '@girder/core/views/widgets/AccessWidget';
 import HierarchyWidget from '@girder/core/views/widgets/HierarchyWidget';
 

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerSelectWidget.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerSelectWidget.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 
-import { wrap } from '@girder/core/utilities/PluginUtils';
+import {wrap} from '@girder/core/utilities/PluginUtils';
 
 import ImageViewerSelectWidget from '@girder/large_image/views/imageViewerSelectWidget';
 

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -3,8 +3,8 @@ import _ from 'underscore';
 import Backbone from 'backbone';
 
 import events from '@girder/core/events';
-import { wrap } from '@girder/core/utilities/PluginUtils';
-import { restRequest } from '@girder/core/rest';
+import {wrap} from '@girder/core/utilities/PluginUtils';
+import {restRequest} from '@girder/core/rest';
 
 import convertAnnotation from '../../annotations/geojs/convert';
 
@@ -137,7 +137,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             const s21 = matrix[1][0];
             const s22 = matrix[1][1];
 
-            let scale = Math.sqrt(Math.abs(s11 * s22 - s12 * s21)) || 1;
+            const scale = Math.sqrt(Math.abs(s11 * s22 - s12 * s21)) || 1;
             return Math.floor(Math.log2(scale));
         },
 
@@ -148,7 +148,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
         _countDrawnImageOverlays: function () {
             let numOverlays = 0;
             _.each(this._annotations, (value, key, obj) => {
-                let annotationOverlays = value.overlays || [];
+                const annotationOverlays = value.overlays || [];
                 numOverlays += annotationOverlays.length;
             });
             return numOverlays;
@@ -172,7 +172,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             }
             let pixelmapData = pixelmapElement.values;
             if (pixelmapElement.boundaries) {
-                let valuesWithBoundaries = new Array(pixelmapData.length * 2);
+                const valuesWithBoundaries = new Array(pixelmapData.length * 2);
                 for (let i = 0; i < pixelmapData.length; i++) {
                     valuesWithBoundaries[i * 2] = valuesWithBoundaries[i * 2 + 1] = pixelmapData[i];
                 }
@@ -188,7 +188,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                         return 'rgba(0, 0, 0, 0)';
                     }
                     let color;
-                    let category = categoryMap[d];
+                    const category = categoryMap[d];
                     if (boundaries) {
                         color = (i % 2 === 0) ? category.fillColor : category.strokeColor;
                     } else {
@@ -209,7 +209,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
          */
         _generateOverlayLayerParams(overlayImageMetadata, overlayImageId, overlay) {
             const geo = window.geo;
-            let params = geo.util.pixelCoordinateParams(
+            const params = geo.util.pixelCoordinateParams(
                 this.viewer.node(), overlayImageMetadata.sizeX, overlayImageMetadata.sizeY, overlayImageMetadata.tileWidth, overlayImageMetadata.tileHeight
             );
             params.layer.useCredentials = true;
@@ -336,7 +336,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             var featureList = this._annotations[annotation.id].features;
             // draw centroids except for otherwise shown values
             if (annotation._centroids && !centroidFeature) {
-                let feature = this.featureLayer.createFeature('point');
+                const feature = this.featureLayer.createFeature('point');
                 featureList.push(feature);
                 feature.data(annotation._centroids.data).position((d, i) => ({
                     x: annotation._centroids.centroids.x[i],
@@ -357,26 +357,26 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                         return !annotation._shownIds || !annotation._shownIds.has(annotation._centroids.centroids.id[i]);
                     },
                     strokeColor: (d, i) => {
-                        let s = annotation._centroids.centroids.s[i];
+                        const s = annotation._centroids.centroids.s[i];
                         return annotation._centroids.props[s].strokeColor;
                     },
                     strokeOpacity: (d, i) => {
-                        let s = annotation._centroids.centroids.s[i];
+                        const s = annotation._centroids.centroids.s[i];
                         return annotation._centroids.props[s].strokeOpacity;
                     },
                     strokeWidth: (d, i) => {
-                        let s = annotation._centroids.centroids.s[i];
+                        const s = annotation._centroids.centroids.s[i];
                         return annotation._centroids.props[s].strokeWidth;
                     },
                     fill: (d, i) => {
                         return !annotation._shownIds || !annotation._shownIds.has(annotation._centroids.centroids.id[i]);
                     },
                     fillColor: (d, i) => {
-                        let s = annotation._centroids.centroids.s[i];
+                        const s = annotation._centroids.centroids.s[i];
                         return annotation._centroids.props[s].fillColor;
                     },
                     fillOpacity: (d, i) => {
-                        let s = annotation._centroids.centroids.s[i];
+                        const s = annotation._centroids.centroids.s[i];
                         return annotation._centroids.props[s].fillOpacity;
                     }
                 });
@@ -386,8 +386,8 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                     if (this.viewer.zoom() !== annotation._centroidLastZoom) {
                         annotation._centroidLastZoom = this.viewer.zoom();
                         if (feature.verticesPerFeature) {
-                            let scale = 2.5 * this.viewer.unitsPerPixel(this.viewer.zoom());
-                            let vpf = feature.verticesPerFeature(),
+                            const scale = 2.5 * this.viewer.unitsPerPixel(this.viewer.zoom());
+                            const vpf = feature.verticesPerFeature(),
                                 count = feature.data().length,
                                 radius = new Float32Array(vpf * count);
                             for (var i = 0, j = 0; i < count; i += 1) {
@@ -496,11 +496,11 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                     if (annotation._centroids && featureList[0]) {
                         if (featureList[0].verticesPerFeature) {
                             this.viewer.scheduleAnimationFrame(() => {
-                                let vpf = featureList[0].verticesPerFeature(),
+                                const vpf = featureList[0].verticesPerFeature(),
                                     count = featureList[0].data().length,
                                     shown = new Float32Array(vpf * count);
                                 for (let i = 0, j = 0; i < count; i += 1) {
-                                    let val = annotation._shownIds.has(annotation._centroids.centroids.id[i]) ? 0 : 1;
+                                    const val = annotation._shownIds.has(annotation._centroids.centroids.id[i]) ? 0 : 1;
                                     for (let k = 0; k < vpf; k += 1, j += 1) {
                                         shown[j] = val;
                                     }

--- a/girder_annotation/girder_large_image_annotation/web_client/views/itemList.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/itemList.js
@@ -1,8 +1,8 @@
 import $ from 'jquery';
 import _ from 'underscore';
 
-import { restRequest } from '@girder/core/rest';
-import { wrap } from '@girder/core/utilities/PluginUtils';
+import {restRequest} from '@girder/core/rest';
+import {wrap} from '@girder/core/utilities/PluginUtils';
 import ItemListWidget from '@girder/core/views/widgets/ItemListWidget';
 
 import largeImageAnnotationConfig from './configView';
@@ -56,7 +56,7 @@ wrap(ItemListWidget, 'render', function (render) {
                 data: {
                     items: needCounts.join(',')
                 },
-                headers: { 'X-HTTP-Method-Override': 'GET' },
+                headers: {'X-HTTP-Method-Override': 'GET'},
                 error: null
             }).done((resp) => {
                 Object.entries(resp).forEach(([id, count]) => {

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANG=en_US.UTF-8 \
     PYENV_ROOT="/.pyenv" \
     PATH="/.pyenv/bin:/.pyenv/shims:$PATH" \
-    PYTHON_VERSIONS="3.9.16 3.8.16 3.7.16 3.6.15 3.10.9 3.11.1"
+    PYTHON_VERSIONS="3.9.16 3.8.16 3.7.16 3.6.15 3.10.10 3.11.2"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist =
   docs
   flake8
   lintclient
-  lintannotationclient
 skip_missing_interpreters = true
 toxworkdir = {toxinidir}/build/tox
 
@@ -121,7 +120,7 @@ deps =
 commands = flake8 {posargs}
 
 [testenv:format]
-description = Autoformat import order
+description = Autoformat import order and autopep8
 skipsdist = true
 skip_install = true
 deps =
@@ -135,23 +134,25 @@ commands =
 description = Lint the girder large_image plugin client
 skip_install = true
 deps =
-changedir = {toxinidir}/girder/girder_large_image/web_client
 allowlist_externals =
   npm
 commands =
-  npm install --no-package-lock
-  npm run lint
+  npm --prefix {toxinidir}/girder/girder_large_image/web_client install --no-package-lock
+  npm --prefix {toxinidir}/girder_annotation/girder_large_image_annotation/web_client install --no-package-lock
+  npm --prefix {toxinidir}/girder/girder_large_image/web_client run lint
+  npm --prefix {toxinidir}/girder_annotation/girder_large_image_annotation/web_client run lint
 
-[testenv:lintannotationclient]
-description = Lint the girder large_image_annotation plugin client
+[testenv:formatclient]
+description = Autoformat client
 skip_install = true
 deps =
-changedir = {toxinidir}/girder_annotation/girder_large_image_annotation/web_client
 allowlist_externals =
   npm
 commands =
-  npm install --no-package-lock
-  npm run lint
+  npm --prefix {toxinidir}/girder/girder_large_image/web_client install --no-package-lock
+  npm --prefix {toxinidir}/girder_annotation/girder_large_image_annotation/web_client install --no-package-lock
+  npm --prefix {toxinidir}/girder/girder_large_image/web_client run format
+  npm --prefix {toxinidir}/girder_annotation/girder_large_image_annotation/web_client run format
 
 # You can use "tox devenv -e dev <venv path>" to create a development
 # environment.  This will only work on python base versions that support all


### PR DESCRIPTION
Before, tox -e lintclient,lintannotationclient checked linting, but there was no easy way to fix issues.  This simplifies the linting by combining the two command into one (lintclient) and adds formatclient (e.g., tox -e formatclient) to format the javascript (the linting checks stylus and pug, but neither of those current have an autoformatter).

This also updates the linting rules for object-curly-spacing for greater consistency.

Running the auto formatting with the newer package versions has resulted in some spacing changes and a number of let to const conversions.