### PR TITLE
Remove rasterio dep on pyproj

### DIFF
--- a/large_image/tilesource/geo.py
+++ b/large_image/tilesource/geo.py
@@ -233,7 +233,7 @@ class GDALBaseFileTileSource(GeoBaseFileTileSource):
         if not has_pyproj:
             # Estimate based on great-cirlce distance
             def great_circle(lon1, lat1, lon2, lat2):
-                from math import acos, asin, cos, radians, sin, sqrt
+                from math import acos, cos, radians, sin
                 lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
                 return None, None, 6.378e+6 * (
                     acos(sin(lat1) * sin(lat2) + cos(lat1) * cos(lat2) * cos(lon1 - lon2))

--- a/large_image/tilesource/geo.py
+++ b/large_image/tilesource/geo.py
@@ -1,13 +1,17 @@
 from urllib.parse import urlencode, urlparse
 
-import pyproj  # TODO: import issues
-
 from large_image.cache_util import CacheProperties, methodcache
 from large_image.constants import SourcePriority, TileInputUnits
 from large_image.exceptions import TileSourceError
 
 from .base import FileTileSource
 from .utilities import JSONDict, getPaletteColors
+
+try:
+    import pyproj
+    has_pyproj = True
+except Exception:
+    has_pyproj = False
 
 # Inform the tile source cache about the potential size of this tile source
 CacheProperties['tilesource']['itemExpectedSize'] = max(
@@ -18,8 +22,9 @@ CacheProperties['tilesource']['itemExpectedSize'] = max(
 ProjUnitsAcrossLevel0 = {}
 ProjUnitsAcrossLevel0_MaxSize = 100
 
-InitPrefix = '+init='
-NeededInitPrefix = '' if int(pyproj.proj_version_str.split('.')[0]) >= 6 else InitPrefix
+InitPrefix = ''
+if has_pyproj:
+    NeededInitPrefix = '+init=' if int(pyproj.proj_version_str.split('.')[0]) < 6 else InitPrefix
 
 
 def make_vsi(url: str, **options):
@@ -225,6 +230,7 @@ class GDALBaseFileTileSource(GeoBaseFileTileSource):
         bounds = self.getBounds(NeededInitPrefix + 'epsg:4326')
         if not bounds:
             return
+        # TODO: can we do this withou pyproj? ...For rasterio
         geod = pyproj.Geod(ellps='WGS84')
         az12, az21, s1 = geod.inv(bounds['ul']['x'], bounds['ul']['y'],
                                   bounds['ur']['x'], bounds['ur']['y'])

--- a/large_image/tilesource/geo.py
+++ b/large_image/tilesource/geo.py
@@ -230,18 +230,17 @@ class GDALBaseFileTileSource(GeoBaseFileTileSource):
         bounds = self.getBounds(NeededInitPrefix + 'epsg:4326')
         if not bounds:
             return
-        if not has_pyproj:
+        if has_pyproj:
+            geod = pyproj.Geod(ellps='WGS84')
+            computer = geod.inv
+        else:
             # Estimate based on great-cirlce distance
-            def great_circle(lon1, lat1, lon2, lat2):
+            def computer(lon1, lat1, lon2, lat2):
                 from math import acos, cos, radians, sin
                 lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
                 return None, None, 6.378e+6 * (
                     acos(sin(lat1) * sin(lat2) + cos(lat1) * cos(lat2) * cos(lon1 - lon2))
                 )
-            computer = great_circle
-        else:
-            geod = pyproj.Geod(ellps='WGS84')
-            computer = geod.inv
         _, _, s1 = computer(bounds['ul']['x'], bounds['ul']['y'],
                             bounds['ur']['x'], bounds['ur']['y'])
         _, _, s2 = computer(bounds['ur']['x'], bounds['ur']['y'],


### PR DESCRIPTION
Draft work to remove the `rasterio` source module's dependence on `pyproj`.

Considering how easy it is to install `pyproj` these days, I don't think this is totally necessary but it's probably best to have the rasterio source module use `rasterio` directly for everything rather than pulling an additional dependency.

There is still one remaining function `getPixelSizeInMeters()` that I wasn't immediately sure on how to reproduce with `rasterio`