### PR TITLE
Rename a css class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 - Allow editing metadata in item lists ([#1235](../../pull/1235))
+- Frame selector hotkeys for channel or bands  ([#1233](../../pull/1233))
 
 ## 1.23.1
 

--- a/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
+++ b/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
@@ -297,7 +297,7 @@ export default {
                                     <span class="small-text">Auto Range</span>
                                     <label class="switch">
                                         <span
-                                            :class="allAutoRange() ? 'slider checked' : 'slider'"
+                                            :class="allAutoRange() ? 'onoff-slider checked' : 'onoff-slider'"
                                             @click="() => updateAllAutoRanges(allAutoRange() ? undefined : 0.2)"
                                         />
                                     </label>
@@ -363,7 +363,7 @@ export default {
                             <div class="auto-range-toggle">
                                 <label class="switch">
                                     <span
-                                        :class="autoRange ? 'slider checked' : 'slider'"
+                                        :class="autoRange ? 'onoff-slider checked' : 'onoff-slider'"
                                         @click="() => updateLayerAutoRange(layerName, autoRange ? undefined : 0.2)"
                                     />
                                 </label>
@@ -453,7 +453,7 @@ export default {
   height: 20px;
   margin-top: 5px;
 }
-.slider {
+.onoff-slider {
   position: absolute;
   cursor: pointer;
   top: 0;
@@ -465,13 +465,13 @@ export default {
   transition: .4s;
   border-radius: 34px;
 }
-.slider.checked {
+.onoff-slider.checked {
   background-color: #2196F3;
 }
-.slider:focus{
+.onoff-slider:focus{
   box-shadow: 0 0 1px #2196F3;
 }
-.slider:before {
+.onoff-slider:before {
   position: absolute;
   content: "";
   height: 15px;
@@ -483,7 +483,7 @@ export default {
   transition: .4s;
   border-radius: 50%;
 }
-.slider.checked:before {
+.onoff-slider.checked:before {
   -webkit-transform: translateX(22px);
   -ms-transform: translateX(22px);
   transform: translateX(22px);


### PR DESCRIPTION
slider is too generic; other girder plugins which don't scope properly can do odd things to the slider class.