### PR TITLE
Simplify style locking.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Improvements
 - Harden reading some nc files ([#1218](../../pull/1218))
 - Increase the cache used for opening directories in the pylibtiff source ([#1221](../../pull/1221))
+- Refactor style locking to increase parallelism ([#1224](../../pull/1224))
+
+### Changes
+- Clean up some old slideatlas url references ([#1223](../../pull/1223))
 
 ### Bug Fixes
 - Pass style to histogram endpoint as json ([#1220](../../pull/1220))

--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -204,11 +204,12 @@ class LruCacheMetaclass(type):
                 subkwargs.pop('style')
                 subresult = cls(*args, **subkwargs)
                 result = subresult.__class__.__new__(subresult.__class__)
-                with subresult._styleLock:
+                with subresult._sourceLock:
                     result.__dict__ = subresult.__dict__.copy()
-                    result._styleLock = threading.RLock()
+                    result._sourceLock = threading.RLock()
                 result._setStyle(kwargs['style'])
                 result._classkey = key
+                result._unstyledInstance = subresult
                 # for pickling
                 result._initValues = (args, kwargs.copy())
                 with cacheLock:

--- a/sources/rasterio/large_image_source_rasterio/__init__.py
+++ b/sources/rasterio/large_image_source_rasterio/__init__.py
@@ -488,7 +488,8 @@ class RasterioFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass
                 infoSet[i] = {k: v for k, v in info.items() if v not in (None, '')}
 
         # set the value to cache if needed
-        cache is False or getattr(self, '_bandInfo', infoSet)
+        if cache:
+            self._bandInfo = infoSet
 
         return infoSet
 


### PR DESCRIPTION
Just reference the unstyled instance directly.  This improves speed by reducing locking.