### PR TITLE
Reduce the default max texture size for frame quads.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@
 
 ### Changes
 - Change how extensions and fallback priorities in Girder interact ([#1208](../../pull/1208))
+- Reduce the default max texture size for frame quads ([#1212](../../pull/1212))
 
 ### Bug Fixes
 - Fix clearing the style threshold cache ([#1210](../../pull/1210))
-- 
+-
 ## 1.22.4
 
 ### Bug Fixes

--- a/girder/girder_large_image/web_client/views/imageViewerWidget/setFrameQuad.js
+++ b/girder/girder_large_image/web_client/views/imageViewerWidget/setFrameQuad.js
@@ -70,7 +70,7 @@ function setFrameQuad(tileinfo, layer, options) {
     try {
         maxTextureSize = layer.renderer()._maxTextureSize || layer.renderer().constructor._maxTextureSize;
     } catch (err) { }
-    options = Object.assign({}, {maxTextureSize: Math.min(16384, maxTextureSize)}, options);
+    options = Object.assign({}, {maxTextureSize: Math.min(8192, maxTextureSize || 8192)}, options);
     const status = {
         tileinfo: tileinfo,
         options: options,

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -864,7 +864,7 @@ def getTileFramesQuadInfo(metadata, options=None):
         'frameGroup': 1,
         'frameGroupFactor': 4,
         'frameGroupStride': 1,
-        'maxTextureSize': 16384,
+        'maxTextureSize': 8192,
         'maxTextures': 1,
         'maxTotalTexturePixels': 1024 * 1024 * 1024,
         'alignment': 16,

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -368,7 +368,7 @@ def testTileOverlapWithRegionOffset():
 
 
 @pytest.mark.parametrize('options,lensrc,lenquads,frame10,src0,srclast,quads10', [
-    ({}, 1, 250, 10, {
+    ({'maxTextureSize': 16384}, 1, 250, 10, {
         'encoding': 'JPEG',
         'exact': False,
         'fill': 'corner:black',
@@ -402,7 +402,7 @@ def testTileOverlapWithRegionOffset():
         'top': 3816,
     }),
 
-    ({'maxTextures': 8}, 4, 250, 10, {
+    ({'maxTextureSize': 16384, 'maxTextures': 8}, 4, 250, 10, {
         'framesAcross': 7,
         'height': 1632,
         'width': 2176,
@@ -420,7 +420,8 @@ def testTileOverlapWithRegionOffset():
         'top': 2304,
     }),
 
-    ({'maxTextures': 8, 'maxTotalTexturePixels': 8 * 1024 ** 3}, 8, 250, 10, {
+    ({'maxTextureSize': 16384,
+      'maxTextures': 8, 'maxTotalTexturePixels': 8 * 1024 ** 3}, 8, 250, 10, {
         'framesAcross': 5,
         'height': 2336,
         'width': 3120,
@@ -429,7 +430,7 @@ def testTileOverlapWithRegionOffset():
         'top': 9344,
     }),
 
-    ({'alignment': 32}, 1, 250, 10, {
+    ({'maxTextureSize': 16384, 'alignment': 32}, 1, 250, 10, {
         'framesAcross': 14,
         'height': 864,
         'width': 1152,
@@ -438,7 +439,7 @@ def testTileOverlapWithRegionOffset():
         'top': 14688,
     }),
 
-    ({'frameBase': 100}, 1, 150, 110, {
+    ({'maxTextureSize': 16384, 'frameBase': 100}, 1, 150, 110, {
         'framesAcross': 11,
         'height': 1088,
         'width': 1456,
@@ -447,7 +448,7 @@ def testTileOverlapWithRegionOffset():
         'top': 14144,
     }),
 
-    ({'frameStride': 10}, 1, 25, 100, {
+    ({'maxTextureSize': 16384, 'frameStride': 10}, 1, 25, 100, {
         'framesAcross': 5,
         'height': 2448,
         'width': 3264,


### PR DESCRIPTION
For images with lots of frames, a large value preserves quick resolution, but browsers are glacial at decoding large images.  This attempts to adjust the balance.