### PR TITLE
Improve access and repr of metadata and style

### DIFF
--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -186,9 +186,10 @@ class TileSource:
                 self._jsonstyle = json.dumps(style, sort_keys=True, separators=(',', ':'))
             else:
                 try:
-                    self._style = JSONDict(json.loads(style))
-                    if not isinstance(self._style, dict):
+                    style = json.loads(style)
+                    if not isinstance(style, dict):
                         raise TypeError
+                    self._style = JSONDict(style)
                 except TypeError:
                     raise exceptions.TileSourceError('Style is not a valid json object.')
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -196,10 +196,6 @@ class TileSource:
     def style(self):
         return self._style
 
-    @style.setter
-    def style(self, value):
-        self._setStyle(value)
-
     @staticmethod
     def getLRUHash(*args, **kwargs):
         """

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1741,7 +1741,7 @@ class TileSource:
         """
         frame = int(frame or 0)
         if (not getattr(self, '_skipStyle', None) and
-                hasattr(self, 'style') and 'bands' in self.style and
+                hasattr(self, '_style') and 'bands' in self.style and
                 len(self.style['bands']) and
                 all(entry.get('frame') is not None for entry in self.style['bands'])):
             frame = int(self.style['bands'][0]['frame'])

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -64,6 +64,17 @@ class ImageBytes(bytes):
         return f'ImageBytes<{len(self)}> (wrapped image bytes)'
 
 
+class JSONDict(dict):
+    """Wrapper class to improve Jupyter repr of JSON-able dicts."""
+
+    def __init__(self, *args, **kwargs):
+        super(JSONDict, self).__init__(*args, **kwargs)
+        # TODO: validate JSON serializable?
+
+    def _repr_json_(self):
+        return self
+
+
 def _encodeImageBinary(image, encoding, jpegQuality, jpegSubsampling, tiffCompression):
     """
     Encode a PIL Image to a binary representation of the image (a jpeg, png, or

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -291,7 +291,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                     'palette': ['#ffffff00', '#ffffffff'],
                 })
             self.logger.debug('Using style %r', style)
-            self._style = {'bands': style}
+            self._style = JSONDict({'bands': style})
         self._bandNames = {}
         for idx, band in self.getBandInformation().items():
             if band.get('interpretation'):

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -45,7 +45,7 @@ from large_image.exceptions import (TileSourceError,
                                     TileSourceFileNotFoundError,
                                     TileSourceInefficientError)
 from large_image.tilesource import FileTileSource
-from large_image.tilesource.utilities import getPaletteColors
+from large_image.tilesource.utilities import JSONDict, getPaletteColors
 
 try:
     from importlib.metadata import PackageNotFoundError
@@ -261,7 +261,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             styleBands = self.style['bands'] if 'bands' in self.style else [self.style]
             if not len(styleBands) or (len(styleBands) == 1 and isinstance(
                     styleBands[0].get('band', 1), int) and styleBands[0].get('band', 1) <= 0):
-                del self.style
+                del self._style
         style = self._styleBands()
         if len(style):
             hasAlpha = False
@@ -629,7 +629,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
 
     def getMetadata(self):
         with self._getDatasetLock:
-            metadata = {
+            metadata = JSONDict({
                 'geospatial': self.geospatial,
                 'levels': self.levels,
                 'sizeX': self.sizeX,
@@ -642,7 +642,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 'bounds': self.getBounds(self.projection),
                 'sourceBounds': self.getBounds(),
                 'bands': self.getBandInformation(),
-            }
+            })
         metadata.update(self.getNativeMagnification())
         if hasattr(self, '_netcdf'):
             # To ensure all band information from all subdatasets in netcdf,

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -218,7 +218,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             'alpha': ['#ffffff00', '#ffffffff'],
         }
         style = []
-        if hasattr(self, 'style'):
+        if hasattr(self, '_style'):
             styleBands = self.style['bands'] if 'bands' in self.style else [self.style]
             for styleBand in styleBands:
 
@@ -257,7 +257,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
 
     def _setDefaultStyle(self):
         """If not style was specified, create a default style."""
-        if hasattr(self, 'style'):
+        if hasattr(self, '_style'):
             styleBands = self.style['bands'] if 'bands' in self.style else [self.style]
             if not len(styleBands) or (len(styleBands) == 1 and isinstance(
                     styleBands[0].get('band', 1), int) and styleBands[0].get('band', 1) <= 0):
@@ -291,7 +291,7 @@ class GDALFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                     'palette': ['#ffffff00', '#ffffffff'],
                 })
             self.logger.debug('Using style %r', style)
-            self.style = {'bands': style}
+            self._style = {'bands': style}
         self._bandNames = {}
         for idx, band in self.getBandInformation().items():
             if band.get('interpretation'):

--- a/sources/mapnik/large_image_source_mapnik/__init__.py
+++ b/sources/mapnik/large_image_source_mapnik/__init__.py
@@ -24,6 +24,7 @@ from osgeo import gdal, gdalconst
 from large_image.cache_util import LruCacheMetaclass, methodcache
 from large_image.constants import TILE_FORMAT_PIL, SourcePriority
 from large_image.exceptions import TileSourceError
+from large_image.tilesource.utilities import JSONDict
 
 try:
     from importlib.metadata import PackageNotFoundError
@@ -165,13 +166,13 @@ class MapnikFileTileSource(GDALFileTileSource, metaclass=LruCacheMetaclass):
                 self.dataset = dataset['dataset']  # use for projection information
 
         if not hasattr(self, '_style'):
-            self._style = {
+            self._style = JSONDict({
                 'band': self._netcdf['default'] + ':1' if self._netcdf.get('default') else 1,
                 'scheme': 'linear',
                 'palette': ['#000000', '#ffffff'],
                 'min': 'min',
                 'max': 'max'
-            }
+            })
         return True
 
     def _setDefaultStyle(self):

--- a/sources/mapnik/large_image_source_mapnik/__init__.py
+++ b/sources/mapnik/large_image_source_mapnik/__init__.py
@@ -164,8 +164,8 @@ class MapnikFileTileSource(GDALFileTileSource, metaclass=LruCacheMetaclass):
 
                 self.dataset = dataset['dataset']  # use for projection information
 
-        if not hasattr(self, 'style'):
-            self.style = {
+        if not hasattr(self, '_style'):
+            self._style = {
                 'band': self._netcdf['default'] + ':1' if self._netcdf.get('default') else 1,
                 'scheme': 'linear',
                 'palette': ['#000000', '#ffffff'],


### PR DESCRIPTION
Adds `_repr_json_` for metadata and style (as both are JSON serializable objects) to improve representation in Jupyter (see screenshot). Further, this adds `metadata` and `style` properties to `TileSource` to improve access and prevent a user from setting these properties improperly.

The `style` property is a start to what is mentioned in #1119 

<img width="937" alt="Screen Shot 2023-04-19 at 12 26 18 PM" src="https://user-images.githubusercontent.com/22067021/233167240-273f6df9-3b86-40b3-af54-8e7afb130be1.png">