### PR TITLE
Remove psutil hard dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ setup(
         'palettable',
         # Pillow 8.3.0 and 8.3.1 won't save jpeg compressed tiffs properly.
         'Pillow',
-        'psutil>=4.2.0',  # technically optional
         'numpy>=1.10.4',
         'importlib-metadata<5 ; python_version < "3.8"',
     ],

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ extraReqs = {
     'colormaps': ['matplotlib'],
     'tiledoutput': ['pyvips'],
     'performance': [
+        'psutil>=4.2.0',
         'simplejpeg ; python_version >= "3.7"',
         'simplejpeg<1.6.6 ; python_version < "3.7"',
     ],


### PR DESCRIPTION
This is a soft dependency and the only one that isn't readily available in the most minimal Python environments (pyodide). 

Removing psutil should make the following source modules installable in pyodide (from a quick glance at dependencies... need to verify these actually work though)

- large-image-source-deepzoom
- large-image-source-dicom
- large-image-source-openjpeg
- large-image-source-pil
- large-image-source-vips
- large-image-source-tifffile

It is well handled if psutil is missing:

https://github.com/girder/large_image/blob/f7e664ad406e70538a52af2901ed44bb798d7e0f/large_image/cache_util/cachefactory.py#L96-L99

and the only other place it is used is in `large-image-converter` (and the girder modules) which has it as a hard dependency:

https://github.com/girder/large_image/blob/f7e664ad406e70538a52af2901ed44bb798d7e0f/utilities/converter/setup.py#L64

https://github.com/girder/girder/blob/d994d93a00257a17eeeab7e0b6fa4a54f5658550/setup.py#L39