### PR TITLE
Create, select, and delete image view presets

### DIFF
--- a/girder/girder_large_image/__init__.py
+++ b/girder/girder_large_image/__init__.py
@@ -48,6 +48,7 @@ from .models.image_item import ImageItem
 from .rest import addSystemEndpoints
 from .rest.large_image_resource import LargeImageResource
 from .rest.tiles import TilesItemResource
+from .rest.item_meta import InternalMetadataItemResource
 
 try:
     from importlib.metadata import PackageNotFoundError
@@ -641,6 +642,7 @@ class LargeImagePlugin(GirderPlugin):
 
         girder_tilesource.loadGirderTileSources()
         TilesItemResource(info['apiRoot'])
+        InternalMetadataItemResource(info['apiRoot'])
         info['apiRoot'].large_image = LargeImageResource()
 
         Item().exposeFields(level=AccessType.READ, fields='largeImage')

--- a/girder/girder_large_image/__init__.py
+++ b/girder/girder_large_image/__init__.py
@@ -46,9 +46,9 @@ from .girder_tilesource import getGirderTileSource  # noqa
 from .loadmodelcache import invalidateLoadModelCache
 from .models.image_item import ImageItem
 from .rest import addSystemEndpoints
+from .rest.item_meta import InternalMetadataItemResource
 from .rest.large_image_resource import LargeImageResource
 from .rest.tiles import TilesItemResource
-from .rest.item_meta import InternalMetadataItemResource
 
 try:
     from importlib.metadata import PackageNotFoundError

--- a/girder/girder_large_image/rest/item_meta.py
+++ b/girder/girder_large_image/rest/item_meta.py
@@ -1,0 +1,100 @@
+#############################################################################
+#  Copyright Kitware Inc.
+#
+#  Licensed under the Apache License, Version 2.0 ( the "License" );
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#############################################################################
+
+from girder.api import access
+from girder.api.describe import Description, describeRoute
+from girder.api.rest import loadmodel
+from girder.constants import AccessType, TokenScope
+from girder.api.v1.item import Item
+
+
+class InternalMetadataItemResource(Item):
+    def __init__(self, apiRoot):
+        super().__init__()
+        apiRoot.item.route(
+            "GET", (":itemId", "internal_metadata", ":key"), self.getMetadataKey
+        )
+        apiRoot.item.route(
+            "PUT", (":itemId", "internal_metadata", ":key"), self.updateMetadataKey
+        )
+        apiRoot.item.route(
+            "DELETE", (":itemId", "internal_metadata", ":key"), self.deleteMetadataKey
+        )
+
+    @describeRoute(
+        Description("Get the value for a single internal metadata key on this item.")
+        .param("itemId", "The ID of the item.", paramType="path")
+        .param(
+            "key",
+            "The metadata key to retrieve.",
+            paramType="path",
+            default="meta",
+        )
+        .errorResponse("ID was invalid.")
+        .errorResponse("Read access was denied for the item.", 403)
+    )
+    @access.user(scope=TokenScope.DATA_READ)
+    @loadmodel(model="item", map={"itemId": "item"}, level=AccessType.READ)
+    def getMetadataKey(self, item, key, params):
+        if key not in item:
+            return None
+        return item[key]
+
+    @describeRoute(
+        Description(
+            "Overwrite the value for a single internal metadata key on this item."
+        )
+        .param("itemId", "The ID of the item.", paramType="path")
+        .param(
+            "key",
+            'The metadata key which should have a new value. \
+                The default key, "meta" is equivalent to the external metadata. \
+                Editing the "meta" key is equivalent to using PUT /item/{id}/metadata.',
+            paramType="path",
+            default="meta",
+        )
+        .param(
+            "value",
+            "The new value that should be written for the chosen metadata key",
+            paramType="body",
+        )
+        .errorResponse("ID was invalid.")
+        .errorResponse("Write access was denied for the item.", 403)
+    )
+    @access.user(scope=TokenScope.DATA_WRITE)
+    @loadmodel(model="item", map={"itemId": "item"}, level=AccessType.WRITE)
+    def updateMetadataKey(self, item, key, params):
+        item[key] = self.getBodyJson()
+        self._model.save(item)
+
+    @describeRoute(
+        Description("Delete a single internal metadata key on this item.")
+        .param("itemId", "The ID of the item.", paramType="path")
+        .param(
+            "key",
+            "The metadata key to delete.",
+            paramType="path",
+            default="meta",
+        )
+        .errorResponse("ID was invalid.")
+        .errorResponse("Write access was denied for the item.", 403)
+    )
+    @access.user(scope=TokenScope.DATA_WRITE)
+    @loadmodel(model="item", map={"itemId": "item"}, level=AccessType.READ)
+    def deleteMetadataKey(self, item, key, params):
+        if key in item:
+            del item[key]
+        self._model.save(item)

--- a/girder/girder_large_image/rest/item_meta.py
+++ b/girder/girder_large_image/rest/item_meta.py
@@ -17,37 +17,37 @@
 from girder.api import access
 from girder.api.describe import Description, describeRoute
 from girder.api.rest import loadmodel
-from girder.constants import AccessType, TokenScope
 from girder.api.v1.item import Item
+from girder.constants import AccessType, TokenScope
 
 
 class InternalMetadataItemResource(Item):
     def __init__(self, apiRoot):
         super().__init__()
         apiRoot.item.route(
-            "GET", (":itemId", "internal_metadata", ":key"), self.getMetadataKey
+            'GET', (':itemId', 'internal_metadata', ':key'), self.getMetadataKey
         )
         apiRoot.item.route(
-            "PUT", (":itemId", "internal_metadata", ":key"), self.updateMetadataKey
+            'PUT', (':itemId', 'internal_metadata', ':key'), self.updateMetadataKey
         )
         apiRoot.item.route(
-            "DELETE", (":itemId", "internal_metadata", ":key"), self.deleteMetadataKey
+            'DELETE', (':itemId', 'internal_metadata', ':key'), self.deleteMetadataKey
         )
 
     @describeRoute(
-        Description("Get the value for a single internal metadata key on this item.")
-        .param("itemId", "The ID of the item.", paramType="path")
+        Description('Get the value for a single internal metadata key on this item.')
+        .param('itemId', 'The ID of the item.', paramType='path')
         .param(
-            "key",
-            "The metadata key to retrieve.",
-            paramType="path",
-            default="meta",
+            'key',
+            'The metadata key to retrieve.',
+            paramType='path',
+            default='meta',
         )
-        .errorResponse("ID was invalid.")
-        .errorResponse("Read access was denied for the item.", 403)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Read access was denied for the item.', 403)
     )
     @access.user(scope=TokenScope.DATA_READ)
-    @loadmodel(model="item", map={"itemId": "item"}, level=AccessType.READ)
+    @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def getMetadataKey(self, item, key, params):
         if key not in item:
             return None
@@ -55,45 +55,45 @@ class InternalMetadataItemResource(Item):
 
     @describeRoute(
         Description(
-            "Overwrite the value for a single internal metadata key on this item."
+            'Overwrite the value for a single internal metadata key on this item.'
         )
-        .param("itemId", "The ID of the item.", paramType="path")
+        .param('itemId', 'The ID of the item.', paramType='path')
         .param(
-            "key",
+            'key',
             'The metadata key which should have a new value. \
                 The default key, "meta" is equivalent to the external metadata. \
                 Editing the "meta" key is equivalent to using PUT /item/{id}/metadata.',
-            paramType="path",
-            default="meta",
+            paramType='path',
+            default='meta',
         )
         .param(
-            "value",
-            "The new value that should be written for the chosen metadata key",
-            paramType="body",
+            'value',
+            'The new value that should be written for the chosen metadata key',
+            paramType='body',
         )
-        .errorResponse("ID was invalid.")
-        .errorResponse("Write access was denied for the item.", 403)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Write access was denied for the item.', 403)
     )
     @access.user(scope=TokenScope.DATA_WRITE)
-    @loadmodel(model="item", map={"itemId": "item"}, level=AccessType.WRITE)
+    @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.WRITE)
     def updateMetadataKey(self, item, key, params):
         item[key] = self.getBodyJson()
         self._model.save(item)
 
     @describeRoute(
-        Description("Delete a single internal metadata key on this item.")
-        .param("itemId", "The ID of the item.", paramType="path")
+        Description('Delete a single internal metadata key on this item.')
+        .param('itemId', 'The ID of the item.', paramType='path')
         .param(
-            "key",
-            "The metadata key to delete.",
-            paramType="path",
-            default="meta",
+            'key',
+            'The metadata key to delete.',
+            paramType='path',
+            default='meta',
         )
-        .errorResponse("ID was invalid.")
-        .errorResponse("Write access was denied for the item.", 403)
+        .errorResponse('ID was invalid.')
+        .errorResponse('Write access was denied for the item.', 403)
     )
     @access.user(scope=TokenScope.DATA_WRITE)
-    @loadmodel(model="item", map={"itemId": "item"}, level=AccessType.READ)
+    @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def deleteMetadataKey(self, item, key, params):
         if key in item:
             del item[key]

--- a/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
+++ b/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
@@ -101,6 +101,7 @@ export default {
             this.fetchCurrentFrameHistogram()
         },
         initializeStateFromStyle() {
+            this.enabledLayers = []
             const styleArray = this.currentStyle.bands
             this.layers.forEach((layerName) => {
                 const layerInfo = this.compositeLayerInfo[layerName]
@@ -112,7 +113,9 @@ export default {
                         && currentLayerStyle.min.includes("min:")
                         && currentLayerStyle.max.includes("max:")
                     ) {
-                        currentLayerStyle.autoRange = currentLayerStyle.min.replace("min:", '')
+                        currentLayerStyle.autoRange = parseFloat(
+                            currentLayerStyle.min.replace("min:", '')
+                        ) * 100
                         currentLayerStyle.min = undefined
                         currentLayerStyle.max = undefined
                     }
@@ -141,7 +144,7 @@ export default {
             });
         },
         toggleEnableAll() {
-            if (this.enabledLayers !== this.layers) {
+            if (!this.layers.every((l) => this.enabledLayers.includes(l))) {
                 this.enabledLayers = this.layers
             } else {
                 this.enabledLayers = []
@@ -323,7 +326,7 @@ export default {
                             <input
                                 type="checkbox"
                                 class="input-80"
-                                :checked="enabledLayers === layers"
+                                :checked="layers.every((l) => enabledLayers.includes(l))"
                                 @input="toggleEnableAll"
                             >
                         </th>

--- a/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
+++ b/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
@@ -124,6 +124,12 @@ export default {
             this.layers.forEach((layer) => {
                 this.compositeLayerInfo[layer].enabled = this.enabledLayers.includes(layer);
             })
+            const autoRanges = Object.entries(this.compositeLayerInfo)
+                .map(([index, info]) => info.autoRange)
+                .filter((a) => a !== undefined)
+            if (autoRanges.every((v) => v === autoRanges[0])) {
+                this.autoRangeForAll = autoRanges[0]
+            }
         },
         fetchCurrentFrameHistogram() {
             restRequest({

--- a/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
+++ b/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
@@ -121,7 +121,9 @@ export default {
                     {}, layerInfo, currentLayerStyle
                 )
             })
-            this.updateActiveLayers()
+            this.layers.forEach((layer) => {
+                this.compositeLayerInfo[layer].enabled = this.enabledLayers.includes(layer);
+            })
         },
         fetchCurrentFrameHistogram() {
             restRequest({
@@ -272,6 +274,9 @@ export default {
             } else {
                 document.removeEventListener('keydown', this.keyHandler)
             }
+        },
+        currentStyle() {
+            this.initializeStateFromStyle()
         }
     }
 }

--- a/girder/girder_large_image/web_client/vue/components/DualInput.vue
+++ b/girder/girder_large_image/web_client/vue/components/DualInput.vue
@@ -8,6 +8,9 @@ export default {
         }
     },
     watch: {
+        currentValue(v) {
+            this.value = v
+        },
         value(v) {
             this.$emit('updateValue', v);
         }

--- a/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
+++ b/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
@@ -48,10 +48,8 @@ export default Vue.extend({
             this.currentFrame = frame
             this.indexInfo = Object.fromEntries(
                 Object.entries(this.indexInfo)
-                .sort((a, b) => a[1].stride < b[1].stride)
                 .map(([index, info]) => {
-                    info.current = Math.floor(frame / info.stride)
-                    frame -= info.current * info.stride
+                    info.current = Math.floor(frame / info.stride) % (info.range + 1)
                     return [index, info]
                 })
             )

--- a/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
+++ b/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
@@ -1,10 +1,12 @@
 <script>
 import Vue from 'vue';
 import CompositeLayers from './CompositeLayers.vue';
-import DualInput from './DualInput.vue'
+import DualInput from './DualInput.vue';
+import PresetsMenu from './PresetsMenu.vue';
+
 export default Vue.extend({
     props: ['itemId', 'imageMetadata', 'frameUpdate'],
-    components: { CompositeLayers, DualInput },
+    components: { CompositeLayers, DualInput, PresetsMenu },
     data() {
         return {
             loaded: false,
@@ -39,6 +41,15 @@ export default Vue.extend({
         }
     },
     methods: {
+        setCurrentMode(mode) {
+            this.currentModeId = mode.id
+        },
+        setCurrentFrame(frame) {
+            this.currentFrame = frame
+            this.indices.forEach((index) => {
+                this.indexInfo[index].current = this.currentFrame / this.indexInfo[index].stride
+            })
+        },
         updateStyle(idx, style) {
             this.$set(this.style, idx, style);
             this.update()
@@ -48,6 +59,7 @@ export default Vue.extend({
             this.update();
         },
         updateFrameSlider(frame) {
+            this.currentFrame = frame
             this.frameUpdate(frame, undefined);
         },
         update() {
@@ -182,6 +194,15 @@ export default Vue.extend({
                     {{ mode.name }}
                 </option>
             </select>
+            <presets-menu
+                :itemId="itemId"
+                :currentMode="sliderModes.find((m) => m.id === currentModeId)"
+                :currentFrame="currentFrame"
+                :currentStyle="style[currentModeId]"
+                @setCurrentMode="setCurrentMode"
+                @setCurrentFrame="setCurrentFrame"
+                @updateStyle="updateStyle"
+            />
         </div>
         <dual-input
             v-if="currentModeId === 0"
@@ -210,6 +231,7 @@ export default Vue.extend({
                 v-if="imageMetadata.channels && modesShown[2]"
                 :itemId="itemId"
                 :currentFrame="currentFrame"
+                :currentStyle="style[2]"
                 :layers="imageMetadata.channels"
                 :layerMap="imageMetadata.channelmap"
                 :active="currentModeId === 2"
@@ -221,6 +243,7 @@ export default Vue.extend({
                 v-if="imageMetadata.bands && modesShown[3]"
                 :itemId="itemId"
                 :currentFrame="currentFrame"
+                :currentStyle="style[3]"
                 :layers="imageMetadata.bands"
                 :layerMap="undefined"
                 :active="currentModeId === 3"

--- a/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
+++ b/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
@@ -46,9 +46,15 @@ export default Vue.extend({
         },
         setCurrentFrame(frame) {
             this.currentFrame = frame
-            this.indices.forEach((index) => {
-                this.indexInfo[index].current = this.currentFrame / this.indexInfo[index].stride
-            })
+            this.indexInfo = Object.fromEntries(
+                Object.entries(this.indexInfo)
+                .sort((a, b) => a[1].stride < b[1].stride)
+                .map(([index, info]) => {
+                    info.current = Math.floor(frame / info.stride)
+                    frame -= info.current * info.stride
+                    return [index, info]
+                })
+            )
         },
         updateStyle(idx, style) {
             this.$set(this.style, idx, style);

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -97,7 +97,7 @@ export default {
         Image View Presets:
         <select v-model="selectedPreset">
             <option v-if="availablePresets.length === 0" :value="undefined" selected disabled>
-                No presets available.
+                No presets available
             </option>
             <option v-else :value="undefined" selected disabled>
                 Select a preset

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -1,0 +1,133 @@
+<script>
+import { restRequest } from '@girder/core/rest';
+
+export default {
+    props: ['itemId', 'currentMode', 'currentFrame', 'currentStyle'],
+    emits: ['setCurrentMode', 'setCurrentFrame', 'updateStyle'],
+    data() {
+        return {
+            availablePresets: [],
+            selectedPreset: undefined,
+            showPresetCreation: false,
+            newPresetName: undefined,
+        }
+    },
+    methods: {
+        getPresets() {
+            restRequest({
+                type: 'GET',
+                url: 'item/' + this.itemId + '/internal_metadata/presets',
+            }).then((presets) => {
+                if (presets) {
+                    this.availablePresets = presets
+                }
+            })
+        },
+        addPreset() {
+            const newPreset = {
+                'name': this.newPresetName || this.generatedPresetName,
+                'mode': this.currentMode,
+                'frame': this.currentFrame,
+                'style': this.currentStyle,
+            }
+            this.availablePresets.push(newPreset)
+            this.selectedPreset = newPreset.name
+            this.savePresetsList()
+        },
+        deleteSelectedPreset() {
+            this.availablePresets = this.availablePresets.filter((p) => p.name !== this.selectedPreset)
+            this.selectedPreset = undefined
+            this.savePresetsList()
+        },
+        savePresetsList() {
+            restRequest({
+                type: 'PUT',
+                url: 'item/' + this.itemId + '/internal_metadata/presets',
+                data: JSON.stringify(this.availablePresets),
+                contentType: 'application/json',
+            })
+        }
+    },
+    computed: {
+        generatedPresetName() {
+            let name = `${this.currentMode.name} control - Frame ${this.currentFrame}`;
+            if (this.currentMode.id === 2) {
+                name = `${this.currentStyle.bands.length} channels`
+            } else if (this.currentMode.id === 3) {
+                name = `${this.currentStyle.bands.length} bands`
+            }
+            return name;
+        }
+    },
+    watch: {
+        selectedPreset() {
+            if (this.selectedPreset) {
+                const preset = this.availablePresets.find((p) => p.name === this.selectedPreset)
+                if (preset.mode && preset.mode.id !== undefined) {
+                    this.$emit('setCurrentMode', preset.mode);
+                }
+                if (preset.frame !== undefined) {
+                    this.$emit('setCurrentFrame', preset.frame)
+                }
+                if (preset.style && Object.keys(preset.style.bands).length) {
+                    this.$emit('updateStyle', preset.mode.id, preset.style)
+                }
+            }
+        }
+    },
+    mounted() {
+        this.getPresets()
+    },
+}
+</script>
+
+<template>
+    <div class="presets-menu">
+        Image View Presets:
+        <select v-model="selectedPreset">
+            <option v-if="availablePresets.length === 0" :value="undefined" selected disabled>
+                No presets available.
+            </option>
+            <option v-else :value="undefined" selected disabled>
+                Select a preset
+            </option>
+            <option
+                v-for="preset in availablePresets"
+                :key="preset.id"
+                >
+                {{ preset.name }}
+            </option>
+        </select>
+        <i
+            class="icon-trash"
+            v-if="selectedPreset"
+            @click="deleteSelectedPreset"
+        />
+        <i
+            class="icon-plus"
+            @click="showPresetCreation = true"
+        />
+        <div v-if="showPresetCreation" class="preset-creation">
+            Save Current State as New Preset:
+            <input
+                v-model="newPresetName"
+                :placeholder="generatedPresetName"
+            >
+            <button @click="addPreset">
+                Save Preset
+            </button>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.presets-menu {
+    float: right;
+}
+.preset-creation {
+    display: flex;
+    flex-direction: column;
+    align-items: end;
+    padding-top: 5px;
+}
+</style>

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -116,7 +116,7 @@ export default {
         />
         <i
             class="icon-plus"
-            @click="showPresetCreation = true"
+            @click="showPresetCreation = !showPresetCreation"
         />
         <div v-if="showPresetCreation" class="preset-creation">
             Save Current State as New Preset:

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -24,21 +24,25 @@ export default {
                 }
             })
         },
-        addPreset() {
+        addPreset(e, overwrite=false) {
+            this.newPresetName = this.newPresetName.trim()
             const newPreset = {
                 'name': this.newPresetName || this.generatedPresetName,
                 'mode': this.currentMode,
                 'frame': this.currentFrame,
                 'style': this.currentStyle,
             }
-            if (this.availablePresets.find((p) => p.name === newPreset.name)) {
-                this.errorMessage = `There is already a preset named "${newPreset.name}".`
+            if (!overwrite && this.availablePresets.find((p) => p.name === newPreset.name)) {
+                this.errorMessage = `There is already a preset named "${newPreset.name}". Overwrite "${newPreset.name}"?`
             } else {
+                this.availablePresets = this.availablePresets.filter((p) => p.name !== newPreset.name)
                 this.availablePresets.push(newPreset)
                 this.selectedPreset = newPreset.name
                 this.savePresetsList()
+                this.newPresetName = undefined
+                this.errorMessage = undefined
+                this.showPresetCreation = false
             }
-            this.newPresetName = undefined
         },
         deleteSelectedPreset() {
             this.availablePresets = this.availablePresets.filter((p) => p.name !== this.selectedPreset)
@@ -125,8 +129,11 @@ export default {
                 :placeholder="generatedPresetName"
             >
             <span class="red--text">{{ errorMessage }}</span>
-            <button @click="addPreset">
+            <button @click="addPreset" v-if="errorMessage === undefined">
                 Save Preset
+            </button>
+            <button @click="(e) => addPreset(e, true)" v-else>
+                Update Preset
             </button>
         </div>
     </div>
@@ -135,6 +142,7 @@ export default {
 <style scoped>
 .presets-menu {
     float: right;
+    text-align: right;
 }
 .preset-creation {
     display: flex;
@@ -144,5 +152,6 @@ export default {
 }
 .red--text {
     color: red;
+    max-width: 250px;
 }
 </style>

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -10,6 +10,7 @@ export default {
             selectedPreset: undefined,
             showPresetCreation: false,
             newPresetName: undefined,
+            errorMessage: undefined,
         }
     },
     methods: {
@@ -30,9 +31,14 @@ export default {
                 'frame': this.currentFrame,
                 'style': this.currentStyle,
             }
-            this.availablePresets.push(newPreset)
-            this.selectedPreset = newPreset.name
-            this.savePresetsList()
+            if (this.availablePresets.find((p) => p.name === newPreset.name)) {
+                this.errorMessage = `There is already a preset named "${newPreset.name}".`
+            } else {
+                this.availablePresets.push(newPreset)
+                this.selectedPreset = newPreset.name
+                this.savePresetsList()
+            }
+            this.newPresetName = undefined
         },
         deleteSelectedPreset() {
             this.availablePresets = this.availablePresets.filter((p) => p.name !== this.selectedPreset)
@@ -60,6 +66,11 @@ export default {
         }
     },
     watch: {
+        newPresetName() {
+            if (this.newPresetName){
+                this.errorMessage = undefined;
+            }
+        },
         selectedPreset() {
             if (this.selectedPreset) {
                 const preset = this.availablePresets.find((p) => p.name === this.selectedPreset)
@@ -113,6 +124,7 @@ export default {
                 v-model="newPresetName"
                 :placeholder="generatedPresetName"
             >
+            <span class="red--text">{{ errorMessage }}</span>
             <button @click="addPreset">
                 Save Preset
             </button>
@@ -129,5 +141,8 @@ export default {
     flex-direction: column;
     align-items: end;
     padding-top: 5px;
+}
+.red--text {
+    color: red;
 }
 </style>

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -85,6 +85,7 @@ export default {
                     this.$emit('setCurrentFrame', preset.frame)
                 }
                 if (preset.style && Object.keys(preset.style.bands).length) {
+                    console.log(preset.style)
                     this.$emit('updateStyle', preset.mode.id, preset.style)
                 }
             }


### PR DESCRIPTION
This PR adds a widget for Image View Presets on the righthand side of the image controls. 
The user doe the following: 
1. select from existing presets to apply one
2. use the plus button to name and save the current state as a new preset
3. delete the selected preset 

Requesting @manthey to take a look, since this will probably need a few iterations.

![image](https://github.com/girder/large_image/assets/44912689/29db4a2e-defb-4e7f-94ff-f5bd2ed027c3)
