### PR TITLE
Use stylus-supremacy for linting and reformating stylus files

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,3 +7,5 @@
 
 # PR 1093: Add a tox command to format the client code
 18dac36d043948cd973d0188abe18504042a49aa
+# PR 1129: Use stylus-supremacy for linting and reformating stylus files
+497ddf38b1461da47d1d542003172603e2166b5f

--- a/girder/girder_large_image/web_client/package.json
+++ b/girder/girder_large_image/web_client/package.json
@@ -67,116 +67,13 @@
             "**/node_modules/"
         ]
     },
-    "stylintrc": {
-        "blocks": false,
-        "brackets": {
-            "expect": "never",
-            "error": true
-        },
-        "colons": {
-            "expect": "never",
-            "error": true
-        },
-        "colors": false,
-        "commaSpace": {
-            "expect": "always",
-            "error": true
-        },
-        "commentSpace": {
-            "expect": "always",
-            "error": true
-        },
-        "cssLiteral": {
-            "expect": "never",
-            "error": true
-        },
-        "depthLimit": false,
-        "efficient": {
-            "expect": "always",
-            "error": true
-        },
-        "exclude": [
-            "**/node_modules/**"
-        ],
-        "extendPref": "@extend",
-        "globalDupe": false,
-        "groupOutputByFile": {
-            "expect": true,
-            "error": true
-        },
-        "indentPref": {
-            "expect": 2,
-            "error": true
-        },
-        "leadingZero": {
-            "expect": "always",
-            "error": true
-        },
-        "maxErrors": false,
-        "maxWarnings": false,
-        "mixed": false,
-        "mixins": [],
-        "namingConvention": false,
-        "namingConventionStrict": false,
-        "none": {
-            "expect": "always",
-            "error": true
-        },
-        "noImportant": false,
-        "parenSpace": {
-            "expect": "never",
-            "error": true
-        },
-        "placeholders": false,
-        "prefixVarsWithDollar": {
-            "expect": "always",
-            "error": true
-        },
-        "quotePref": {
-            "expect": "double",
-            "error": true
-        },
-        "reporterOptions": {
-            "columns": [
-                "lineData",
-                "severity",
-                "description",
-                "rule"
-            ],
-            "columnSplitter": "  ",
-            "showHeaders": false,
-            "truncate": true
-        },
-        "semicolons": {
-            "expect": "never",
-            "error": true
-        },
-        "sortOrder": false,
-        "stackedProperties": {
-            "expect": "never",
-            "error": true
-        },
-        "trailingWhitespace": {
-            "expect": "never",
-            "error": true
-        },
-        "universal": {
-            "expect": "never",
-            "error": true
-        },
-        "valid": {
-            "expect": true,
-            "error": true
-        },
-        "zeroUnits": {
-            "expect": "never",
-            "error": true
-        },
-        "zIndexNormalize": {
-            "expect": 5,
-            "error": true
-        }
-    },
+    "stylusSupremacy.insertColons": false,
+    "stylusSupremacy.insertSemicolons": false,
+    "stylusSupremacy.insertBraces": false,
+    "stylusSupremacy.tabStopChar": "  ",
+    "stylusSupremacy.quoteChar": "\"",
+    "stylusSupremacy.alwaysUseZeroWithoutUnit": true,
+    "stylusSupremacy.reduceMarginAndPaddingValues": true,
     "devDependencies": {
         "@girder/eslint-config": "^3.0.0-rc1",
         "eslint": "^8.20.0",
@@ -188,10 +85,10 @@
         "eslint-plugin-promise": "^6.0.0",
         "@girder/pug-lint-config": "^3.0.0-rc1",
         "pug-lint": "^2.6.0",
-        "stylint": "^2"
+        "stylus-supremacy": "^2.17.5"
     },
     "scripts": {
-        "lint": "eslint --cache . && pug-lint . && stylint",
-        "format": "eslint --cache --fix ."
+        "lint": "eslint --cache . && pug-lint . && stylus-supremacy format --compare ./**/*.styl --options package.json",
+        "format": "eslint --cache --fix . && eslint --cache --fix . && stylus-supremacy format ./**/*.styl --replace --options package.json"
     }
 }

--- a/girder/girder_large_image/web_client/stylesheets/fileList.styl
+++ b/girder/girder_large_image/web_client/stylesheets/fileList.styl
@@ -1,15 +1,19 @@
 span.fa-stack
   position relative
+
   i
     position absolute
     left 0
     top 0
+
   i:first-child
     position relative
+
   i.fa-cancel-cover
     font-size 75%
     left 40%
     top -30%
     color red
+
 .g-large-image-expected
   opacity 0.5

--- a/girder/girder_large_image/web_client/stylesheets/imageViewerSelectWidget.styl
+++ b/girder/girder_large_image/web_client/stylesheets/imageViewerSelectWidget.styl
@@ -27,11 +27,13 @@
 .image-controls-frame
   label
     margin-right 8px
+
   input.image-controls-number
     display inline-block
     vertical-align middle
     width 60px
     margin-right 8px
+
   input.image-controls-slider
     display inline-block
     vertical-align middle

--- a/girder/girder_large_image/web_client/stylesheets/itemList.styl
+++ b/girder/girder_large_image/web_client/stylesheets/itemList.styl
@@ -1,74 +1,97 @@
 div.large_image_thumbnail
   display inline-block
   width 160px
+
   img
     display none
     margin auto
+
     &.loaded
       display block
+
 div.large_image_container
   display inline-block
   min-width 160px
+
 div.large_image_container+span
   white-space nowrap
+
 [large_image_columns="2"]
   div.large_image_container
     min-width 320px
+
 [large_image_columns="3"]
   div.large_image_container
     min-width 480px
+
 ul.g-item-list
   &.li-item-list
     display table
     background #fff
+
     >li
       display table-row
+
       &.li-item-list-header
         padding-bottom 5px
+
       >span.li-item-list-header
         display table-cell
         font-weight bold
         text-align center
         border-bottom 1px solid #888
         padding 0 5px
+
         &.sortable
           &:after
             color black
             content "\002b65"
             padding-left 5px
+
           &.down:after
             content "\002b63"
+
           &.up:after
             content "\002b61"
+
       >.li-item-list-cell
         display table-cell
         padding 4px 3px 3px
         vertical-align top
+
         &.li-column-record-size
           div
             float none
             margin-left 0
             padding 0 10px
+
         &.li-column-record-controls
           white-space nowrap
+
       >span.li-item-list-cell:first-child
         padding-left 5px
+
       >span.li-item-list-cell:last-child
         padding-right 5px
+
       >span.li-column-metadata
         padding-left 5px
         padding-right 5px
+
       div.large_image_thumbnail
         display flex
         align-items flex-end
         justify-content center
         width inherit
+
 .li-item-list-filter
   padding-left 12px
-@media (min-width: 768px)
+
+@media (min-width 768px)
   .modal-dialog.li-item-list-dialog
     width inherit
-@media (min-width: 900px)
+
+@media (min-width 900px)
   .modal-dialog.li-item-list-dialog
     width 70%
     max-width 1000px
@@ -77,6 +100,7 @@ ul.g-item-list
   font-size 14px
   display inline-block
   margin-left 20px
+
   label
     padding-left 5px
     font-weight normal

--- a/girder/girder_large_image/web_client/stylesheets/itemView.styl
+++ b/girder/girder_large_image/web_client/stylesheets/itemView.styl
@@ -4,19 +4,23 @@
 .li-metadata-tabs
   margin-top 10px
   overflow-x hidden
+
   .yaml
     display block
     unicode-bidi embed
     font-family monospace
     white-space pre-wrap
+
   td
     max-width 50vw
+
     td
       max-width 33vw
 
 a.g-widget-auximage
   display inline-block
   padding 5px
+
   .g-widget-auximage-title
     color black
     font-weight bold

--- a/girder_annotation/girder_large_image_annotation/web_client/package.json
+++ b/girder_annotation/girder_large_image_annotation/web_client/package.json
@@ -58,116 +58,13 @@
             "**/node_modules/"
         ]
     },
-    "stylintrc": {
-        "blocks": false,
-        "brackets": {
-            "expect": "never",
-            "error": true
-        },
-        "colons": {
-            "expect": "never",
-            "error": true
-        },
-        "colors": false,
-        "commaSpace": {
-            "expect": "always",
-            "error": true
-        },
-        "commentSpace": {
-            "expect": "always",
-            "error": true
-        },
-        "cssLiteral": {
-            "expect": "never",
-            "error": true
-        },
-        "depthLimit": false,
-        "efficient": {
-            "expect": "always",
-            "error": true
-        },
-        "exclude": [
-            "**/node_modules/**"
-        ],
-        "extendPref": "@extend",
-        "globalDupe": false,
-        "groupOutputByFile": {
-            "expect": true,
-            "error": true
-        },
-        "indentPref": {
-            "expect": 2,
-            "error": true
-        },
-        "leadingZero": {
-            "expect": "always",
-            "error": true
-        },
-        "maxErrors": false,
-        "maxWarnings": false,
-        "mixed": false,
-        "mixins": [],
-        "namingConvention": false,
-        "namingConventionStrict": false,
-        "none": {
-            "expect": "always",
-            "error": true
-        },
-        "noImportant": false,
-        "parenSpace": {
-            "expect": "never",
-            "error": true
-        },
-        "placeholders": false,
-        "prefixVarsWithDollar": {
-            "expect": "always",
-            "error": true
-        },
-        "quotePref": {
-            "expect": "double",
-            "error": true
-        },
-        "reporterOptions": {
-            "columns": [
-                "lineData",
-                "severity",
-                "description",
-                "rule"
-            ],
-            "columnSplitter": "  ",
-            "showHeaders": false,
-            "truncate": true
-        },
-        "semicolons": {
-            "expect": "never",
-            "error": true
-        },
-        "sortOrder": false,
-        "stackedProperties": {
-            "expect": "never",
-            "error": true
-        },
-        "trailingWhitespace": {
-            "expect": "never",
-            "error": true
-        },
-        "universal": {
-            "expect": "never",
-            "error": true
-        },
-        "valid": {
-            "expect": true,
-            "error": true
-        },
-        "zeroUnits": {
-            "expect": "never",
-            "error": true
-        },
-        "zIndexNormalize": {
-            "expect": 5,
-            "error": true
-        }
-    },
+    "stylusSupremacy.insertColons": false,
+    "stylusSupremacy.insertSemicolons": false,
+    "stylusSupremacy.insertBraces": false,
+    "stylusSupremacy.tabStopChar": "  ",
+    "stylusSupremacy.quoteChar": "\"",
+    "stylusSupremacy.alwaysUseZeroWithoutUnit": true,
+    "stylusSupremacy.reduceMarginAndPaddingValues": true,
     "devDependencies": {
         "@girder/eslint-config": "^3.0.0-rc1",
         "eslint": "^8.20.0",
@@ -179,10 +76,10 @@
         "eslint-plugin-promise": "^6.0.0",
         "@girder/pug-lint-config": "^3.0.0-rc1",
         "pug-lint": "^2.6.0",
-        "stylint": "^2"
+        "stylus-supremacy": "^2.17.5"
     },
     "scripts": {
-        "lint": "eslint --cache . && pug-lint . && stylint",
-        "format": "eslint --cache --fix ."
+        "lint": "eslint --cache . && pug-lint . && stylus-supremacy format --compare ./**/*.styl --options package.json",
+        "format": "eslint --cache --fix . && eslint --cache --fix . && stylus-supremacy format ./**/*.styl --replace --options package.json"
     }
 }

--- a/girder_annotation/girder_large_image_annotation/web_client/stylesheets/annotationListWidget.styl
+++ b/girder_annotation/girder_large_image_annotation/web_client/stylesheets/annotationListWidget.styl
@@ -11,6 +11,7 @@
     width initial
     max-width initial
     min-width 100%
+
   table-layout fixed
 
   td

--- a/girder_annotation/girder_large_image_annotation/web_client/stylesheets/itemList.styl
+++ b/girder_annotation/girder_large_image_annotation/web_client/stylesheets/itemList.styl
@@ -5,9 +5,8 @@
   position absolute
   top 0
   right 0
-  transform scale(1)translate(50%, -50%)
+  transform scale(1) translate(50%, -50%)
   transform-origin 100% 0
-
   height 20px
   padding 0 6px
   z-index 10
@@ -16,9 +15,7 @@
   align-items center
   justify-content center
   font-size 80%
-
   line-height 1
-
   background-color lightgrey
   color black
   border-radius 10px


### PR DESCRIPTION
This still depends on stylint, so it doesn't address any outdated package issues.

The main benefit is we can auto-format stylus files.