### PR TITLE
Presets from Large Image Configuration file

### DIFF
--- a/docs/girder_config_options.rst
+++ b/docs/girder_config_options.rst
@@ -19,7 +19,7 @@ The yaml file has the following structure:
 
     ---
     # most settings are key-value pairs, where the value could be another
-    # directionary with keys and values, lists, or other valid data.
+    # dictionary with keys and values, lists, or other valid data.
     <key>: <value>
     # The access key is special
     access:
@@ -191,6 +191,139 @@ By default, item metadata can contain any keys and values.  These can be given b
         # Exclusive values can be specified instead
         # exclusiveMinimum: 0
         # exclusiveMaximum: 10
+
+Image View Presets
+...........
+
+This is used to specify a list of default presets for viewing images in the folder.
+Presets can be customized and saved in the GeoJS Image Viewer.
+To retrieve saved presets, use http://[serverURL]/api/v1/item/[itemID]/internal_metadata/presets.
+You can convert the response to YAML and paste it into the `imagePresets` key in your config file.
+
+Each preset can specify a name, a view mode, an image frame, and style options.
+- The name of a preset can be any string which uniquely identifies the preset.
+- There are four options for mode:
+  1. Frame control
+    id: 0
+    name: Frame
+  2. Axis control
+    id: 1
+    name: Axis
+  3. Channel Compositing
+    id: 2
+    name: Channel Compositing
+  4. Band Compositing
+    id: 3
+    name: Band Compositing
+- The frame of a preset is a 0-based index representing a single frame in a multiframe image.
+  For single-frame images, this value will always be 0.
+  For channel compositing, each channel will have a `framedelta` value which represents distance from this base frame value.
+  The result of channel compositing is multiple frames (calculated via framedelta) composited together.
+- The style of a preset is a dictionary with a schema similar to the [style schema for tile retrieval](tilesource_options.rst#style).
+  The value for a preset's style consists of a band definition, where each band may have the following:
+  1. `band`: A 1-based index of a band within the current frame
+  2. `framedelta`: An integer representing distance from the current frame, used for compositing multiple frames together
+  3. `palette`: A hexidecimal string beginning with "#" representing a color to stain this frame
+  4. `min`: The value to map to the first palette value
+  5. `max`: The value to map to the last palette value
+  6. `autoRange`: A shortcut for excluding a percentage from each end of the value distribution in the image. Express as a float.
+
+The YAML below includes some example presets.
+
+::
+
+    ---
+    # If present, each preset in this list will be added to the preset list
+    # of every image in the folder for which the preset is applicable
+    imagePresets:
+    - name: Frame control - Frame 4
+      frame: 4
+      mode:
+        id: 0
+        name: Frame
+    - name: Axis control - Frame 25
+      frame: 25
+      mode:
+        id: 1
+        name: Axis
+    - name: 3 channels
+      frame: 0
+      mode:
+        id: 2
+        name: Channel Compositing
+      style:
+        bands:
+        - framedelta: 0
+          palette: "#0000FF"
+        - framedelta: 1
+          palette: "#FF0000"
+        - framedelta: 2
+          palette: "#00FF00"
+    - name: 3 bands
+      frame: 0
+      mode:
+        id: 3
+        name: Band Compositing
+      style:
+        bands:
+        - band: 1
+          palette: "#0000FF"
+        - band: 2
+          palette: "#FF0000"
+        - band: 3
+          palette: "#00FF00"
+    - name: Channels with Min and Max
+      frame: 0
+      mode:
+        id: 2
+        name: Channel Compositing
+      style:
+        bands:
+        - min: 18000
+          max: 43000
+          framedelta: 0
+          palette: "#0000FF"
+        - min: 18000
+          max: 43000
+          framedelta: 1
+          palette: "#FF0000"
+        - min: 18000
+          max: 43000
+          framedelta: 2
+          palette: "#00FF00"
+        - min: 18000
+          max: 43000
+          framedelta: 3
+          palette: "#FFFF00"
+    - name: Auto Ranged Channels
+      frame: 0
+      mode:
+        id: 2
+        name: Channel Compositing
+      style:
+        bands:
+        - autoRange: 0.2
+          framedelta: 0
+          palette: "#0000FF"
+        - autoRange: 0.2
+          framedelta: 1
+          palette: "#FF0000"
+        - autoRange: 0.2
+          framedelta: 2
+          palette: "#00FF00"
+        - autoRange: 0.2
+          framedelta: 3
+          palette: "#FFFF00"
+        - autoRange: 0.2
+          framedelta: 4
+          palette: "#FF00FF"
+        - autoRange: 0.2
+          framedelta: 5
+          palette: "#00FFFF"
+        - autoRange: 0.2
+          framedelta: 6
+          palette: "#FF8000"
+
 
 Editing Configuration Files
 ---------------------------

--- a/docs/girder_config_options.rst
+++ b/docs/girder_config_options.rst
@@ -193,7 +193,7 @@ By default, item metadata can contain any keys and values.  These can be given b
         # exclusiveMaximum: 10
 
 Image View Presets
-...........
+..................
 
 This is used to specify a list of default presets for viewing images in the folder.
 Presets can be customized and saved in the GeoJS Image Viewer.

--- a/docs/girder_config_options.rst
+++ b/docs/girder_config_options.rst
@@ -201,24 +201,28 @@ To retrieve saved presets, use http://[serverURL]/api/v1/item/[itemID]/internal_
 You can convert the response to YAML and paste it into the `imagePresets` key in your config file.
 
 Each preset can specify a name, a view mode, an image frame, and style options.
+
 - The name of a preset can be any string which uniquely identifies the preset.
+
 - There are four options for mode:
-  1. Frame control
-    id: 0
-    name: Frame
-  2. Axis control
-    id: 1
-    name: Axis
-  3. Channel Compositing
-    id: 2
-    name: Channel Compositing
-  4. Band Compositing
-    id: 3
-    name: Band Compositing
+    1. Frame control
+        id: 0
+        name: Frame
+    2. Axis control
+        id: 1
+        name: Axis
+    3. Channel Compositing
+        id: 2
+        name: Channel Compositing
+    4. Band Compositing
+        id: 3
+        name: Band Compositing
+
 - The frame of a preset is a 0-based index representing a single frame in a multiframe image.
   For single-frame images, this value will always be 0.
   For channel compositing, each channel will have a `framedelta` value which represents distance from this base frame value.
   The result of channel compositing is multiple frames (calculated via framedelta) composited together.
+
 - The style of a preset is a dictionary with a schema similar to the [style schema for tile retrieval](tilesource_options.rst#style).
   The value for a preset's style consists of a band definition, where each band may have the following:
   1. `band`: A 1-based index of a band within the current frame

--- a/docs/girder_config_options.rst
+++ b/docs/girder_config_options.rst
@@ -206,16 +206,24 @@ Each preset can specify a name, a view mode, an image frame, and style options.
 - The name of a preset can be any string which uniquely identifies the preset.
 
 - There are four options for mode:
+
   - Frame control
+
     - id: 0
     - name: Frame
+
   - Axis control
+
     - id: 1
     - name: Axis
+
   - Channel Compositing
+
     - id: 2
     - name: Channel Compositing
+
   - Band Compositing
+
     - id: 3
     - name: Band Compositing
 
@@ -225,6 +233,7 @@ Each preset can specify a name, a view mode, an image frame, and style options.
   The result of channel compositing is multiple frames (calculated via framedelta) composited together.
 
 - The style of a preset is a dictionary with a schema similar to the [style schema for tile retrieval](tilesource_options.rst#style). The value for a preset's style consists of a band definition, where each band may have the following:
+
   - `band`: A 1-based index of a band within the current frame
   - `framedelta`: An integer representing distance from the current frame, used for compositing multiple frames together
   - `palette`: A hexidecimal string beginning with "#" representing a color to stain this frame

--- a/docs/girder_config_options.rst
+++ b/docs/girder_config_options.rst
@@ -192,8 +192,9 @@ By default, item metadata can contain any keys and values.  These can be given b
         # exclusiveMinimum: 0
         # exclusiveMaximum: 10
 
+
 Image Frame Presets
-...................
+....................
 
 This is used to specify a list of default presets for viewing images in the folder.
 Presets can be customized and saved in the GeoJS Image Viewer.
@@ -205,16 +206,16 @@ Each preset can specify a name, a view mode, an image frame, and style options.
 - The name of a preset can be any string which uniquely identifies the preset.
 
 - There are four options for mode:
-    1. Frame control
+    - Frame control
         id: 0
         name: Frame
-    2. Axis control
+    - Axis control
         id: 1
         name: Axis
-    3. Channel Compositing
+    - Channel Compositing
         id: 2
         name: Channel Compositing
-    4. Band Compositing
+    - Band Compositing
         id: 3
         name: Band Compositing
 
@@ -225,12 +226,12 @@ Each preset can specify a name, a view mode, an image frame, and style options.
 
 - The style of a preset is a dictionary with a schema similar to the [style schema for tile retrieval](tilesource_options.rst#style).
   The value for a preset's style consists of a band definition, where each band may have the following:
-  1. `band`: A 1-based index of a band within the current frame
-  2. `framedelta`: An integer representing distance from the current frame, used for compositing multiple frames together
-  3. `palette`: A hexidecimal string beginning with "#" representing a color to stain this frame
-  4. `min`: The value to map to the first palette value
-  5. `max`: The value to map to the last palette value
-  6. `autoRange`: A shortcut for excluding a percentage from each end of the value distribution in the image. Express as a float.
+    - `band`: A 1-based index of a band within the current frame
+    - `framedelta`: An integer representing distance from the current frame, used for compositing multiple frames together
+    - `palette`: A hexidecimal string beginning with "#" representing a color to stain this frame
+    - `min`: The value to map to the first palette value
+    - `max`: The value to map to the last palette value
+    - `autoRange`: A shortcut for excluding a percentage from each end of the value distribution in the image. Express as a float.
 
 The YAML below includes some example presets.
 

--- a/docs/girder_config_options.rst
+++ b/docs/girder_config_options.rst
@@ -191,12 +191,6 @@ By default, item metadata can contain any keys and values.  These can be given b
         # Exclusive values can be specified instead
         # exclusiveMinimum: 0
         # exclusiveMaximum: 10
-      # Your can hide specific metadata keys by adding the hidden: true flag.
-      # These keys will not be shown in the list of metadata, even if they
-      # exist.
-      -
-        value: internalProperty
-        hidden: true
 
 
 Image Frame Presets
@@ -212,32 +206,31 @@ Each preset can specify a name, a view mode, an image frame, and style options.
 - The name of a preset can be any string which uniquely identifies the preset.
 
 - There are four options for mode:
-    - Frame control
-        id: 0
-        name: Frame
-    - Axis control
-        id: 1
-        name: Axis
-    - Channel Compositing
-        id: 2
-        name: Channel Compositing
-    - Band Compositing
-        id: 3
-        name: Band Compositing
+  - Frame control
+    - id: 0
+    - name: Frame
+  - Axis control
+    - id: 1
+    - name: Axis
+  - Channel Compositing
+    - id: 2
+    - name: Channel Compositing
+  - Band Compositing
+    - id: 3
+    - name: Band Compositing
 
 - The frame of a preset is a 0-based index representing a single frame in a multiframe image.
   For single-frame images, this value will always be 0.
   For channel compositing, each channel will have a `framedelta` value which represents distance from this base frame value.
   The result of channel compositing is multiple frames (calculated via framedelta) composited together.
 
-- The style of a preset is a dictionary with a schema similar to the [style schema for tile retrieval](tilesource_options.rst#style).
-  The value for a preset's style consists of a band definition, where each band may have the following:
-    - `band`: A 1-based index of a band within the current frame
-    - `framedelta`: An integer representing distance from the current frame, used for compositing multiple frames together
-    - `palette`: A hexidecimal string beginning with "#" representing a color to stain this frame
-    - `min`: The value to map to the first palette value
-    - `max`: The value to map to the last palette value
-    - `autoRange`: A shortcut for excluding a percentage from each end of the value distribution in the image. Express as a float.
+- The style of a preset is a dictionary with a schema similar to the [style schema for tile retrieval](tilesource_options.rst#style). The value for a preset's style consists of a band definition, where each band may have the following:
+  - `band`: A 1-based index of a band within the current frame
+  - `framedelta`: An integer representing distance from the current frame, used for compositing multiple frames together
+  - `palette`: A hexidecimal string beginning with "#" representing a color to stain this frame
+  - `min`: The value to map to the first palette value
+  - `max`: The value to map to the last palette value
+  - `autoRange`: A shortcut for excluding a percentage from each end of the value distribution in the image. Express as a float.
 
 The YAML below includes some example presets.
 

--- a/docs/girder_config_options.rst
+++ b/docs/girder_config_options.rst
@@ -192,13 +192,13 @@ By default, item metadata can contain any keys and values.  These can be given b
         # exclusiveMinimum: 0
         # exclusiveMaximum: 10
 
-Image View Presets
-..................
+Image Frame Presets
+...................
 
 This is used to specify a list of default presets for viewing images in the folder.
 Presets can be customized and saved in the GeoJS Image Viewer.
 To retrieve saved presets, use http://[serverURL]/api/v1/item/[itemID]/internal_metadata/presets.
-You can convert the response to YAML and paste it into the `imagePresets` key in your config file.
+You can convert the response to YAML and paste it into the `imageFramePresets` key in your config file.
 
 Each preset can specify a name, a view mode, an image frame, and style options.
 
@@ -239,7 +239,7 @@ The YAML below includes some example presets.
     ---
     # If present, each preset in this list will be added to the preset list
     # of every image in the folder for which the preset is applicable
-    imagePresets:
+    imageFramePresets:
     - name: Frame control - Frame 4
       frame: 4
       mode:

--- a/girder/girder_large_image/web_client/views/imageViewerSelectWidget.js
+++ b/girder/girder_large_image/web_client/views/imageViewerSelectWidget.js
@@ -47,7 +47,12 @@ var ImageViewerSelectWidget = View.extend({
         this.itemId = settings.imageModel.id;
         this.model = settings.imageModel;
         this.currentViewer = null;
-        largeImageConfig.getSettings(() => this.render());
+        largeImageConfig.getSettings(() => {
+            largeImageConfig.getConfigFile(this.model.get('folderId')).done((config) => {
+                this._liConfig = config || {};
+                this.render();
+            });
+        });
     },
 
     render: function () {
@@ -73,7 +78,8 @@ var ImageViewerSelectWidget = View.extend({
             propsData: {
                 itemId: this.itemId,
                 imageMetadata: imageMetadata,
-                frameUpdate: frameUpdate
+                frameUpdate: frameUpdate,
+                liConfig: this._liConfig
             }
         });
         this.vueApp = vm;

--- a/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
+++ b/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
@@ -121,6 +121,8 @@ export default {
                         ) * 100
                         currentLayerStyle.min = undefined
                         currentLayerStyle.max = undefined
+                    } else {
+                        currentLayerStyle.autoRange = undefined;
                     }
                 }
                 this.compositeLayerInfo[layerName] = Object.assign(
@@ -135,6 +137,8 @@ export default {
                 .filter((a) => a !== undefined)
             if (autoRanges.every((v) => v === autoRanges[0])) {
                 this.autoRangeForAll = autoRanges[0]
+            } else {
+                this.autoRangeForAll = undefined
             }
         },
         fetchCurrentFrameHistogram() {

--- a/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
+++ b/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
@@ -135,6 +135,7 @@ export default {
                 if (this.enabledLayers.includes(layer)){
                     this.compositeLayerInfo[layer].enabled = true;
                 } else {
+                    this.compositeLayerInfo[layer].enabled = false;
                     this.compositeLayerInfo[layer].autoRange = undefined;
                     this.compositeLayerInfo[layer].min = undefined;
                     this.compositeLayerInfo[layer].max = undefined;

--- a/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
+++ b/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
@@ -66,7 +66,6 @@ export default {
                     enabled: true,
                     min: undefined,
                     max: undefined,
-                    custom: false,
                     autoRange: undefined
                 }
             })
@@ -121,7 +120,10 @@ export default {
                         ) * 100
                         currentLayerStyle.min = undefined
                         currentLayerStyle.max = undefined
-                    } else if (!currentLayerStyle.autoRange) {
+                    } else if (currentLayerStyle.autoRange) {
+                        currentLayerStyle.min = `min:${currentLayerStyle.autoRange / 100}`
+                        currentLayerStyle.max = `max:${currentLayerStyle.autoRange / 100}`
+                    } else {
                         currentLayerStyle.autoRange = undefined
                     }
                 }
@@ -298,7 +300,9 @@ export default {
             }
         },
         currentStyle() {
-            this.initializeStateFromStyle()
+            if(this.currentStyle.preset) {
+                this.initializeStateFromStyle()
+            }
         }
     }
 }

--- a/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
+++ b/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
@@ -121,8 +121,8 @@ export default {
                         ) * 100
                         currentLayerStyle.min = undefined
                         currentLayerStyle.max = undefined
-                    } else {
-                        currentLayerStyle.autoRange = undefined;
+                    } else if (!currentLayerStyle.autoRange) {
+                        currentLayerStyle.autoRange = undefined
                     }
                 }
                 this.compositeLayerInfo[layerName] = Object.assign(
@@ -130,11 +130,17 @@ export default {
                 )
             })
             this.layers.forEach((layer) => {
-                this.compositeLayerInfo[layer].enabled = this.enabledLayers.includes(layer);
+                if (this.enabledLayers.includes(layer)){
+                    this.compositeLayerInfo[layer].enabled = true;
+                } else {
+                    this.compositeLayerInfo[layer].autoRange = undefined;
+                    this.compositeLayerInfo[layer].min = undefined;
+                    this.compositeLayerInfo[layer].max = undefined;
+                }
             })
             const autoRanges = Object.entries(this.compositeLayerInfo)
+                .filter(([index, info]) => info.enabled)
                 .map(([index, info]) => info.autoRange)
-                .filter((a) => a !== undefined)
             if (autoRanges.every((v) => v === autoRanges[0])) {
                 this.autoRangeForAll = autoRanges[0]
             } else {

--- a/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
+++ b/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
@@ -101,46 +101,38 @@ export default {
         },
         initializeStateFromStyle() {
             this.enabledLayers = []
-            let styleArray = this.currentStyle.bands
-            if (styleArray && !Array.isArray(styleArray)) {
-                styleArray = Object.values(styleArray)
-            }
-            this.layers.forEach((layerName) => {
-                const layerInfo = this.compositeLayerInfo[layerName]
-                const currentLayerStyle = styleArray.find((s) => s.framedelta === layerInfo.framedelta && s.band === layerInfo.band)
+            this.layers.forEach((layer) => {
+                const layerInfo = this.compositeLayerInfo[layer]
+                const currentLayerStyle = this.currentStyle.bands.find(
+                    (s) => s.framedelta === layerInfo.framedelta
+                        && s.band === layerInfo.band
+                )
                 if (currentLayerStyle) {
-                    this.enabledLayers.push(layerName)
+                    this.enabledLayers.push(layer)
+                    this.compositeLayerInfo[layer].enabled = true;
+                    this.compositeLayerInfo[layer].palette = currentLayerStyle.palette;
                     if (
                         currentLayerStyle.min && currentLayerStyle.max
                         && currentLayerStyle.min.toString().includes("min:")
                         && currentLayerStyle.max.toString().includes("max:")
                     ) {
-                        currentLayerStyle.autoRange = parseFloat(
+                        this.compositeLayerInfo[layer].autoRange = parseFloat(
                             currentLayerStyle.min.toString().replace("min:", '')
                         ) * 100
-                        currentLayerStyle.min = undefined
-                        currentLayerStyle.max = undefined
-                    } else if (currentLayerStyle.autoRange) {
-                        currentLayerStyle.min = `min:${currentLayerStyle.autoRange / 100}`
-                        currentLayerStyle.max = `max:${currentLayerStyle.autoRange / 100}`
+                        this.compositeLayerInfo[layer].min = undefined
+                        this.compositeLayerInfo[layer].max = undefined
                     } else {
-                        currentLayerStyle.autoRange = undefined
+                        this.compositeLayerInfo[layer].autoRange = undefined
                     }
                 }
-                this.compositeLayerInfo[layerName] = Object.assign(
-                    {}, layerInfo, currentLayerStyle
-                )
-            })
-            this.layers.forEach((layer) => {
-                if (this.enabledLayers.includes(layer)){
-                    this.compositeLayerInfo[layer].enabled = true;
-                } else {
+                else {
                     this.compositeLayerInfo[layer].enabled = false;
                     this.compositeLayerInfo[layer].autoRange = undefined;
                     this.compositeLayerInfo[layer].min = undefined;
                     this.compositeLayerInfo[layer].max = undefined;
                 }
             })
+
             const autoRanges = Object.entries(this.compositeLayerInfo)
                 .filter(([index, info]) => info.enabled)
                 .map(([index, info]) => info.autoRange)

--- a/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
+++ b/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
@@ -102,7 +102,10 @@ export default {
         },
         initializeStateFromStyle() {
             this.enabledLayers = []
-            const styleArray = this.currentStyle.bands
+            let styleArray = this.currentStyle.bands
+            if (styleArray && !Array.isArray(styleArray)) {
+                styleArray = Object.values(styleArray)
+            }
             this.layers.forEach((layerName) => {
                 const layerInfo = this.compositeLayerInfo[layerName]
                 const currentLayerStyle = styleArray.find((s) => s.framedelta === layerInfo.framedelta && s.band === layerInfo.band)
@@ -110,11 +113,11 @@ export default {
                     this.enabledLayers.push(layerName)
                     if (
                         currentLayerStyle.min && currentLayerStyle.max
-                        && currentLayerStyle.min.includes("min:")
-                        && currentLayerStyle.max.includes("max:")
+                        && currentLayerStyle.min.toString().includes("min:")
+                        && currentLayerStyle.max.toString().includes("max:")
                     ) {
                         currentLayerStyle.autoRange = parseFloat(
-                            currentLayerStyle.min.replace("min:", '')
+                            currentLayerStyle.min.toString().replace("min:", '')
                         ) * 100
                         currentLayerStyle.min = undefined
                         currentLayerStyle.max = undefined

--- a/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
+++ b/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
@@ -75,7 +75,8 @@ export default Vue.extend({
                 }
             });
             this.currentFrame = frame
-            let style = this.currentModeId > 1 ? this.style[this.currentModeId] : undefined
+            let style = this.currentModeId > 1 ? Object.assign({}, this.style[this.currentModeId]) : undefined
+            if(style && style.preset) delete style.preset
             this.frameUpdate(frame, style);
         },
         fillMetadata() {

--- a/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
+++ b/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
@@ -5,7 +5,7 @@ import DualInput from './DualInput.vue';
 import PresetsMenu from './PresetsMenu.vue';
 
 export default Vue.extend({
-    props: ['itemId', 'imageMetadata', 'frameUpdate'],
+    props: ['itemId', 'imageMetadata', 'frameUpdate', 'liConfig'],
     components: { CompositeLayers, DualInput, PresetsMenu },
     data() {
         return {
@@ -200,6 +200,9 @@ export default Vue.extend({
             </select>
             <presets-menu
                 :itemId="itemId"
+                :liConfig="liConfig"
+                :imageMetadata="imageMetadata"
+                :availableModes="sliderModes.map((m) => m.id)"
                 :currentMode="sliderModes.find((m) => m.id === currentModeId)"
                 :currentFrame="currentFrame"
                 :currentStyle="style[currentModeId]"

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -92,9 +92,13 @@ export default {
             })
         },
         checkPresetMatch() {
-            const targetStyle = this.currentStyle && this.currentStyle.bands ? {
-                bands: this.currentStyle.bands.map((b) => {
-                    if (b.min && b.max && b.min.includes("min:") && b.max.includes("max:")) {
+            let styleArray = this.currentStyle.bands
+            if (styleArray && !Array.isArray(styleArray)) {
+                styleArray = Object.values(styleArray)
+            }
+            const targetStyle = styleArray ? {
+                bands: styleArray.map((b) => {
+                    if (b.min && b.max && b.min.toString().includes("min:") && b.max.toString().includes("max:")) {
                         b.autoRange = parseFloat(
                             b.min.replace("min:", '')
                         ) * 100

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -20,9 +20,15 @@ export default {
                 // preset with this name already exists on the item,
                 // prefer the item preset; don't show both
                 return false
-            } if(
+            } else if (
                 parseInt(preset.frame) >= this.imageMetadata.frames.length
                 || !this.availableModes.includes(preset.mode.id)
+            ) {
+                return false
+            } else if (
+                preset.style && preset.style.bands
+                && this.imageMetadata.IndexRange.IndexC
+                && preset.style.bands.some((b) => b.framedelta > this.imageMetadata.IndexRange.IndexC)
             ) {
                 return false
             }

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -16,7 +16,11 @@ export default {
     },
     methods: {
         presetApplicable(preset) {
-            if(
+            if (this.itemPresets.find((p) => p.name === preset.name)) {
+                // preset with this name already exists on the item,
+                // prefer the item preset; don't show both
+                return false
+            } if(
                 parseInt(preset.frame) >= this.imageMetadata.frames.length
                 || !this.availableModes.includes(preset.mode.id)
             ) {
@@ -26,15 +30,15 @@ export default {
             return true
         },
         getPresets() {
-            if (this.liConfig.imageFramePresets) {
-                this.folderPresets = this.liConfig.imageFramePresets.filter(this.presetApplicable)
-            }
             restRequest({
                 type: 'GET',
                 url: 'item/' + this.itemId + '/internal_metadata/presets',
             }).then((presets) => {
                 this.itemPresets = presets
             })
+            if (this.liConfig.imageFramePresets) {
+                this.folderPresets = this.liConfig.imageFramePresets.filter(this.presetApplicable)
+            }
         },
         addPreset(e, overwrite=false) {
             const newPreset = {

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -156,6 +156,7 @@ export default {
                         }
                         return v
                     })
+                    preset.style.preset = true;
                     this.$emit('updateStyle', preset.mode.id, preset.style)
                 }
             }

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -6,7 +6,8 @@ export default {
     emits: ['setCurrentMode', 'setCurrentFrame', 'updateStyle'],
     data() {
         return {
-            availablePresets: [],
+            itemPresets: [],
+            folderPresets: [],
             selectedPreset: undefined,
             showPresetCreation: false,
             newPresetName: undefined,
@@ -25,18 +26,14 @@ export default {
             return true
         },
         getPresets() {
-            if (this.liConfig.imagePresets) {
-                this.availablePresets = this.availablePresets.concat(
-                    this.liConfig.imagePresets.filter(this.presetApplicable)
-                )
+            if (this.liConfig.imageFramePresets) {
+                this.folderPresets = this.liConfig.imageFramePresets.filter(this.presetApplicable)
             }
             restRequest({
                 type: 'GET',
                 url: 'item/' + this.itemId + '/internal_metadata/presets',
             }).then((presets) => {
-                if (presets) {
-                    this.availablePresets = this.availablePresets.concat(presets)
-                }
+                this.itemPresets = presets
             })
         },
         addPreset(e, overwrite=false) {
@@ -50,8 +47,8 @@ export default {
             if (!overwrite && this.availablePresets.find((p) => p.name === newPreset.name)) {
                 this.errorMessage = `There is already a preset named "${newPreset.name}". Overwrite "${newPreset.name}"?`
             } else {
-                this.availablePresets = this.availablePresets.filter((p) => p.name !== newPreset.name)
-                this.availablePresets.push(newPreset)
+                this.itemPresets = this.itemPresets.filter((p) => p.name !== newPreset.name)
+                this.itemPresets.push(newPreset)
                 this.selectedPreset = newPreset.name
                 this.savePresetsList()
                 this.newPresetName = undefined
@@ -60,7 +57,7 @@ export default {
             }
         },
         deleteSelectedPreset() {
-            this.availablePresets = this.availablePresets.filter((p) => p.name !== this.selectedPreset)
+            this.itemPresets = this.itemPresets.filter((p) => p.name !== this.selectedPreset)
             this.selectedPreset = undefined
             this.savePresetsList()
         },
@@ -68,7 +65,7 @@ export default {
             restRequest({
                 type: 'PUT',
                 url: 'item/' + this.itemId + '/internal_metadata/presets',
-                data: JSON.stringify(this.availablePresets),
+                data: JSON.stringify(this.itemPresets),
                 contentType: 'application/json',
             })
         },
@@ -120,6 +117,9 @@ export default {
                 name = `${this.currentStyle.bands.length} bands`
             }
             return name;
+        },
+        availablePresets() {
+            return this.itemPresets.concat(this.folderPresets)
         }
     },
     watch: {

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -146,16 +146,14 @@ export default {
                     this.$emit('setCurrentFrame', preset.frame)
                 }
                 if (preset.style && Object.keys(preset.style.bands).length) {
-                    preset.style.bands = Object.fromEntries(
-                        Object.entries(preset.style.bands).map(([k, v]) => {
-                            if (['min', 'max', 'band', 'framedelta'].includes(k)) {
-                                v = parseInt(v)
-                            } else if (k === 'autoRange') {
-                                v = parseFloat(v)
-                            }
-                            return [k, v]
-                        })
-                    )
+                    preset.style.bands = Object.entries(preset.style.bands).map(([k, v]) => {
+                        if (['min', 'max', 'band', 'framedelta'].includes(k)) {
+                            v = parseInt(v)
+                        } else if (k === 'autoRange') {
+                            v = parseFloat(v)
+                        }
+                        return v
+                    })
                     this.$emit('updateStyle', preset.mode.id, preset.style)
                 }
             }

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -138,6 +138,16 @@ export default {
                     this.$emit('setCurrentFrame', preset.frame)
                 }
                 if (preset.style && Object.keys(preset.style.bands).length) {
+                    preset.style.bands = Object.fromEntries(
+                        Object.entries(preset.style.bands).map(([k, v]) => {
+                            if (['min', 'max', 'band', 'framedelta'].includes(k)) {
+                                v = parseInt(v)
+                            } else if (k === 'autoRange') {
+                                v = parseFloat(v)
+                            }
+                            return [k, v]
+                        })
+                    )
                     this.$emit('updateStyle', preset.mode.id, preset.style)
                 }
             }

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -2,7 +2,7 @@
 import { restRequest } from '@girder/core/rest';
 
 export default {
-    props: ['itemId', 'currentMode', 'currentFrame', 'currentStyle'],
+    props: ['itemId', 'liConfig', 'imageMetadata', 'availableModes', 'currentMode', 'currentFrame', 'currentStyle'],
     emits: ['setCurrentMode', 'setCurrentFrame', 'updateStyle'],
     data() {
         return {
@@ -14,13 +14,28 @@ export default {
         }
     },
     methods: {
+        presetApplicable(preset) {
+            if(
+                parseInt(preset.frame) >= this.imageMetadata.frames.length
+                || !this.availableModes.includes(preset.mode.id)
+            ) {
+                return false
+            }
+
+            return true
+        },
         getPresets() {
+            if (this.liConfig.imagePresets) {
+                this.availablePresets = this.availablePresets.concat(
+                    this.liConfig.imagePresets.filter(this.presetApplicable)
+                )
+            }
             restRequest({
                 type: 'GET',
                 url: 'item/' + this.itemId + '/internal_metadata/presets',
             }).then((presets) => {
                 if (presets) {
-                    this.availablePresets = presets
+                    this.availablePresets = this.availablePresets.concat(presets)
                 }
             })
         },

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -92,28 +92,30 @@ export default {
             })
         },
         checkPresetMatch() {
-            let styleArray = this.currentStyle.bands
-            if (styleArray && !Array.isArray(styleArray)) {
-                styleArray = Object.values(styleArray)
+            if (this.currentStyle) {
+                let styleArray = this.currentStyle.bands
+                if (styleArray && !Array.isArray(styleArray)) {
+                    styleArray = Object.values(styleArray)
+                }
+                const targetStyle = styleArray ? {
+                    bands: styleArray.map((b) => {
+                        if (b.min && b.max && b.min.toString().includes("min:") && b.max.toString().includes("max:")) {
+                            b.autoRange = parseFloat(
+                                b.min.replace("min:", '')
+                            ) * 100
+                            b.min = undefined
+                            b.max = undefined
+                        }
+                        return b
+                    })
+                } : this.currentStyle
+                const match = this.availablePresets.find((p) => (
+                    p.mode.id === this.currentMode.id
+                    && p.frame === this.currentFrame
+                    && this.styleEqual(targetStyle, p.style)
+                ))
+                this.selectedPreset = match ? match.name : undefined
             }
-            const targetStyle = styleArray ? {
-                bands: styleArray.map((b) => {
-                    if (b.min && b.max && b.min.toString().includes("min:") && b.max.toString().includes("max:")) {
-                        b.autoRange = parseFloat(
-                            b.min.replace("min:", '')
-                        ) * 100
-                        b.min = undefined
-                        b.max = undefined
-                    }
-                    return b
-                })
-            } : this.currentStyle
-            const match = this.availablePresets.find((p) => (
-                p.mode.id === this.currentMode.id
-                && p.frame === this.currentFrame
-                && this.styleEqual(targetStyle, p.style)
-            ))
-            this.selectedPreset = match ? match.name : undefined
         }
     },
     computed: {


### PR DESCRIPTION
This PR allows a user to specify image view presets in their `.large_image_config.yaml` configuration file at the folder level. Presets specified in the configuration file will be added to the presets available for every image in that folder (as long as the preset is applicable to that image). 

We can write more complicated logic for determining whether a preset is applicable to an image, but for now, the `presetApplicable` function simply evaluates whether the preset's `mode` and `frame` values are available for the image.

This PR also adds a section to the documentation explaining how to add presets to the configuration file. This section includes some basic example presets.