### PR TITLE
Harmonize the girder code paths for image conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Improvements
 - Allow editing metadata in item lists ([#1235](../../pull/1235))
-- Frame selector hotkeys for channel or bands  ([#1233](../../pull/1233))
+- Frame selector hotkeys for channel or bands ([#1233](../../pull/1233))
+- More consistency in how local and remote image conversions are performed in Girder ([#1238](../../pull/1238))
 
 ## 1.23.1
 

--- a/girder/girder_large_image/__init__.py
+++ b/girder/girder_large_image/__init__.py
@@ -95,6 +95,11 @@ def _postUpload(event):
         if fileObj['name'].endswith('.geo.tiff'):
             item['largeImage']['sourceName'] = 'gdal'
         Item().save(item)
+        # If the job looks finished, update it once more to force notifications
+        if 'jobId' in item['largeImage'] and item['largeImage'].get('notify'):
+            job = Job().load(item['largeImage']['jobId'], force=True)
+            if job and job['status'] == JobStatus.SUCCESS:
+                Job().save(job)
 
 
 def _updateJob(event):

--- a/girder/girder_large_image/rest/tiles.py
+++ b/girder/girder_large_image/rest/tiles.py
@@ -198,6 +198,8 @@ class TilesItemResource(ItemResource):
         .param('notify', 'If a job is required to create the large image, '
                'a nofication can be sent when it is complete.',
                dataType='boolean', default=True, required=False)
+        .param('localJob', 'If true, run as a local job; if false, run via '
+               'the remote worker', dataType='boolean', required=False)
         .param('tileSize', 'Tile size', dataType='int', default=256,
                required=False)
         .param('compression', 'Internal compression format', required=False,
@@ -215,9 +217,9 @@ class TilesItemResource(ItemResource):
         .param('cr', 'JP2K target compression ratio where 1 is lossless',
                dataType='int', required=False)
         .param('concurrent', 'Suggested number of maximum concurrent '
-               'processes to use during conversion.  Values <= 0 use the '
-               'number of logical cpus less that value.  Default is -2.',
-               dataType='int', required=False)
+               'processes to use during conversion.  Values less than or '
+               'equal to 0 use the number of logical cpus less that value.  '
+               'Default is -2.', dataType='int', required=False)
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.WRITE)
@@ -237,11 +239,14 @@ class TilesItemResource(ItemResource):
         token = self.getCurrentToken()
         notify = self.boolParam('notify', params, default=True)
         params.pop('notify', None)
+        localJob = self.boolParam('localJob', params, default=None)
+        params.pop('localJob', None)
         try:
             return self.imageItemModel.createImageItem(
                 item, largeImageFile, user, token,
                 createJob='always' if self.boolParam('force', params, default=False) else True,
                 notify=notify,
+                localJob=localJob,
                 **params)
         except TileGeneralError as e:
             raise RestException(e.args[0])
@@ -256,8 +261,7 @@ class TilesItemResource(ItemResource):
         .param('folderId', 'The destination folder.', required=False)
         .param('name', 'A new name for the output item.', required=False)
         .param('localJob', 'If true, run as a local job; if false, run via '
-               'the remote worker', dataType='boolean', default=True,
-               required=False)
+               'the remote worker', dataType='boolean', required=False)
         .param('tileSize', 'Tile size', dataType='int', default=256,
                required=False)
         .param('onlyFrame', 'Only convert a specific 0-based frame of a '
@@ -280,9 +284,9 @@ class TilesItemResource(ItemResource):
         .param('cr', 'JP2K target compression ratio where 1 is lossless',
                dataType='int', required=False)
         .param('concurrent', 'Suggested number of maximum concurrent '
-               'processes to use during conversion.  Values <= 0 use the '
-               'number of logical cpus less that value.  Default is -2.',
-               dataType='int', required=False)
+               'processes to use during conversion.  Values less than or '
+               'equal to 0 use the number of logical cpus less that value.  '
+               'Default is -2.', dataType='int', required=False)
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)

--- a/girder/girder_large_image/web_client/views/fileList.js
+++ b/girder/girder_large_image/web_client/views/fileList.js
@@ -53,7 +53,7 @@ wrap(FileListWidget, 'render', function (render) {
         restRequest({
             type: 'POST',
             url: 'item/' + this.parentItem.id + '/tiles',
-            data: {fileId: fileId, notify: true, force: !!(e.originalEvent || {}).ctrlKey},
+            data: {fileId: fileId, notify: true, force: !!(e.originalEvent || {}).ctrlKey, localJob: true},
             error: function (error) {
                 if (error.status !== 0) {
                     events.trigger('g:alert', {

--- a/girder_annotation/girder_large_image_annotation/web_client/views/annotationListWidget.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/annotationListWidget.js
@@ -59,7 +59,7 @@ const AnnotationListWidget = View.extend({
         }).done((createResp) => {
             this.createResp = createResp;
             largeImageConfig.getConfigFile(this.model.get('folderId')).done((val) => {
-                this._liconfig = val;
+                this._liconfig = val || {};
                 this._confList = this._liconfig.annotationList || {
                     columns: [{
                         type: 'record',

--- a/utilities/tasks/large_image_tasks/tasks.py
+++ b/utilities/tasks/large_image_tasks/tasks.py
@@ -101,12 +101,18 @@ def convert_image_job(job):
     from girder.models.user import User
 
     kwargs = job['kwargs']
+    toFolder = kwargs.pop('toFolder', True)
     item = Item().load(kwargs.pop('itemId'), force=True)
     fileObj = File().load(kwargs.pop('fileId'), force=True)
     userId = kwargs.pop('userId', None)
     user = User().load(userId, force=True) if userId else None
-    folder = Folder().load(kwargs.pop('folderId', item['folderId']),
-                           user=user, level=AccessType.WRITE)
+    if toFolder:
+        parentType = 'folder'
+        parent = Folder().load(kwargs.pop('folderId', item['folderId']),
+                               user=user, level=AccessType.WRITE)
+    else:
+        parentType = 'item'
+        parent = item
     name = kwargs.pop('name', None)
 
     job = Job().updateJob(
@@ -138,8 +144,8 @@ def convert_image_job(job):
                     fobj,
                     size=os.path.getsize(dest),
                     name=name or os.path.basename(dest),
-                    parentType='folder',
-                    parent=folder,
+                    parentType=parentType,
+                    parent=parent,
                     user=user,
                 )
                 job = Job().load(job['_id'], force=True)


### PR DESCRIPTION
This makes it easier to force convert images that exist as multiple file images.  Before, the reconversion would be sent to a worker; now it can optionally use a local job which can take advantage of local or fuse paths.

Additionally, there is less code duplication.