### PR TITLE
Add an endpoint to make it easier to replace thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Adjust the bounds on non geospatial leaflet maps ([#1249](../../pull/1249))
 - Allow hiding metadata on item pages ([#1250](../../pull/1250))
 - Allow caching rounded histograms ([#1252](../../pull/1252))
+- Add an endpoint to make it easier to replace thumbnails ([#1253](../../pull/1253))
 
 ### Bug Fixes
 - Guard against ICC profiles that won't parse ([#1245](../../pull/1245))

--- a/girder/test_girder/test_tiles_rest.py
+++ b/girder/test_girder/test_tiles_rest.py
@@ -1499,3 +1499,30 @@ def testThumbnailMaintenance(server, admin, fsAssetstore):
     resp = server.request(path='/item/%s/tiles/thumbnails' % itemId, user=admin)
     assert utilities.respStatus(resp) == 200
     assert len(resp.json) == 0
+
+    # Get a thumbnail
+    resp = server.request(path='/item/%s/tiles/thumbnail' % itemId,
+                          user=admin, isJson=False)
+    assert utilities.respStatus(resp) == 200
+    thumb = utilities.getBody(resp, text=False)
+    resp = server.request(path='/item/%s/tiles/thumbnails' % itemId, user=admin)
+    assert utilities.respStatus(resp) == 200
+    # Ask to delete it specifically
+    key = resp.json[0]['thumbnailKey']
+    resp = server.request(
+        path='/item/%s/tiles/thumbnails' % itemId, method='DELETE', user=admin,
+        params={'key': key})
+    assert utilities.respStatus(resp) == 200
+    assert len(resp.json) == 1
+    # It should be gone
+    resp = server.request(path='/item/%s/tiles/thumbnails' % itemId, user=admin)
+    assert utilities.respStatus(resp) == 200
+    assert len(resp.json) == 0
+    # Add it back
+    resp = server.request(
+        path='/item/%s/tiles/thumbnails' % itemId, method='POST', user=admin,
+        params={'key': key}, body=thumb, type='application/octet-stream')
+
+    resp = server.request(path='/item/%s/tiles/thumbnails' % itemId, user=admin)
+    assert utilities.respStatus(resp) == 200
+    assert len(resp.json) == 1


### PR DESCRIPTION
This also allows attaching data to large_image files.

The core of this work is
```
datafile = Upload().uploadFromFile(
    io.BytesIO(data), size=len(data),
    name='_largeImageThumbnail', parentType='item', parent=item,
    user=user, mimeType=mimeType, attachParent=True)
datafile.update({
    'isLargeImageThumbnail' if thumbnail is not False else 'isLargeImageData': True,
    'thumbnailKey': key,
})
datafile = File().save(datafile)
```
where `data` is the binary data to store, `item` is the girder item, and `key` is the standardizes key for the thumbnail/data (e.g., `{"height":100,"width":160}`, where order and spacing matter).

The new endpoint replaces an existing thumbnail or adds if it doesn't exist.