### PR TITLE
Tile serving can bypass loading a source if it is in memory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Improvements
 - Better cache handling with Etags ([#1097](../../pull/1097))
-- Reduce duplicate computation of slow cached values  ([#1100](../../pull/1100))
+- Reduce duplicate computation of slow cached values ([#1100](../../pull/1100))
+
+### Bug Fixes
+- Tile serving can bypass loading a source if it is in memory ([#1102](../../pull/1102))
 
 ### Changes
 - On the large image item page, guard against overflow ([#1096](../../pull/1096))

--- a/girder/girder_large_image/models/image_item.py
+++ b/girder/girder_large_image/models/image_item.py
@@ -190,17 +190,19 @@ class ImageItem(Item):
             sourceClass = girder_tilesource.AvailableGirderTileSources[sourceName]
         except TileSourceError:
             return None
+        if '_' in kwargs:
+            kwargs = kwargs.copy()
+            kwargs.pop('_', None)
         classHash = sourceClass.getLRUHash(item, **kwargs)
         tileHash = sourceClass.__name__ + ' ' + classHash + ' ' + strhash(
-            classHash) + strhash(*(x, y, z), mayRedirect=mayRedirect, **kwargs)
+            sourceClass.__name__ + ' ' + classHash) + strhash(
+            *(x, y, z), mayRedirect=mayRedirect, **kwargs)
         try:
             if tileCacheLock is None:
                 tileData = tileCache[tileHash]
             else:
-                # Checking this outside the lock is sufficient for the cache
-                # miss condition and faster
-                if tileHash not in tileCache:
-                    return None
+                # It would be nice if we could test if tileHash was in
+                # tileCache, but memcached doesn't expose that functionaility
                 with tileCacheLock:
                     tileData = tileCache[tileHash]
             tileMime = TileOutputMimeTypes.get(kwargs.get('encoding'), 'image/jpeg')


### PR DESCRIPTION
This was intended to work between restarts with memcached, but was not doing so because memcached doesn't expose checking if a key is present without fetching the data associated with that key and we were using that as a check.