### PR TITLE
Fix a bug with caching tiles and styling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 - Allow clearing the min/max fields of the frame selector ([#1030](../../pull/1030))
+- Fix a bug with caching tiles and styling ([#1031](../../pull/1031))
 
 ## 1.20.5
 

--- a/girder/girder_large_image/models/image_item.py
+++ b/girder/girder_large_image/models/image_item.py
@@ -190,10 +190,12 @@ class ImageItem(Item):
             sourceClass = girder_tilesource.AvailableGirderTileSources[sourceName]
         except TileSourceError:
             return None
-        if '_' in kwargs:
+        if '_' in kwargs or 'style' in kwargs:
             kwargs = kwargs.copy()
             kwargs.pop('_', None)
         classHash = sourceClass.getLRUHash(item, **kwargs)
+        # style isn't part of the tile hash strhash parameters
+        kwargs.pop('style', None)
         tileHash = sourceClass.__name__ + ' ' + classHash + ' ' + strhash(
             sourceClass.__name__ + ' ' + classHash) + strhash(
             *(x, y, z), mayRedirect=mayRedirect, **kwargs)


### PR DESCRIPTION
If multiple threads are styling tiles, it was possible for the tile cache key to be erroneous due to the styler fetching the "unstyled" tile and a second thread fetching the tile cache reference based on the name of the unstyled class rather than the styled class.