### PR TITLE
Retry tests on CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
           # Piping through cat does less buffering of the output but can
           # consume the exit code
           # command: PYTEST_ADDOPTS=--forked tox -e << parameters.env >> | cat; test ${PIPESTATUS[0]} -eq 0
-          command: tox -e << parameters.env >> | cat; test ${PIPESTATUS[0]} -eq 0
+          command: PYTEST_RERUNS=3 tox -e << parameters.env >> | cat; test ${PIPESTATUS[0]} -eq 0
   switchpython:
     description: "Upgrade python"
     parameters:


### PR DESCRIPTION
Some of the client tests occasionally fail; since we aim to refactor how girder client tests are run in the future, rather than hunting down the issue now, just retry tests a few times.