### PR TITLE
Allow rounding histogram bin edges and reducing bin counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Better DICOM multi-level detection ([#1196](../../pull/1196))
 - Added an internal field to report populated tile levels in some sources ([#1197](../../pull/1197), [#1199](../../pull/1199))
 - Allow specifying an empty style dict ([#1200](../../pull/1200))
+- Allow rounding histogram bin edges and reducing bin counts ([#1201](../../pull/1201))
 
 ### Changes
 - Change how extensions and fallback priorities interact ([#1192](../../pull/1192))

--- a/girder/girder_large_image/rest/tiles.py
+++ b/girder/girder_large_image/rest/tiles.py
@@ -985,6 +985,10 @@ class TilesItemResource(ItemResource):
         .param('rangeMax', 'The maximum value in the histogram.  Defaults to '
                'the maximum value in the image.',
                required=False, dataType='float')
+        .param('roundRange', 'If true and neither a minimum or maximum is '
+               'specified for the range, round the bin edges and adjust the '
+               'number of bins for integer data with smaller ranges.',
+               required=False, dataType='boolean', default=False)
         .param('density', 'If true, scale the results by the number of '
                'samples.', required=False, dataType='boolean', default=False)
         .errorResponse('ID was invalid.')
@@ -1020,12 +1024,16 @@ class TilesItemResource(ItemResource):
             ('bins', int),
             ('rangeMin', int),
             ('rangeMax', int),
+            ('roundRange', bool),
             ('density', bool),
         ])
         _handleETag('getHistogram', item, params)
         histRange = None
         if 'rangeMin' in params or 'rangeMax' in params:
             histRange = [params.pop('rangeMin', 0), params.pop('rangeMax', 256)]
+        if params.get('roundRange'):
+            if params.pop('roundRange', False) and histRange is None:
+                histRange = 'round'
         result = self.imageItemModel.histogram(item, range=histRange, **params)
         result = result['histogram']
         # Cast everything to lists and floats so json with encode properly

--- a/girder/test_girder/test_tiles_rest.py
+++ b/girder/test_girder/test_tiles_rest.py
@@ -1218,6 +1218,19 @@ def testTilesHistogram(server, admin, fsAssetstore):
     assert len(resp.json) == 3
     assert len(resp.json[0]['hist']) == 256
 
+    resp = server.request(
+        path='/item/%s/tiles/histogram' % itemId,
+        params={'width': 2048, 'height': 2048, 'resample': False,
+                'roundRange': False, 'bins': 512})
+    assert len(resp.json) == 3
+    assert len(resp.json[0]['hist']) == 512
+    resp = server.request(
+        path='/item/%s/tiles/histogram' % itemId,
+        params={'width': 2048, 'height': 2048, 'resample': False,
+                'roundRange': True, 'bins': 512})
+    assert len(resp.json) == 3
+    assert len(resp.json[0]['hist']) == 256
+
 
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')

--- a/test/test_source_tiff.py
+++ b/test/test_source_tiff.py
@@ -713,6 +713,7 @@ def testHistogram():
     hist = source.histogram(bins=8, output={'maxWidth': 1024}, resample=False)
     assert len(hist['histogram']) == 3
     assert hist['histogram'][0]['range'] == (0, 256)
+    assert len(hist['histogram'][0]['bin_edges']) == 9
     assert len(list(hist['histogram'][0]['hist'])) == 8
     assert list(hist['histogram'][0]['bin_edges']) == [0, 32, 64, 96, 128, 160, 192, 224, 256]
     assert hist['histogram'][0]['samples'] == 700416
@@ -729,6 +730,15 @@ def testHistogram():
                             density=True, resample=False)
     assert hist['histogram'][0]['samples'] == 2801664
     assert 6e-5 < hist['histogram'][0]['hist'][128] < 8e-5
+
+    hist = source.histogram(bins=512, output={'maxWidth': 2048}, resample=False)
+    assert hist['histogram'][0]['range'] == (0, 256)
+    assert len(hist['histogram'][0]['bin_edges']) == 513
+
+    hist = source.histogram(bins=512, output={'maxWidth': 2048}, resample=False,
+                            range='round')
+    assert hist['histogram'][0]['range'] == (0, 256)
+    assert len(hist['histogram'][0]['bin_edges']) == 257
 
 
 def testSingleTileIteratorResample():


### PR DESCRIPTION
For integer data types, using full bin counts can result in jagged looking results because some bins will have fewer or no discrete values than others.