### PR TITLE
Fix NeededInitPrefix namepsace errors

### DIFF
--- a/large_image/tilesource/geo.py
+++ b/large_image/tilesource/geo.py
@@ -10,6 +10,7 @@ from .utilities import JSONDict, getPaletteColors
 try:
     import pyproj
     has_pyproj = True
+    _pyproj_under_6 = int(pyproj.proj_version_str.split('.')[0]) < 6
 except Exception:
     has_pyproj = False
 
@@ -23,7 +24,7 @@ ProjUnitsAcrossLevel0 = {}
 ProjUnitsAcrossLevel0_MaxSize = 100
 
 InitPrefix = ''
-NeededInitPrefix = '+init=' if has_pyproj and int(pyproj.proj_version_str.split('.')[0]) < 6 else InitPrefix
+NeededInitPrefix = '+init=' if has_pyproj and _pyproj_under_6 else InitPrefix
 
 
 def make_vsi(url: str, **options):

--- a/large_image/tilesource/geo.py
+++ b/large_image/tilesource/geo.py
@@ -23,8 +23,7 @@ ProjUnitsAcrossLevel0 = {}
 ProjUnitsAcrossLevel0_MaxSize = 100
 
 InitPrefix = ''
-if has_pyproj:
-    NeededInitPrefix = '+init=' if int(pyproj.proj_version_str.split('.')[0]) < 6 else InitPrefix
+NeededInitPrefix = '+init=' if has_pyproj and int(pyproj.proj_version_str.split('.')[0]) < 6 else InitPrefix
 
 
 def make_vsi(url: str, **options):


### PR DESCRIPTION
Fixes issue if pyproj isn't installed

```
File ~/miniconda3/envs/venv/lib/python3.11/site-packages/large_image/tilesource/geo.py:230, in GDALBaseFileTileSource.getPixelSizeInMeters(self)
    223 def getPixelSizeInMeters(self):
    224     """
    225     Get the approximate base pixel size in meters.  This is calculated as
    226     the average scale of the four edges in the WGS84 ellipsoid.
    227 
    228     :returns: the pixel size in meters or None.
    229     """
--> 230     bounds = self.getBounds(NeededInitPrefix + 'epsg:4326')
    231     if not bounds:
    232         return

NameError: name 'NeededInitPrefix' is not defined
```