### PR TITLE
Add manual index names where index names might get too long

### DIFF
--- a/girder_annotation/girder_large_image_annotation/models/annotationelement.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotationelement.py
@@ -63,16 +63,22 @@ class Annotationelement(Model):
                 ('bbox.lowx', SortDir.DESCENDING),
                 ('bbox.highx', SortDir.ASCENDING),
                 ('bbox.size', SortDir.DESCENDING),
-            ], {}),
+            ], {
+                'name': 'annotationBboxIdx'
+            }),
             ([
                 ('annotationId', SortDir.ASCENDING),
                 ('bbox.size', SortDir.DESCENDING),
-            ], {}),
+            ], {
+                'name': 'annotationBboxSizeIdx'
+            }),
             ([
                 ('annotationId', SortDir.ASCENDING),
                 ('_version', SortDir.DESCENDING),
                 ('element.group', SortDir.ASCENDING),
-            ], {}),
+            ], {
+                'name': 'annotationGroupIdx'
+            }),
             ([
                 ('created', SortDir.ASCENDING),
                 ('_version', SortDir.ASCENDING),


### PR DESCRIPTION
Some managed mongoDB providers limit index name lengths, and multi-column indexes' default names may exceed this.