### PR TITLE
Try to harden one of the tests.

### DIFF
--- a/girder/test_girder/web_client_specs/imageViewerSpec.js
+++ b/girder/test_girder/web_client_specs/imageViewerSpec.js
@@ -164,7 +164,7 @@ $(function () {
                 girderTest.binaryUpload('${large_image}/../../test/test_files/yb10kx5k.png');
             });
             girderTest.waitForLoad();
-        });
+        }, 30000);
         it('navigate to item and make a large image', function () {
             waitsFor(function () {
                 return $('a.g-item-list-link').length > 0;


### PR DESCRIPTION
We have transient failures on the imageViewerSpec test.  If this is purely a short-term occasional timeout, this change may help.