### PR TITLE
Refactor reading the .large_image_config.yaml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 - Change how extensions and fallback priorities interact ([#1192](../../pull/1192))
+- Refactor reading the .large_image_config.yaml file on the girder client ([#1193](../../pull/1193))
 
 ## 1.22.2
 

--- a/girder/girder_large_image/web_client/views/configView.js
+++ b/girder/girder_large_image/web_client/views/configView.js
@@ -226,6 +226,59 @@ var ConfigView = View.extend({
     },
 
     /**
+     * Get the folder config file for the current user.
+     *
+     * @param {string} folderId the folder to get the config for.
+     * @param {boolean} reload if true, refetch the config file even if it was
+     *      the last one fetched.  Since config files can be changed by the
+     *      user, this should be done based on the UI behavior.
+     * @param {function} callback a function to call after the config file is
+     *      fetched.  If the file is already fetched, this is called without
+     *      any delay.
+     * @returns a promise that resolves to the config file values.
+     */
+    getConfigFile: function (folderId, reload, callback) {
+        if (!folderId) {
+            const result = {};
+            if (callback) {
+                callback(result);
+            }
+            return $.Deferred().resolve({});
+        }
+        if (ConfigView._lastliconfig === folderId && !reload) {
+            if (callback) {
+                callback(ConfigView._liconfig);
+            }
+            return $.Deferred().resolve(ConfigView._liconfig);
+        }
+        if (ConfigView._liconfigSettingsRequest) {
+            if (ConfigView._nextliconfig === folderId) {
+                if (callback) {
+                    ConfigView._liconfigSettingsRequest.done(() => {
+                        callback(ConfigView._liconfig);
+                    });
+                }
+                return ConfigView._liconfigSettingsRequest;
+            }
+            ConfigView._liconfigSettingsRequest.cancel();
+        }
+        ConfigView._nextliconfig = folderId;
+        ConfigView._liconfigSettingsRequest = restRequest({
+            url: `folder/${folderId}/yaml_config/.large_image_config.yaml`
+        }).done((val) => {
+            val = val || {};
+            ConfigView._lastliconfig = folderId;
+            ConfigView._liconfigSettingsRequest = null;
+            ConfigView._liconfig = val || {};
+            if (callback) {
+                callback(ConfigView._liconfig);
+            }
+            return val;
+        });
+        return ConfigView._liconfigSettingsRequest;
+    },
+
+    /**
      * Clear the settings so that getSettings will refetch them.
      */
     clearSettings: function () {

--- a/girder/girder_large_image/web_client/views/itemList.js
+++ b/girder/girder_large_image/web_client/views/itemList.js
@@ -3,7 +3,7 @@ import _ from 'underscore';
 import Backbone from 'backbone';
 
 import {wrap} from '@girder/core/utilities/PluginUtils';
-import {getApiRoot, restRequest} from '@girder/core/rest';
+import {getApiRoot} from '@girder/core/rest';
 import {getCurrentUser} from '@girder/core/auth';
 import {AccessType} from '@girder/core/constants';
 import {formatSize, parseQueryString, splitRoute} from '@girder/core/misc';
@@ -49,13 +49,10 @@ wrap(ItemListWidget, 'initialize', function (initialize, settings) {
     const result = initialize.call(this, settings);
     delete this._hasAnyLargeImage;
 
-    if (!settings.folderId) {
-        this._liconfig = {};
-    }
-    restRequest({
-        url: `folder/${settings.folderId}/yaml_config/.large_image_config.yaml`
-    }).done((val) => {
-        val = val || {};
+    largeImageConfig.getConfigFile(settings.folderId, true, (val) => {
+        if (!settings.folderId) {
+            this._liconfig = val;
+        }
         if (_.isEqual(val, this._liconfig) && !this._recurse) {
             return;
         }

--- a/girder_annotation/girder_large_image_annotation/web_client/views/annotationListWidget.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/annotationListWidget.js
@@ -11,6 +11,7 @@ import events from '@girder/core/events';
 import UserCollection from '@girder/core/collections/UserCollection';
 import UploadWidget from '@girder/core/views/widgets/UploadWidget';
 import View from '@girder/core/views/View';
+import largeImageConfig from '@girder/large_image/views/configView';
 
 import AnnotationCollection from '../collections/AnnotationCollection';
 
@@ -57,10 +58,8 @@ const AnnotationListWidget = View.extend({
             error: null
         }).done((createResp) => {
             this.createResp = createResp;
-            restRequest({
-                url: `folder/${this.model.get('folderId')}/yaml_config/.large_image_config.yaml`
-            }).done((val) => {
-                this._liconfig = val || {};
+            largeImageConfig.getConfigFile(this.model.get('folderId')).done((val) => {
+                this._liconfig = val;
                 this._confList = this._liconfig.annotationList || {
                     columns: [{
                         type: 'record',


### PR DESCRIPTION
We aim to use this file in more places and want to avoid duplicating the reader code.