### PR TITLE
Allow specifying an empty style dict.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 - Better DICOM multi-level detection ([#1196](../../pull/1196))
 - Added an internal field to report populated tile levels in some sources ([#1197](../../pull/1197), [#1199](../../pull/1199))
+- Allow specifying an empty style dict ([#1200](../../pull/1200))
 
 ### Changes
 - Change how extensions and fallback priorities interact ([#1192](../../pull/1192))

--- a/docs/tilesource_options.rst
+++ b/docs/tilesource_options.rst
@@ -33,7 +33,7 @@ Style
 
 Often tiles are desired as 8-bit-per-sample images.  However, if the tile source is more than 8 bits per sample or has more than 3 channels, some data will be lost.  Similarly, if the data is returned as a numpy array, the range of values returned can vary by tile source.  The ``style`` parameter can remap samples values and determine how channels are composited.
 
-If ``style`` is not specified or None, the default style for the file is used.  Otherwise, this is a json-encoded string that contains an object with a key of ``bands`` consisting of an array of band definitions.  If only one band is needed, a json-encoded string of just the band definition can be used.
+If ``style`` is ``{}``, the default style for the file is used.  If it is not specified or None, it will be the default style for non-geospatial tile sources and a default style consisting of the visible bands for geospatial sources.  Otherwise, this is a json-encoded string that contains an object with a key of ``bands`` consisting of an array of band definitions.  If only one band is needed, a json-encoded string of just the band definition can be used.
 
 A band definition is an object which can contain the following keys:
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -192,7 +192,7 @@ class TileSource:
                 pass
         self._bandRanges = {}
         self._jsonstyle = style
-        if style:
+        if style is not None:
             if isinstance(style, dict):
                 self._style = JSONDict(style)
                 self._jsonstyle = json.dumps(style, sort_keys=True, separators=(',', ':'))
@@ -1382,7 +1382,7 @@ class TileSource:
         sc = types.SimpleNamespace(
             image=image, originalStyle=style, x=x, y=y, z=z, frame=frame,
             mainImage=image, mainFrame=frame, dtype=None, axis=None)
-        if style is None or ('icc' in style and len(style) == 1):
+        if not style or ('icc' in style and len(style) == 1):
             sc.style = {'icc': (style or {}).get(
                 'icc', config.getConfig('icc_correction', True)), 'bands': []}
         else:
@@ -1392,7 +1392,7 @@ class TileSource:
         if hasattr(self, '_iccprofiles') and sc.style.get(
                 'icc', config.getConfig('icc_correction', True)):
             image = self._applyICCProfile(sc, frame)
-        if style is None or ('icc' in style and len(style) == 1):
+        if not style or ('icc' in style and len(style) == 1):
             sc.output = image
         else:
             sc.output = numpy.zeros((image.shape[0], image.shape[1], 4), float)

--- a/large_image/tilesource/geo.py
+++ b/large_image/tilesource/geo.py
@@ -169,7 +169,14 @@ class GDALBaseFileTileSource(GeoBaseFileTileSource):
         return style
 
     def _setDefaultStyle(self):
-        """If not style was specified, create a default style."""
+        """If no style was specified, create a default style."""
+        self._bandNames = {}
+        for idx, band in self.getBandInformation().items():
+            if band.get('interpretation'):
+                self._bandNames[band['interpretation'].lower()] = idx
+        if isinstance(getattr(self, '_style', None), dict) and (
+                not self._style or 'icc' in self._style and len(self._style) == 1):
+            return
         if hasattr(self, '_style'):
             styleBands = self.style['bands'] if 'bands' in self.style else [self.style]
             if not len(styleBands) or (len(styleBands) == 1 and isinstance(
@@ -205,10 +212,6 @@ class GDALBaseFileTileSource(GeoBaseFileTileSource):
                 })
             self.logger.debug('Using style %r', style)
             self._style = JSONDict({'bands': style})
-        self._bandNames = {}
-        for idx, band in self.getBandInformation().items():
-            if band.get('interpretation'):
-                self._bandNames[band['interpretation'].lower()] = idx
 
     @staticmethod
     def getHexColors(palette):

--- a/test/test_source_openslide.py
+++ b/test/test_source_openslide.py
@@ -346,6 +346,9 @@ def testGetPixelWithICCCorrection():
     source = large_image_source_openslide.open(imagePath, style={'icc': True})
     pixel2 = source.getPixel(region={'left': 12125, 'top': 10640})
     assert pixel == pixel2
+    source = large_image_source_openslide.open(imagePath, style={})
+    pixel3 = source.getPixel(region={'left': 12125, 'top': 10640})
+    assert pixel == pixel3
 
 
 def testTilesFromPowerOf3Tiles():


### PR DESCRIPTION
This overrides the default style on geospatial sources, allowing getting the unstyled histogram or other data.