### PR TITLE
Improve how dtypes are reported from #1224

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Improvements
 - Harden reading some nc files ([#1218](../../pull/1218))
 - Increase the cache used for opening directories in the pylibtiff source ([#1221](../../pull/1221))
-- Refactor style locking to increase parallelism ([#1224](../../pull/1224))
+- Refactor style locking to increase parallelism ([#1224](../../pull/1224), [#1233](../../pull/1233))
 - Better isGeospatial consistency ([#1228](../../pull/1228))
 - Better channel handling on frame selector ([#1222](../../pull/1222))
 

--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -228,6 +228,10 @@ class LruCacheMetaclass(type):
                         pass
                 raise exc
             instance._classkey = key
+            if kwargs.get('style') != getattr(cls, '_unstyledStyle', None):
+                subkwargs = kwargs.copy()
+                subkwargs['style'] = getattr(cls, '_unstyledStyle', None)
+                instance._unstyledInstance = subresult = cls(*args, **subkwargs)
             with cacheLock:
                 cache[key] = instance
         return instance


### PR DESCRIPTION
PR #1224 changed how unstyled data was accessed to reduce locking.  As a side effect, if you asked for the dtype from a source with a default style before asking for tile data, the result could be inconsistent. This fixes that.