### PR TITLE
Pin pydantic for rio-cog

### DIFF
--- a/sources/rasterio/setup.py
+++ b/sources/rasterio/setup.py
@@ -60,7 +60,10 @@ setup(
     ],
     extras_require={
         'girder': f'girder-large-image{limit_version}',
-        'all': 'rio-cogeo',
+        'all': [
+            'rio-cogeo',
+            'pydantic<2',
+        ],
     },
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),


### PR DESCRIPTION
rio-cog uses mercantile which uses pydantic.  It requires pydantic < 2.