### PR TITLE
Use ruff for linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
     steps:
       - checkout
       - tox:
-          env: docs,flake8,lintclient
+          env: docs,lint,lintclient
       - store_artifacts:
           path: build/docs
       - persist_to_workspace:

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -11,3 +11,5 @@
 497ddf38b1461da47d1d542003172603e2166b5f
 # PR 1148: Lint the client tests
 23ab7f011abaa71d0a4904a9da599174c38f64c3
+# PR 1257: Use ruff for linting
+dcda95e659a4eaa73cae85ab02f1b89059e63c32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Add an endpoint to make it easier to replace thumbnails ([#1253](../../pull/1253))
 - Presets from Large Image Configuration file ([#1248](../../pull/1248))
 
+### Changes
+- Minor code changes based on suggestions from ruff linting ([#1257](../../pull/1257))
+
 ### Bug Fixes
 - Guard against ICC profiles that won't parse ([#1245](../../pull/1245))
 - Fix filter button on item lists ([#1251](../../pull/1251))

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -19,7 +19,7 @@ By default, instead of storing test environments in a ``.tox`` directory, they a
 nodejs and npm for Girder Tests or Development
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``nodejs`` version 12.x and a corresponding version of ``npm`` are required to build and test Girder client code.  See `nodejs <https://nodejs.org/en/download/>`_ for how to download and install it.  Remember to get version 12 or earlier.
+``nodejs`` version 14.x and a corresponding version of ``npm`` are required to build and test Girder client code.  See `nodejs <https://nodejs.org/en/download/>`_ for how to download and install it.  Remember to get version 12 or 14.
 
 Mongo for Girder Tests or Development
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -33,13 +33,13 @@ Tests are run via tox environments:
 
 .. code-block:: bash
 
-    tox -e test-py39,flake8,lintclient
+    tox -e test-py39,lint,lintclient
 
 Or, without Girder:
 
 .. code-block:: bash
 
-    tox -e core-py39,flake8
+    tox -e core-py39,lint
 
 You can build the docs.  They are created in the ``docs/build`` directory:
 

--- a/examples/algorithm_progression.py
+++ b/examples/algorithm_progression.py
@@ -64,8 +64,8 @@ def apply_algorithm(algorithm, input_filename, output_dir, params, param_space, 
     filepath = Path(output_dir, filename)
 
     desc = dict(
-        **{'path': filename},
-        **{VARIABLE_LAYERS[i]: v for i, v in enumerate(iteration_id)}
+        path=filename,
+        **{VARIABLE_LAYERS[i]: v for i, v in enumerate(iteration_id)},
     )
 
     source = large_image.open(input_filename)
@@ -145,7 +145,7 @@ if __name__ == '__main__':
         input_params = {}
     input_params = {
         key: np.linspace(
-            float(value[0]), float(value[1]), int(value[2]), endpoint=len(value) > 3
+            float(value[0]), float(value[1]), int(value[2]), endpoint=len(value) > 3,
         )
         for key, value in input_params.items()
         if len(value) >= 3
@@ -153,7 +153,8 @@ if __name__ == '__main__':
     param_order = list(input_params.keys())
 
     if not Path(input_filename).exists():
-        raise ValueError(f'Cannot locate file {input_filename}.')
+        msg = f'Cannot locate file {input_filename}.'
+        raise ValueError(msg)
 
     algorithm = algorithms.ALGORITHM_CODES[algorithm_code]
     sig = inspect.signature(algorithm)

--- a/examples/algorithms.py
+++ b/examples/algorithms.py
@@ -16,17 +16,15 @@ def rgb_to_hsi(im):
     """
     im = np.moveaxis(im, -1, 0)
     if len(im) not in (3, 4):
-        raise ValueError(
-            'Expected 3-channel RGB or 4-channel RGBA image; '
-            'received a {}-channel image'.format(len(im))
-        )
+        msg = f'Expected 3-channel RGB or 4-channel RGBA image; received a {len(im)}-channel image'
+        raise ValueError(msg)
     im = im[:3]
     hues = (
         np.arctan2(3**0.5 * (im[1] - im[2]), 2 * im[0] - im[1] - im[2]) / (2 * np.pi)
     ) % 1
     intensities = im.mean(0)
     saturations = np.where(
-        intensities, 1 - im.min(0) / np.maximum(intensities, 1e-10), 0
+        intensities, 1 - im.min(0) / np.maximum(intensities, 1e-10), 0,
     )
     return np.stack([hues, saturations, intensities], -1)
 

--- a/examples/average_color.py
+++ b/examples/average_color.py
@@ -3,7 +3,7 @@
 
 import argparse
 
-import numpy
+import numpy as np
 
 import large_image
 
@@ -36,13 +36,13 @@ def average_color(imagePath, magnification=None):
             resample=True):
         # The tile image data is in tile['tile'] and is a numpy
         # multi-dimensional array
-        mean = numpy.mean(tile['tile'], axis=(0, 1))
+        mean = np.mean(tile['tile'], axis=(0, 1))
         tileMeans.append(mean)
         tileWeights.append(tile['width'] * tile['height'])
         print('x: %d  y: %d  w: %d  h: %d  mag: %g  color: %g %g %g' % (
             tile['x'], tile['y'], tile['width'], tile['height'],
             tile['magnification'], mean[0], mean[1], mean[2]))
-    mean = numpy.average(tileMeans, axis=0, weights=tileWeights)
+    mean = np.average(tileMeans, axis=0, weights=tileWeights)
     print('Average color: %g %g %g' % (mean[0], mean[1], mean[2]))
     return mean
 

--- a/examples/sumsquare_color.py
+++ b/examples/sumsquare_color.py
@@ -3,7 +3,7 @@
 
 import argparse
 
-import numpy
+import numpy as np
 
 import large_image
 
@@ -33,12 +33,12 @@ def sum_squares(imagePath, magnification=None, **kwargs):
             tile['tile_overlap']['left']:
                 data.shape[1] - tile['tile_overlap']['right'],
             :]
-        sumsq = numpy.sum(data**2, axis=(0, 1))
+        sumsq = np.sum(data**2, axis=(0, 1))
         tileSumSquares.append(sumsq)
         print('x: %d  y: %d  w: %d  h: %d  mag: %g  sums: %d %d %d' % (
             tile['x'], tile['y'], tile['width'], tile['height'],
             tile['magnification'], sumsq[0], sumsq[1], sumsq[2]))
-    sumsq = numpy.sum(tileSumSquares, axis=0)
+    sumsq = np.sum(tileSumSquares, axis=0)
     print('Sum of squares: %d %d %d' % (sumsq[0], sumsq[1], sumsq[2]))
     return sumsq
 

--- a/girder/girder_large_image/__init__.py
+++ b/girder/girder_large_image/__init__.py
@@ -153,7 +153,7 @@ def _updateJob(event):
                 'job_id': job['_id'],
                 'item_id': item['_id'],
                 'success': status == JobStatus.SUCCESS,
-                'status': status
+                'status': status,
             },
             user={'_id': job.get('userId')},
             expires=datetime.datetime.utcnow() + datetime.timedelta(seconds=30))
@@ -294,7 +294,8 @@ def metadataSearchHandler(  # noqa
     if any(typ not in models for typ in types):
         raise RestException('The metadata search is only able to search in %r.' % models)
     if not isinstance(query, str):
-        raise RestException('The search query must be a string.')
+        msg = 'The search query must be a string.'
+        raise RestException(msg)
     # If we have the beginning of the field specifier, don't do a search
     if re.match(r'^(k|ke|key|key:)$', query.strip()):
         return {k: [] for k in types}
@@ -307,7 +308,7 @@ def metadataSearchHandler(  # noqa
         pipeline = [
             {'$project': {'arrayofkeyvalue': {'$objectToArray': '$$ROOT.%s' % metakey}}},
             {'$unwind': '$arrayofkeyvalue'},
-            {'$group': {'_id': None, 'allkeys': {'$addToSet': '$arrayofkeyvalue.k'}}}
+            {'$group': {'_id': None, 'allkeys': {'$addToSet': '$arrayofkeyvalue.k'}}},
         ]
         for model in (searchModels or types):
             modelInst = ModelImporter.model(*model if isinstance(model, tuple) else [model])
@@ -588,7 +589,7 @@ def validateNonnegativeInteger(doc):
 
 
 @setting_utilities.validator({
-    constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER
+    constants.PluginSettings.LARGE_IMAGE_DEFAULT_VIEWER,
 })
 def validateDefaultViewer(doc):
     doc['value'] = str(doc['value']).strip()

--- a/girder/girder_large_image/loadmodelcache.py
+++ b/girder/girder_large_image/loadmodelcache.py
@@ -79,6 +79,6 @@ def loadModel(resource, model, plugin='_core', id=None, allowCookie=False,
             'tokenId': tokenStr,
             'expiry': time.time() + LoadModelCacheExpiryDuration,
             'result': entry,
-            'hits': 0
+            'hits': 0,
         }
     return entry

--- a/girder/girder_large_image/models/image_item.py
+++ b/girder/girder_large_image/models/image_item.py
@@ -62,14 +62,15 @@ class ImageItem(Item):
         logger.info('createImageItem called on item %s (%s)', item['_id'], item['name'])
         # Using setdefault ensures that 'largeImage' is in the item
         if 'fileId' in item.setdefault('largeImage', {}):
-            raise TileGeneralError('Item already has largeImage set.')
+            msg = 'Item already has largeImage set.'
+            raise TileGeneralError(msg)
         if fileObj['itemId'] != item['_id']:
-            raise TileGeneralError(
-                'The provided file must be in the provided item.')
+            msg = 'The provided file must be in the provided item.'
+            raise TileGeneralError(msg)
         if (item['largeImage'].get('expected') is True and
                 'jobId' in item['largeImage']):
-            raise TileGeneralError(
-                'Item is scheduled to generate a largeImage.')
+            msg = 'Item is scheduled to generate a largeImage.'
+            raise TileGeneralError(msg)
 
         item['largeImage'].pop('expected', None)
         item['largeImage'].pop('sourceName', None)
@@ -90,8 +91,8 @@ class ImageItem(Item):
                 logger.info(
                     'createImageItem will not use item %s (%s) as a largeImage',
                     item['_id'], item['name'])
-                raise TileGeneralError(
-                    'A job must be used to generate a largeImage.')
+                msg = 'A job must be used to generate a largeImage.'
+                raise TileGeneralError(msg)
             logger.debug(
                 'createImageItem creating a job to generate a largeImage for item %s (%s)',
                 item['_id'], item['name'])
@@ -175,8 +176,8 @@ class ImageItem(Item):
 
     def convertImage(self, item, fileObj, user=None, token=None, localJob=True, **kwargs):
         if fileObj['itemId'] != item['_id']:
-            raise TileGeneralError(
-                'The provided file must be in the provided item.')
+            msg = 'The provided file must be in the provided item.'
+            raise TileGeneralError(msg)
         if not localJob:
             return self._createLargeImageJob(item, fileObj, user, token, toFolder=True, **kwargs)
         return self._createLargeImageLocalJob(item, fileObj, user, toFolder=True, **kwargs)
@@ -220,10 +221,11 @@ class ImageItem(Item):
     @classmethod
     def _loadTileSource(cls, item, **kwargs):
         if 'largeImage' not in item:
-            raise TileSourceError('No large image file in this item.')
+            msg = 'No large image file in this item.'
+            raise TileSourceError(msg)
         if item['largeImage'].get('expected'):
-            raise TileSourceError('The large image file for this item is '
-                                  'still pending creation.')
+            msg = 'The large image file for this item is still pending creation.'
+            raise TileSourceError(msg)
 
         sourceName = item['largeImage']['sourceName']
         try:
@@ -374,7 +376,7 @@ class ImageItem(Item):
         if not hasattr(self, '_getAndCacheImageOrDataLock'):
             self._getAndCacheImageOrDataLock = {
                 'keys': {},
-                'lock': threading.Lock()
+                'lock': threading.Lock(),
             }
         keylock = None
         with self._getAndCacheImageOrDataLock['lock']:

--- a/girder/girder_large_image/rest/__init__.py
+++ b/girder/girder_large_image/rest/__init__.py
@@ -81,16 +81,16 @@ def _itemFindRecursive(self, origItemFind, folderId, text, name, limit, offset, 
                 'connectToField': 'parentId',
                 'depthField': '_depth',
                 'as': '_folder',
-                'startWith': '$_id'
+                'startWith': '$_id',
             }},
-            {'$group': {'_id': '$_folder._id'}}
+            {'$group': {'_id': '$_folder._id'}},
         ]
         children = [ObjectId(folderId)] + next(Folder().collection.aggregate(pipeline))['_id']
         if len(children) > 1:
             filters = (filters.copy() if filters else {})
             if text:
                 filters['$text'] = {
-                    '$search': text
+                    '$search': text,
                 }
             if name:
                 filters['name'] = name
@@ -121,7 +121,7 @@ def _itemFindRecursive(self, origItemFind, folderId, text, name, limit, offset, 
         'for admins).')
     .modelParam('id', model=Folder, level=AccessType.READ)
     .param('name', 'The name of the file.', paramType='path')
-    .errorResponse()
+    .errorResponse(),
 )
 @boundHandler()
 def getYAMLConfigFile(self, folder, name):
@@ -142,7 +142,7 @@ def getYAMLConfigFile(self, folder, name):
     .modelParam('id', model=Folder, level=AccessType.WRITE)
     .param('name', 'The name of the file.', paramType='path')
     .param('config', 'The contents of yaml config file to validate.',
-           paramType='body')
+           paramType='body'),
 )
 @boundHandler()
 def putYAMLConfigFile(self, folder, name, config):

--- a/girder/girder_large_image/rest/item_meta.py
+++ b/girder/girder_large_image/rest/item_meta.py
@@ -25,13 +25,13 @@ class InternalMetadataItemResource(Item):
     def __init__(self, apiRoot):
         super().__init__()
         apiRoot.item.route(
-            'GET', (':itemId', 'internal_metadata', ':key'), self.getMetadataKey
+            'GET', (':itemId', 'internal_metadata', ':key'), self.getMetadataKey,
         )
         apiRoot.item.route(
-            'PUT', (':itemId', 'internal_metadata', ':key'), self.updateMetadataKey
+            'PUT', (':itemId', 'internal_metadata', ':key'), self.updateMetadataKey,
         )
         apiRoot.item.route(
-            'DELETE', (':itemId', 'internal_metadata', ':key'), self.deleteMetadataKey
+            'DELETE', (':itemId', 'internal_metadata', ':key'), self.deleteMetadataKey,
         )
 
     @describeRoute(
@@ -44,7 +44,7 @@ class InternalMetadataItemResource(Item):
             default='meta',
         )
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.user(scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
@@ -55,7 +55,7 @@ class InternalMetadataItemResource(Item):
 
     @describeRoute(
         Description(
-            'Overwrite the value for a single internal metadata key on this item.'
+            'Overwrite the value for a single internal metadata key on this item.',
         )
         .param('itemId', 'The ID of the item.', paramType='path')
         .param(
@@ -72,7 +72,7 @@ class InternalMetadataItemResource(Item):
             paramType='body',
         )
         .errorResponse('ID was invalid.')
-        .errorResponse('Write access was denied for the item.', 403)
+        .errorResponse('Write access was denied for the item.', 403),
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.WRITE)
@@ -90,7 +90,7 @@ class InternalMetadataItemResource(Item):
             default='meta',
         )
         .errorResponse('ID was invalid.')
-        .errorResponse('Write access was denied for the item.', 403)
+        .errorResponse('Write access was denied for the item.', 403),
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)

--- a/girder/girder_large_image/rest/large_image_resource.py
+++ b/girder/girder_large_image/rest/large_image_resource.py
@@ -240,7 +240,7 @@ class LargeImageResource(Resource):
         self.route('DELETE', ('tiles', 'incomplete'), self.deleteIncompleteTiles)
 
     @describeRoute(
-        Description('Clear tile source caches to release resources and file handles.')
+        Description('Clear tile source caches to release resources and file handles.'),
     )
     @access.admin(scope=TokenScope.DATA_WRITE)
     def cacheClear(self, params):
@@ -258,14 +258,14 @@ class LargeImageResource(Resource):
         return {'cacheCleared': datetime.datetime.utcnow(), 'before': before, 'after': after}
 
     @describeRoute(
-        Description('Get information on caches.')
+        Description('Get information on caches.'),
     )
     @access.admin(scope=TokenScope.DATA_READ)
     def cacheInfo(self, params):
         return cache_util.cachesInfo()
 
     @describeRoute(
-        Description('Get public settings for large image display.')
+        Description('Get public settings for large image display.'),
     )
     @access.public(scope=TokenScope.DATA_READ)
     def getPublicSettings(self, params):
@@ -280,7 +280,7 @@ class LargeImageResource(Resource):
         .param('spec', 'A JSON list of thumbnail specifications to count.  '
                'If empty, all cached thumbnails are counted.  The '
                'specifications typically include width, height, encoding, and '
-               'encoding options.', required=False)
+               'encoding options.', required=False),
     )
     @access.admin(scope=TokenScope.DATA_READ)
     def countThumbnails(self, params):
@@ -291,7 +291,7 @@ class LargeImageResource(Resource):
                     'large_image items.')
         .param('imageKey', 'If specific, only include images with the '
                'specified key', required=False)
-        .notes('The imageKey can also be "tileFrames".')
+        .notes('The imageKey can also be "tileFrames".'),
     )
     @access.admin(scope=TokenScope.DATA_READ)
     def countAssociatedImages(self, params):
@@ -303,9 +303,10 @@ class LargeImageResource(Resource):
             try:
                 spec = json.loads(spec)
                 if not isinstance(spec, list):
-                    raise ValueError()
+                    raise ValueError
             except ValueError:
-                raise RestException('The spec parameter must be a JSON list.')
+                msg = 'The spec parameter must be a JSON list.'
+                raise RestException(msg)
             spec = [json.dumps(entry, sort_keys=True, separators=(',', ':'))
                     for entry in spec]
         else:
@@ -339,7 +340,7 @@ class LargeImageResource(Resource):
                dataType='float')
         .param('concurrent', 'The number of concurrent threads to use when '
                'making thumbnails.  0 or unspecified to base this on the '
-               'number of reported cpus.', required=False, dataType='int')
+               'number of reported cpus.', required=False, dataType='int'),
     )
     @access.admin(scope=TokenScope.DATA_WRITE)
     def createThumbnails(self, params):
@@ -347,13 +348,15 @@ class LargeImageResource(Resource):
         try:
             spec = json.loads(params['spec'])
             if not isinstance(spec, list):
-                raise ValueError()
+                raise ValueError
         except ValueError:
-            raise RestException('The spec parameter must be a JSON list.')
+            msg = 'The spec parameter must be a JSON list.'
+            raise RestException(msg)
         maxThumbnailFiles = int(Setting().get(
             constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES))
         if maxThumbnailFiles <= 0:
-            raise RestException('Thumbnail files are not enabled.')
+            msg = 'Thumbnail files are not enabled.'
+            raise RestException(msg)
         jobKwargs = {'spec': spec}
         if params.get('logInterval') is not None:
             jobKwargs['logInterval'] = float(params['logInterval'])
@@ -377,7 +380,7 @@ class LargeImageResource(Resource):
         .param('spec', 'A JSON list of thumbnail specifications to delete.  '
                'If empty, all cached thumbnails are deleted.  The '
                'specifications typically include width, height, encoding, and '
-               'encoding options.', required=False)
+               'encoding options.', required=False),
     )
     @access.admin(scope=TokenScope.DATA_WRITE)
     def deleteThumbnails(self, params):
@@ -386,7 +389,7 @@ class LargeImageResource(Resource):
     @describeRoute(
         Description('Delete cached associated image files from large_image items.')
         .param('imageKey', 'If specific, only include images with the '
-               'specified key', required=False)
+               'specified key', required=False),
     )
     @access.admin(scope=TokenScope.DATA_WRITE)
     def deleteAssociatedImages(self, params):
@@ -398,9 +401,10 @@ class LargeImageResource(Resource):
             try:
                 spec = json.loads(spec)
                 if not isinstance(spec, list):
-                    raise ValueError()
+                    raise ValueError
             except ValueError:
-                raise RestException('The spec parameter must be a JSON list.')
+                msg = 'The spec parameter must be a JSON list.'
+                raise RestException(msg)
             spec = [json.dumps(entry, sort_keys=True, separators=(',', ':'))
                     for entry in spec]
         else:
@@ -426,7 +430,7 @@ class LargeImageResource(Resource):
         .notes('This is used to clean up all large image conversion jobs that '
                'have failed to complete.  If a job is in progress, it will be '
                'cancelled.  The return value is the number of items that were '
-               'adjusted.')
+               'adjusted.'),
     )
     @access.admin(scope=TokenScope.DATA_WRITE)
     def deleteIncompleteTiles(self, params):
@@ -452,7 +456,7 @@ class LargeImageResource(Resource):
         Description('List all Girder tile sources with associated extensions, '
                     'mime types, and versions.  Lower values indicate a '
                     'higher priority for an extension or mime type with that '
-                    'source.')
+                    'source.'),
     )
     @access.public(scope=TokenScope.DATA_READ)
     def listSources(self, params):
@@ -474,7 +478,7 @@ class LargeImageResource(Resource):
         return results
 
     @describeRoute(
-        Description('Count the number of cached histograms for large_image items.')
+        Description('Count the number of cached histograms for large_image items.'),
     )
     @access.admin(scope=TokenScope.DATA_READ)
     def countHistograms(self, params):
@@ -487,7 +491,7 @@ class LargeImageResource(Resource):
         return count
 
     @describeRoute(
-        Description('Delete cached histograms from large_image items.')
+        Description('Delete cached histograms from large_image items.'),
     )
     @access.admin(scope=TokenScope.DATA_WRITE)
     def deleteHistograms(self, params):
@@ -562,7 +566,7 @@ class LargeImageResource(Resource):
         Description('Validate a Girder config file')
         .notes('Returns a list of errors found.')
         .param('config', 'The contents of config file to validate.',
-               paramType='body')
+               paramType='body'),
     )
     @access.admin(scope=TokenScope.DATA_WRITE)
     def configValidate(self, config):
@@ -572,7 +576,7 @@ class LargeImageResource(Resource):
     @autoDescribeRoute(  # noqa
         Description('Reformat a Girder config file')
         .param('config', 'The contents of config file to format.',
-               paramType='body')
+               paramType='body'),
     )
     @access.admin(scope=TokenScope.DATA_WRITE)
     def configFormat(self, config):  # noqa
@@ -628,13 +632,14 @@ class LargeImageResource(Resource):
         .param('restart', 'Whether to restart the server after updating the '
                'config file', required=False, dataType='boolean', default=True)
         .param('config', 'The new contents of config file.',
-               paramType='body')
+               paramType='body'),
     )
     @access.admin(scope=TokenScope.USER_AUTH)
     def configReplace(self, config, restart):
         config = config.read().decode('utf8')
         if len(self._configValidate(config)):
-            raise RestException('Invalid config file')
+            msg = 'Invalid config file'
+            raise RestException(msg)
         path = os.path.join(os.path.expanduser('~'), '.girder', 'girder.cfg')
         if 'GIRDER_CONFIG' in os.environ:
             path = os.environ['GIRDER_CONFIG']

--- a/girder/girder_large_image/rest/tiles.py
+++ b/girder/girder_large_image/rest/tiles.py
@@ -222,7 +222,7 @@ class TilesItemResource(ItemResource):
         .param('concurrent', 'Suggested number of maximum concurrent '
                'processes to use during conversion.  Values less than or '
                'equal to 0 use the number of logical cpus less that value.  '
-               'Default is -2.', dataType='int', required=False)
+               'Default is -2.', dataType='int', required=False),
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.WRITE)
@@ -236,7 +236,8 @@ class TilesItemResource(ItemResource):
             if len(files) == 1:
                 largeImageFileId = str(files[0]['_id'])
         if not largeImageFileId:
-            raise RestException('Missing "fileId" parameter.')
+            msg = 'Missing "fileId" parameter.'
+            raise RestException(msg)
         largeImageFile = File().load(largeImageFileId, force=True, exc=True)
         user = self.getCurrentUser()
         token = self.getCurrentToken()
@@ -289,7 +290,7 @@ class TilesItemResource(ItemResource):
         .param('concurrent', 'Suggested number of maximum concurrent '
                'processes to use during conversion.  Values less than or '
                'equal to 0 use the number of logical cpus less that value.  '
-               'Default is -2.', dataType='int', required=False)
+               'Default is -2.', dataType='int', required=False),
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
@@ -303,7 +304,8 @@ class TilesItemResource(ItemResource):
             if len(files) == 1:
                 largeImageFileId = str(files[0]['_id'])
         if not largeImageFileId:
-            raise RestException('Missing "fileId" parameter.')
+            msg = 'Missing "fileId" parameter.'
+            raise RestException(msg)
         largeImageFile = File().load(largeImageFileId, force=True, exc=True)
         user = self.getCurrentUser()
         token = self.getCurrentToken()
@@ -427,7 +429,7 @@ class TilesItemResource(ItemResource):
         Description('Get large image metadata.')
         .param('itemId', 'The ID of the item.', paramType='path')
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.public(scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
@@ -438,7 +440,7 @@ class TilesItemResource(ItemResource):
         Description('Get large image internal metadata.')
         .param('itemId', 'The ID of the item.', paramType='path')
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.public(scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
@@ -449,7 +451,7 @@ class TilesItemResource(ItemResource):
             raise RestException(e.args[0], code=400)
 
     @describeRoute(
-        Description('Get test large image metadata.')
+        Description('Get test large image metadata.'),
     )
     @access.public(scope=TokenScope.DATA_READ)
     def getTestTilesInfo(self, params):
@@ -465,20 +467,23 @@ class TilesItemResource(ItemResource):
         .param('tilesize', 'Tile size (default 256), must be a power of 2',
                required=False, dataType='int')
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.public(scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
     def getDZIInfo(self, item, params):
         if 'encoding' in params and params['encoding'] not in ('JPEG', 'PNG'):
-            raise RestException('Only JPEG and PNG encodings are supported', code=400)
+            msg = 'Only JPEG and PNG encodings are supported'
+            raise RestException(msg, code=400)
         info = self._getTilesInfo(item, params)
         tilesize = int(params.get('tilesize', 256))
         if tilesize & (tilesize - 1):
-            raise RestException('Invalid tilesize', code=400)
+            msg = 'Invalid tilesize'
+            raise RestException(msg, code=400)
         overlap = int(params.get('overlap', 0))
         if overlap < 0:
-            raise RestException('Invalid overlap', code=400)
+            msg = 'Invalid overlap'
+            raise RestException(msg, code=400)
         result = ''.join([
             '<?xml version="1.0" encoding="UTF-8"?>',
             '<Image',
@@ -512,9 +517,11 @@ class TilesItemResource(ItemResource):
         try:
             x, y, z = int(x), int(y), int(z)
         except ValueError:
-            raise RestException('x, y, and z must be integers', code=400)
+            msg = 'x, y, and z must be integers'
+            raise RestException(msg, code=400)
         if x < 0 or y < 0 or z < 0:
-            raise RestException('x, y, and z must be positive integers',
+            msg = 'x, y, and z must be positive integers'
+            raise RestException(msg,
                                 code=400)
         result = self.imageItemModel._tileFromHash(
             item, x, y, z, mayRedirect=mayRedirect, **imageArgs)
@@ -548,7 +555,7 @@ class TilesItemResource(ItemResource):
                enum=['false', 'exact', 'encoding', 'any'], default='false')
         .produces(ImageMimeTypes)
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     # Without caching, this checks for permissions every time.  By using the
     # LoadModelCache, three database lookups are avoided, which saves around
@@ -590,7 +597,7 @@ class TilesItemResource(ItemResource):
                enum=['false', 'exact', 'encoding', 'any'], default='false')
         .produces(ImageMimeTypes)
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     # See getTile for caching rationale
     def getTileWithFrame(self, itemId, frame, z, x, y, params):
@@ -613,7 +620,7 @@ class TilesItemResource(ItemResource):
                paramType='path')
         .param('y', 'The Y coordinate of the tile (0 is the top).',
                paramType='path')
-        .produces(ImageMimeTypes)
+        .produces(ImageMimeTypes),
     )
     @access.public(cookie=True, scope=TokenScope.DATA_READ)
     def getTestTile(self, z, x, y, params):
@@ -631,7 +638,7 @@ class TilesItemResource(ItemResource):
                paramType='path')
         .produces(ImageMimeTypes)
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.public(cookie=True, scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
@@ -639,10 +646,12 @@ class TilesItemResource(ItemResource):
         _adjustParams(params)
         tilesize = int(params.get('tilesize', 256))
         if tilesize & (tilesize - 1):
-            raise RestException('Invalid tilesize', code=400)
+            msg = 'Invalid tilesize'
+            raise RestException(msg, code=400)
         overlap = int(params.get('overlap', 0))
         if overlap < 0:
-            raise RestException('Invalid overlap', code=400)
+            msg = 'Invalid overlap'
+            raise RestException(msg, code=400)
         x, y = (int(xy) for xy in xandy.split('.')[0].split('_'))
         _handleETag('getDZITile', item, level, xandy, params)
         metadata = self.imageItemModel.getMetadata(item, **params)
@@ -650,7 +659,8 @@ class TilesItemResource(ItemResource):
         maxlevel = int(math.ceil(math.log(max(
             metadata['sizeX'], metadata['sizeY'])) / math.log(2)))
         if level < 1 or level > maxlevel:
-            raise RestException('level must be between 1 and the image scale',
+            msg = 'level must be between 1 and the image scale'
+            raise RestException(msg,
                                 code=400)
         lfactor = 2 ** (maxlevel - level)
         region = {
@@ -667,9 +677,11 @@ class TilesItemResource(ItemResource):
             height += int(region['top'] / lfactor)
             region['top'] = 0
         if region['left'] >= metadata['sizeX']:
-            raise RestException('x is outside layer', code=400)
+            msg = 'x is outside layer'
+            raise RestException(msg, code=400)
         if region['top'] >= metadata['sizeY']:
-            raise RestException('y is outside layer', code=400)
+            msg = 'y is outside layer'
+            raise RestException(msg, code=400)
         if region['left'] < metadata['sizeX'] and region['right'] > metadata['sizeX']:
             region['right'] = metadata['sizeX']
             width = int(math.ceil(float(region['right'] - region['left']) / lfactor))
@@ -687,14 +699,14 @@ class TilesItemResource(ItemResource):
 
     @describeRoute(
         Description('Remove a large image from this item.')
-        .param('itemId', 'The ID of the item.', paramType='path')
+        .param('itemId', 'The ID of the item.', paramType='path'),
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.WRITE)
     def deleteTiles(self, item, params):
         deleted = self.imageItemModel.delete(item)
         return {
-            'deleted': deleted
+            'deleted': deleted,
         }
 
     @describeRoute(
@@ -732,7 +744,7 @@ class TilesItemResource(ItemResource):
                'the Content-Disposition response header.', required=False)
         .produces(ImageMimeTypes)
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.public(cookie=True, scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
@@ -749,7 +761,7 @@ class TilesItemResource(ItemResource):
             ('encoding', str),
             ('style', str),
             ('contentDisposition', str),
-            ('contentDispositionFileName', str)
+            ('contentDispositionFileName', str),
         ])
         _handleETag('getTilesThumbnail', item, params)
         pickle = _pickleParams(params)
@@ -859,7 +871,7 @@ class TilesItemResource(ItemResource):
         .produces(ImageMimeTypes)
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
-        .errorResponse('Insufficient memory.')
+        .errorResponse('Insufficient memory.'),
     )
     @access.public(cookie=True, scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
@@ -889,7 +901,7 @@ class TilesItemResource(ItemResource):
             ('style', str),
             ('resample', 'boolOrInt'),
             ('contentDisposition', str),
-            ('contentDispositionFileName', str)
+            ('contentDispositionFileName', str),
         ])
         _handleETag('getTilesRegion', item, params)
         pickle = _pickleParams(params)
@@ -940,7 +952,7 @@ class TilesItemResource(ItemResource):
                'This is ignored on non-multiframe images.', required=False,
                dataType='int')
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.public(cookie=True, scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
@@ -999,7 +1011,7 @@ class TilesItemResource(ItemResource):
         .param('density', 'If true, scale the results by the number of '
                'samples.', required=False, dataType='boolean', default=False)
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.public(scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
@@ -1060,7 +1072,7 @@ class TilesItemResource(ItemResource):
                'This is ignored on non-multiframe images.', required=False,
                dataType='int')
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.public(scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
@@ -1077,7 +1089,7 @@ class TilesItemResource(ItemResource):
         Description('Get a list of additional images associated with a large image.')
         .param('itemId', 'The ID of the item.', paramType='path')
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.public(scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
@@ -1106,7 +1118,7 @@ class TilesItemResource(ItemResource):
                'the Content-Disposition response header.', required=False)
         .produces(ImageMimeTypes)
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.public(cookie=True, scope=TokenScope.DATA_READ)
     def getAssociatedImage(self, itemId, image, params):
@@ -1123,7 +1135,7 @@ class TilesItemResource(ItemResource):
             ('encoding', str),
             ('style', str),
             ('contentDisposition', str),
-            ('contentDispositionFileName', str)
+            ('contentDispositionFileName', str),
         ])
         _handleETag('getAssociatedImage', item, image, params)
         try:
@@ -1145,7 +1157,7 @@ class TilesItemResource(ItemResource):
         .modelParam('itemId', model=Item, level=AccessType.READ)
         .param('image', 'The key of the associated image.', paramType='path')
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.public(scope=TokenScope.DATA_READ)
     def getAssociatedImageMetadata(self, item, image, params):
@@ -1191,7 +1203,7 @@ class TilesItemResource(ItemResource):
         ('style', str),
         ('resample', 'boolOrInt'),
         ('contentDisposition', str),
-        ('contentDispositionFileName', str)
+        ('contentDispositionFileName', str),
     ]
 
     @describeRoute(
@@ -1279,7 +1291,7 @@ class TilesItemResource(ItemResource):
         .produces(ImageMimeTypes)
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
-        .errorResponse('Insufficient memory.')
+        .errorResponse('Insufficient memory.'),
     )
     @access.public(cookie=True, scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
@@ -1377,7 +1389,7 @@ class TilesItemResource(ItemResource):
                required=False,
                enum=['none', 'report', 'schedule'])
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.public(cookie=True, scope=TokenScope.DATA_READ)
     @loadmodel(model='item', map={'itemId': 'item'}, level=AccessType.READ)
@@ -1423,7 +1435,7 @@ class TilesItemResource(ItemResource):
         Description('List all thumbnail and data files associated with a large_image item.')
         .modelParam('itemId', model=Item, level=AccessType.READ)
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.admin(scope=TokenScope.DATA_READ)
     def listTilesThumbnails(self, item):
@@ -1440,7 +1452,7 @@ class TilesItemResource(ItemResource):
                'thumbnail; false if the key is a data record',
                dataType='boolean', required=False)
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.admin(scope=TokenScope.DATA_WRITE)
     def deleteTilesThumbnails(self, item, keep, key=None, thumbnail=True):
@@ -1471,7 +1483,7 @@ class TilesItemResource(ItemResource):
                paramType='body', dataType='binary')
         .consumes('application/octet-stream')
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     def addTilesThumbnails(self, item, key, mimeType, thumbnail=False, data=None):

--- a/girder/setup.py
+++ b/girder/setup.py
@@ -73,6 +73,6 @@ setup(
     entry_points={
         'girder.plugin': [
             'large_image = girder_large_image:LargeImagePlugin',
-        ]
+        ],
     },
 )

--- a/girder/test_girder/conftest.py
+++ b/girder/test_girder/conftest.py
@@ -6,7 +6,7 @@ import pytest
 pytestmark = pytest.mark.girder
 
 
-@pytest.fixture
+@pytest.fixture()
 def unavailableWorker(db):
     """
     Make sure that Girder Worker can't be reached and times out quickly.
@@ -41,7 +41,7 @@ def girderWorkerProcess():
     proc.wait()
 
 
-@pytest.fixture
+@pytest.fixture()
 def girderWorker(db, girderWorkerProcess):
     """
     Run an instance of Girder worker, connected to rabbitmq.  The rabbitmq
@@ -67,7 +67,7 @@ def unbindGirderEventsByHandlerName(handlerName):
         events.unbind(eventName, handlerName)
 
 
-@pytest.fixture
+@pytest.fixture()
 def unbindLargeImage(db):
     yield True
     unbindGirderEventsByHandlerName('large_image')

--- a/girder/test_girder/test_large_image.py
+++ b/girder/test_girder/test_large_image.py
@@ -148,7 +148,7 @@ def testThumbnailFileJob(server, admin, user, fsAssetstore):
     # Run a job to create two sizes of thumbnails
     assert _createThumbnails(server, admin, [
         {'width': 160, 'height': 100},
-        {'encoding': 'PNG'}
+        {'encoding': 'PNG'},
     ])
 
     # We should report two thumbnails
@@ -236,7 +236,7 @@ def testThumbnailFileJob(server, admin, user, fsAssetstore):
     Setting().set(constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES, 0)
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testDeleteIncompleteTile(server, admin, user, fsAssetstore, unavailableWorker):
@@ -407,7 +407,7 @@ def testHistogramCaching(server, admin, user, fsAssetstore):
     assert resp.json == 0
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testHistogramConcurrentCaching(server, admin, user, fsAssetstore):
@@ -617,7 +617,7 @@ def testYAMLConfigFileInherit(server, admin, user, fsAssetstore):
     assert resp.json['keyE'] == 'value7'
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testConfigFileEndpoints(server, admin, fsAssetstore):

--- a/girder/test_girder/test_tiles_rest.py
+++ b/girder/test_girder/test_tiles_rest.py
@@ -159,7 +159,7 @@ def _postTileViaHttp(server, admin, itemId, fileId, jobAction=None, data=None, c
     """
     headers = {
         'Accept': 'application/json',
-        'Girder-Token': str(Token().createToken(admin)['_id'])
+        'Girder-Token': str(Token().createToken(admin)['_id']),
     }
     req = requests.post('http://127.0.0.1:%d/api/v1/item/%s/tiles' % (
         server.boundPort, itemId), headers=headers,
@@ -367,7 +367,7 @@ def testTilesFromTest(server, admin, fsAssetstore):
     params = {'encoding': 'JPEG'}
     meta = _createTestTiles(server, admin, params, {
         'tileWidth': 256, 'tileHeight': 256,
-        'sizeX': 256 * 2 ** 9, 'sizeY': 256 * 2 ** 9, 'levels': 10
+        'sizeX': 256 * 2 ** 9, 'sizeY': 256 * 2 ** 9, 'levels': 10,
     })
     _testTilesZXY(server, admin, 'test', meta, params)
     # Test most of our parameters in a single special case
@@ -378,11 +378,11 @@ def testTilesFromTest(server, admin, fsAssetstore):
         'tileHeight': 120,
         'sizeX': 5000,
         'sizeY': 3000,
-        'encoding': 'JPEG'
+        'encoding': 'JPEG',
     }
     meta = _createTestTiles(server, admin, params, {
         'tileWidth': 160, 'tileHeight': 120,
-        'sizeX': 5000, 'sizeY': 3000, 'levels': 6
+        'sizeX': 5000, 'sizeY': 3000, 'levels': 6,
     })
     meta['minLevel'] = 2
     _testTilesZXY(server, admin, 'test', meta, params)
@@ -390,7 +390,7 @@ def testTilesFromTest(server, admin, fsAssetstore):
     params = {'fractal': 'true'}
     meta = _createTestTiles(server, admin, params, {
         'tileWidth': 256, 'tileHeight': 256,
-        'sizeX': 256 * 2 ** 9, 'sizeY': 256 * 2 ** 9, 'levels': 10
+        'sizeX': 256 * 2 ** 9, 'sizeY': 256 * 2 ** 9, 'levels': 10,
     })
     _testTilesZXY(server, admin, 'test', meta, params, utilities.PNGHeader)
     # Test that the fractal isn't the same as the non-fractal
@@ -416,7 +416,7 @@ def testTilesFromTest(server, admin, fsAssetstore):
         _createTestTiles(server, admin, {key: badParams[key]}, error=err)
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesFromPNG(boundServer, admin, fsAssetstore, girderWorker):
@@ -467,7 +467,7 @@ def testTilesFromPNG(boundServer, admin, fsAssetstore, girderWorker):
     assert 'No large image file' in resp.json['message']
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesDeleteJob(boundServer, admin, fsAssetstore, girderWorker):
@@ -493,7 +493,7 @@ def testTilesDeleteJob(boundServer, admin, fsAssetstore, girderWorker):
     assert tileMetadata['levels'] == 7
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesFromGreyscale(boundServer, admin, fsAssetstore, girderWorker):
@@ -513,7 +513,7 @@ def testTilesFromGreyscale(boundServer, admin, fsAssetstore, girderWorker):
     _testTilesZXY(boundServer, admin, itemId, tileMetadata)
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesFromUnicodeName(boundServer, admin, fsAssetstore, girderWorker):
@@ -565,7 +565,7 @@ def testTilesWithUnicodeName(server, admin, fsAssetstore):
     assert tileMetadata['sizeY'] == 12288
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesFromBadFiles(boundServer, admin, fsAssetstore, girderWorker):
@@ -975,14 +975,14 @@ def testTilesDZIEndpoints(server, admin, fsAssetstore):
     assert 'Width="%d"' % tileMetadata['sizeX'] in xml
     assert 'Overlap="0"' in xml
     resp = server.request(path='/item/%s/tiles/dzi.dzi' % itemId, params={
-        'overlap': 4
+        'overlap': 4,
     }, user=admin, isJson=False)
     assert utilities.respStatus(resp) == 200
     xml = utilities.getBody(resp)
     assert 'Width="%d"' % tileMetadata['sizeX'] in xml
     assert 'Overlap="4"' in xml
     resp = server.request(path='/item/%s/tiles/dzi_files/8/0_0.png' % itemId, params={
-        'encoding': 'PNG'
+        'encoding': 'PNG',
     }, user=admin, isJson=False)
     assert utilities.respStatus(resp) == 200
     image = utilities.getBody(resp, text=False)
@@ -992,37 +992,37 @@ def testTilesDZIEndpoints(server, admin, fsAssetstore):
     assert height == 48
     resp = server.request(path='/item/%s/tiles/dzi_files/8/0_0.png' % itemId, params={
         'encoding': 'PNG',
-        'overlap': 4
+        'overlap': 4,
     }, user=admin, isJson=False)
     assert utilities.respStatus(resp) == 200
     assert utilities.getBody(resp, text=False) == image
     # Test bad queries
     resp = server.request(path='/item/%s/tiles/dzi.dzi' % itemId, params={
-        'encoding': 'TIFF'
+        'encoding': 'TIFF',
     }, user=admin)
     assert utilities.respStatus(resp) == 400
     resp = server.request(path='/item/%s/tiles/dzi.dzi' % itemId, params={
-        'tilesize': 128
+        'tilesize': 128,
     }, user=admin, isJson=False)
     assert utilities.respStatus(resp) == 200
     resp = server.request(path='/item/%s/tiles/dzi.dzi' % itemId, params={
-        'tilesize': 129
+        'tilesize': 129,
     }, user=admin)
     assert utilities.respStatus(resp) == 400
     resp = server.request(path='/item/%s/tiles/dzi.dzi' % itemId, params={
-        'overlap': -1
+        'overlap': -1,
     }, user=admin)
     assert utilities.respStatus(resp) == 400
     resp = server.request(path='/item/%s/tiles/dzi_files/8/0_0.png' % itemId, params={
-        'tilesize': 128
+        'tilesize': 128,
     }, user=admin, isJson=False)
     assert utilities.respStatus(resp) == 200
     resp = server.request(path='/item/%s/tiles/dzi_files/8/0_0.png' % itemId, params={
-        'tilesize': 129
+        'tilesize': 129,
     }, user=admin)
     assert utilities.respStatus(resp) == 400
     resp = server.request(path='/item/%s/tiles/dzi_files/8/0_0.png' % itemId, params={
-        'overlap': -1
+        'overlap': -1,
     }, user=admin)
     assert utilities.respStatus(resp) == 400
     resp = server.request(path='/item/%s/tiles/dzi_files/0/0_0.png' % itemId, user=admin)
@@ -1036,7 +1036,7 @@ def testTilesDZIEndpoints(server, admin, fsAssetstore):
     # Test tile sizes
     resp = server.request(path='/item/%s/tiles/dzi_files/12/0_0.png' % itemId, params={
         'encoding': 'PNG',
-        'overlap': 4
+        'overlap': 4,
     }, user=admin, isJson=False)
     assert utilities.respStatus(resp) == 200
     image = utilities.getBody(resp, text=False)
@@ -1045,7 +1045,7 @@ def testTilesDZIEndpoints(server, admin, fsAssetstore):
     assert height == 260
     resp = server.request(path='/item/%s/tiles/dzi_files/12/0_1.png' % itemId, params={
         'encoding': 'PNG',
-        'overlap': 4
+        'overlap': 4,
     }, user=admin, isJson=False)
     assert utilities.respStatus(resp) == 200
     image = utilities.getBody(resp, text=False)
@@ -1054,7 +1054,7 @@ def testTilesDZIEndpoints(server, admin, fsAssetstore):
     assert height == 264
     resp = server.request(path='/item/%s/tiles/dzi_files/12/2_1.png' % itemId, params={
         'encoding': 'PNG',
-        'overlap': 4
+        'overlap': 4,
     }, user=admin, isJson=False)
     assert utilities.respStatus(resp) == 200
     image = utilities.getBody(resp, text=False)
@@ -1063,7 +1063,7 @@ def testTilesDZIEndpoints(server, admin, fsAssetstore):
     assert height == 264
     resp = server.request(path='/item/%s/tiles/dzi_files/12/14_2.png' % itemId, params={
         'encoding': 'PNG',
-        'overlap': 4
+        'overlap': 4,
     }, user=admin, isJson=False)
     assert utilities.respStatus(resp) == 200
     image = utilities.getBody(resp, text=False)
@@ -1072,7 +1072,7 @@ def testTilesDZIEndpoints(server, admin, fsAssetstore):
     assert height == 260
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesAfterCopyItem(boundServer, admin, fsAssetstore, girderWorker):
@@ -1287,7 +1287,7 @@ def testTilesBandInformationWithFrames(server, admin, fsAssetstore):
     assert resp != resp2
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesFromMultipleDotName(boundServer, admin, fsAssetstore, girderWorker):
@@ -1307,7 +1307,7 @@ def testTilesFromMultipleDotName(boundServer, admin, fsAssetstore, girderWorker)
     _testTilesZXY(boundServer, admin, itemId, tileMetadata)
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesForcedConversion(boundServer, admin, fsAssetstore, girderWorker):
@@ -1325,7 +1325,7 @@ def testTilesForcedConversion(boundServer, admin, fsAssetstore, girderWorker):
     assert item['largeImage']['fileId'] != fileId
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesFromWithOptions(boundServer, admin, fsAssetstore, girderWorker):
@@ -1348,7 +1348,7 @@ def testTilesConvertLocal(boundServer, admin, fsAssetstore):
 
     headers = {
         'Accept': 'application/json',
-        'Girder-Token': str(Token().createToken(admin)['_id'])
+        'Girder-Token': str(Token().createToken(admin)['_id']),
     }
     req = requests.post('http://127.0.0.1:%d/api/v1/item/%s/tiles/convert' % (
         boundServer.boundPort, itemId), headers=headers)
@@ -1371,7 +1371,7 @@ def testTilesConvertLocal(boundServer, admin, fsAssetstore):
     _testTilesZXY(boundServer, admin, itemId, tileMetadata)
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
 def testTilesConvertRemote(boundServer, admin, fsAssetstore, girderWorker):
@@ -1380,7 +1380,7 @@ def testTilesConvertRemote(boundServer, admin, fsAssetstore, girderWorker):
 
     headers = {
         'Accept': 'application/json',
-        'Girder-Token': str(Token().createToken(admin)['_id'])
+        'Girder-Token': str(Token().createToken(admin)['_id']),
     }
     req = requests.post('http://127.0.0.1:%d/api/v1/item/%s/tiles/convert' % (
         boundServer.boundPort, itemId), headers=headers,

--- a/girder/test_girder/test_web_client.py
+++ b/girder/test_girder/test_web_client.py
@@ -11,12 +11,12 @@ except ImportError:
     pass
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
-@pytest.mark.parametrize('spec', (
+@pytest.mark.parametrize('spec', [
     'imageViewerSpec.js',
-))
+])
 def testWebClient(boundServer, fsAssetstore, db, spec, girderWorker):
     spec = os.path.join(os.path.dirname(__file__), 'web_client_specs', spec)
     runWebClientTest(boundServer, spec, 15000)
@@ -24,21 +24,21 @@ def testWebClient(boundServer, fsAssetstore, db, spec, girderWorker):
 
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
-@pytest.mark.parametrize('spec', (
+@pytest.mark.parametrize('spec', [
     'largeImageSpec.js',
     'otherFeatures.js',
-))
+])
 def testWebClientNoWorker(boundServer, fsAssetstore, db, spec):
     spec = os.path.join(os.path.dirname(__file__), 'web_client_specs', spec)
     runWebClientTest(boundServer, spec, 15000)
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')
-@pytest.mark.parametrize('spec', (
+@pytest.mark.parametrize('spec', [
     'imageViewerSpec.js',
-))
+])
 def testWebClientNoStream(boundServer, fsAssetstore, db, spec, girderWorker):
     from girder.models.setting import Setting
     from girder.settings import SettingKey

--- a/girder_annotation/girder_large_image_annotation/handlers.py
+++ b/girder_annotation/girder_large_image_annotation/handlers.py
@@ -113,7 +113,7 @@ def process_annotations(event):  # noqa: C901
 
     file = File().load(
         event.info.get('file', {}).get('_id'),
-        level=AccessType.READ, user=user
+        level=AccessType.READ, user=user,
     )
     startTime = time.time()
 
@@ -122,7 +122,8 @@ def process_annotations(event):  # noqa: C901
         return
     try:
         if file['size'] > 1 * 1024 ** 3:
-            raise Exception('File is larger than will be read into memory.')
+            msg = 'File is larger than will be read into memory.'
+            raise Exception(msg)
         data = []
         with File().open(file) as fptr:
             while True:

--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -23,7 +23,7 @@ import time
 
 import cherrypy
 import jsonschema
-import numpy
+import numpy as np
 from bson import ObjectId
 from girder_large_image import constants
 from girder_large_image.models.image_item import ImageItem
@@ -61,25 +61,25 @@ class AnnotationSchema:
         'type': 'array',
         # TODO: validate that z==0 for now
         'items': {
-            'type': 'number'
+            'type': 'number',
         },
         'minItems': 3,
         'maxItems': 3,
         'name': 'Coordinate',
         # TODO: define origin for 3D images
         'description': 'An X, Y, Z coordinate tuple, in base layer pixel '
-                       'coordinates, where the origin is the upper-left.'
+                       'coordinates, where the origin is the upper-left.',
     }
     coordValueSchema = {
         'type': 'array',
         'items': {
-            'type': 'number'
+            'type': 'number',
         },
         'minItems': 4,
         'maxItems': 4,
         'name': 'CoordinateWithValue',
         'description': 'An X, Y, Z, value coordinate tuple, in base layer '
-                       'pixel coordinates, where the origin is the upper-left.'
+                       'pixel coordinates, where the origin is the upper-left.',
     }
 
     colorSchema = {
@@ -113,7 +113,7 @@ class AnnotationSchema:
 
     userSchema = {
         'type': 'object',
-        'additionalProperties': True
+        'additionalProperties': True,
     }
 
     labelSchema = {
@@ -123,7 +123,7 @@ class AnnotationSchema:
             'visibility': {
                 'type': 'string',
                 # TODO: change to True, False, None?
-                'enum': ['hidden', 'always', 'onhover']
+                'enum': ['hidden', 'always', 'onhover'],
             },
             'fontSize': {
                 'type': 'number',
@@ -132,7 +132,7 @@ class AnnotationSchema:
             'color': colorSchema,
         },
         'required': ['value'],
-        'additionalProperties': False
+        'additionalProperties': False,
     }
 
     groupSchema = {'type': 'string'}
@@ -148,17 +148,17 @@ class AnnotationSchema:
             # schema free field for users to extend annotations
             'user': userSchema,
             'label': labelSchema,
-            'group': groupSchema
+            'group': groupSchema,
         },
         'required': ['type'],
-        'additionalProperties': True
+        'additionalProperties': True,
     }
     baseShapeSchema = extendSchema(baseElementSchema, {
         'properties': {
             'lineColor': colorSchema,
             'lineWidth': {
                 'type': 'number',
-                'minimum': 0
+                'minimum': 0,
             },
         },
     })
@@ -167,20 +167,20 @@ class AnnotationSchema:
         'properties': {
             'type': {
                 'type': 'string',
-                'enum': ['point']
+                'enum': ['point'],
             },
             'center': coordSchema,
-            'fillColor': colorSchema
+            'fillColor': colorSchema,
         },
         'required': ['type', 'center'],
-        'additionalProperties': False
+        'additionalProperties': False,
     })
 
     arrowShapeSchema = extendSchema(baseShapeSchema, {
         'properties': {
             'type': {
                 'type': 'string',
-                'enum': ['arrow']
+                'enum': ['arrow'],
             },
             'points': {
                 'type': 'array',
@@ -188,35 +188,35 @@ class AnnotationSchema:
                 'minItems': 2,
                 'maxItems': 2,
             },
-            'fillColor': colorSchema
+            'fillColor': colorSchema,
         },
         'description': 'The first point is the head of the arrow',
         'required': ['type', 'points'],
-        'additionalProperties': False
+        'additionalProperties': False,
     })
 
     circleShapeSchema = extendSchema(baseShapeSchema, {
         'properties': {
             'type': {
                 'type': 'string',
-                'enum': ['circle']
+                'enum': ['circle'],
             },
             'center': coordSchema,
             'radius': {
                 'type': 'number',
-                'minimum': 0
+                'minimum': 0,
             },
-            'fillColor': colorSchema
+            'fillColor': colorSchema,
         },
         'required': ['type', 'center', 'radius'],
-        'additionalProperties': False
+        'additionalProperties': False,
     })
 
     polylineShapeSchema = extendSchema(baseShapeSchema, {
         'properties': {
             'type': {
                 'type': 'string',
-                'enum': ['polyline']
+                'enum': ['polyline'],
             },
             'points': {
                 'type': 'array',
@@ -227,7 +227,7 @@ class AnnotationSchema:
             'closed': {
                 'type': 'boolean',
                 'description': 'polyline is open if closed flag is '
-                               'not specified'
+                               'not specified',
             },
             'holes': {
                 'type': 'array',
@@ -244,7 +244,7 @@ class AnnotationSchema:
             },
         },
         'required': ['type', 'points'],
-        'additionalProperties': False
+        'additionalProperties': False,
     })
 
     baseRectangleShapeSchema = extendSchema(baseShapeSchema, {
@@ -253,18 +253,18 @@ class AnnotationSchema:
             'center': coordSchema,
             'width': {
                 'type': 'number',
-                'minimum': 0
+                'minimum': 0,
             },
             'height': {
                 'type': 'number',
-                'minimum': 0
+                'minimum': 0,
             },
             'rotation': {
                 'type': 'number',
                 'description': 'radians counterclockwise around normal',
             },
             'normal': coordSchema,
-            'fillColor': colorSchema
+            'fillColor': colorSchema,
         },
         'decription': 'normal is the positive z-axis unless otherwise '
                       'specified',
@@ -275,24 +275,24 @@ class AnnotationSchema:
         'properties': {
             'type': {
                 'type': 'string',
-                'enum': ['rectangle']
+                'enum': ['rectangle'],
             },
         },
-        'additionalProperties': False
+        'additionalProperties': False,
     })
     rectangleGridShapeSchema = extendSchema(baseRectangleShapeSchema, {
         'properties': {
             'type': {
                 'type': 'string',
-                'enum': ['rectanglegrid']
+                'enum': ['rectanglegrid'],
             },
             'widthSubdivisions': {
                 'type': 'integer',
-                'minimum': 1
+                'minimum': 1,
             },
             'heightSubdivisions': {
                 'type': 'integer',
-                'minimum': 1
+                'minimum': 1,
             },
         },
         'required': ['type', 'widthSubdivisions', 'heightSubdivisions'],
@@ -302,18 +302,18 @@ class AnnotationSchema:
         'properties': {
             'type': {
                 'type': 'string',
-                'enum': ['ellipse']
+                'enum': ['ellipse'],
             },
         },
         'required': ['type'],
-        'additionalProperties': False
+        'additionalProperties': False,
     })
 
     heatmapSchema = extendSchema(baseElementSchema, {
         'properties': {
             'type': {
                 'type': 'string',
-                'enum': ['heatmap']
+                'enum': ['heatmap'],
             },
             'points': {
                 'type': 'array',
@@ -337,8 +337,8 @@ class AnnotationSchema:
                 'type': 'boolean',
                 'description':
                     'If true, scale the size of points with the '
-                    'zoom level of the map.'
-            }
+                    'zoom level of the map.',
+            },
         },
         'required': ['type', 'points'],
         'additionalProperties': False,
@@ -351,7 +351,7 @@ class AnnotationSchema:
         'properties': {
             'type': {
                 'type': 'string',
-                'enum': ['griddata']
+                'enum': ['griddata'],
             },
             'origin': coordSchema,
             'dx': {
@@ -376,7 +376,7 @@ class AnnotationSchema:
             },
             'interpretation': {
                 'type': 'string',
-                'enum': ['heatmap', 'contour', 'choropleth']
+                'enum': ['heatmap', 'contour', 'choropleth'],
             },
             'radius': {
                 'type': 'number',
@@ -412,32 +412,32 @@ class AnnotationSchema:
         'items': {
             'type': 'array',
             'minItems': 2,
-            'maxItems': 2
+            'maxItems': 2,
         },
         'minItems': 2,
         'maxItems': 2,
         'description': 'A 2D matrix representing the transform of an '
-                       'image overlay.'
+                       'image overlay.',
     }
 
     overlaySchema = extendSchema(baseElementSchema, {
         'properties': {
             'type': {
                 'type': 'string',
-                'enum': ['image']
+                'enum': ['image'],
             },
             'girderId': {
                 'type': 'string',
                 'pattern': '^[0-9a-f]{24}$',
                 'description': 'Girder item ID containing the image to '
-                               'overlay.'
+                               'overlay.',
             },
             'opacity': {
                 'type': 'number',
                 'minimum': 0,
                 'maximum': 1,
                 'description': 'Default opacity for this image overlay. Must '
-                               'be between 0 and 1. Defaults to 1.'
+                               'be between 0 and 1. Defaults to 1.',
             },
             'hasAlpha': {
                 'type': 'boolean',
@@ -452,14 +452,14 @@ class AnnotationSchema:
                                'an X offset and a Y offset.',
                 'properties': {
                     'xoffset': {
-                        'type': 'number'
+                        'type': 'number',
                     },
                     'yoffset': {
-                        'type': 'number'
+                        'type': 'number',
                     },
-                    'matrix': transformArray
+                    'matrix': transformArray,
                 },
-            }
+            },
         },
         'required': ['girderId', 'type'],
         'additionalProperties': False,
@@ -475,13 +475,13 @@ class AnnotationSchema:
                 'type': 'string',
                 'description': 'A string representing the semantic '
                                'meaning of regions of the map with '
-                               'the corresponding color.'
+                               'the corresponding color.',
             },
             'description': {
                 'type': 'string',
                 'description': 'A more detailed explanation of the '
-                               'meaining of this category.'
-            }
+                               'meaining of this category.',
+            },
         },
         'required': ['fillColor'],
         'additionalProperties': False,
@@ -500,7 +500,7 @@ class AnnotationSchema:
                                'correspond to pixel values in the '
                                'pixel map image and the values are '
                                'used to look up the appropriate '
-                               'color in the categories property.'
+                               'color in the categories property.',
             },
             'categories': {
                 'type': 'array',
@@ -508,7 +508,7 @@ class AnnotationSchema:
                 'description': 'An array used to map between the '
                                'values array and color values. '
                                'Can also contain semantic '
-                               'information for color values.'
+                               'information for color values.',
             },
             'boundaries': {
                 'type': 'boolean',
@@ -518,7 +518,7 @@ class AnnotationSchema:
                                'of each superpixel. If true, the '
                                'length of the values array should be '
                                'half of the maximum value in the '
-                               'pixelmap.'
+                               'pixelmap.',
 
             },
         },
@@ -545,7 +545,7 @@ class AnnotationSchema:
             rectangleGridShapeSchema,
             overlaySchema,
             pixelmapSchema,
-        ]
+        ],
     }
 
     annotationSchema = {
@@ -563,7 +563,7 @@ class AnnotationSchema:
                 'additionalProperties': True,
                 'title': 'Image Attributes',
                 'description': 'Subjective things that apply to the entire '
-                               'image.'
+                               'image.',
             },
             'elements': {
                 'type': 'array',
@@ -572,10 +572,10 @@ class AnnotationSchema:
                 # they are not set, we assign them from Mongo.
                 'title': 'Image Markup',
                 'description': 'Subjective things that apply to a '
-                               'spatial region.'
-            }
+                               'spatial region.',
+            },
         },
-        'additionalProperties': False
+        'additionalProperties': False,
     }
 
 
@@ -611,7 +611,7 @@ class Annotation(AccessControlledModel):
         'updatedId',
         'public',
         'publicFlags',
-        'groups'
+        'groups',
         # 'skill',
         # 'startTime'
         # 'stopTime'
@@ -960,7 +960,7 @@ class Annotation(AccessControlledModel):
 
         logger.debug('Saved annotation in %5.3fs' % (time.time() - starttime))
         events.trigger('large_image.annotations.save_history', {
-            'annotation': annotation
+            'annotation': annotation,
         }, asynchronous=True)
         return result
 
@@ -1082,7 +1082,7 @@ class Annotation(AccessControlledModel):
                     try:
                         # Check if the entire array converts in an obvious
                         # manner
-                        numpy.array(element[key], dtype=float)
+                        np.array(element[key], dtype=float)
                         keys[key] = element[key]
                         element[key] = element[key][:VALIDATE_ARRAY_LENGTH]
                     except Exception:
@@ -1091,7 +1091,7 @@ class Annotation(AccessControlledModel):
                     key = 'holes'
                     try:
                         for h in element['holes']:
-                            numpy.array(h, dtype=float)
+                            np.array(h, dtype=float)
                         keys[key] = element[key]
                         element[key] = []
                     except Exception:
@@ -1118,7 +1118,8 @@ class Annotation(AccessControlledModel):
         elementIds = [entry['id'] for entry in
                       doc['annotation'].get('elements', []) if 'id' in entry]
         if len(set(elementIds)) != len(elementIds):
-            raise ValidationException('Annotation Element IDs are not unique')
+            msg = 'Annotation Element IDs are not unique'
+            raise ValidationException(msg)
         return doc
 
     def versionList(self, annotationId, user=None, limit=0, offset=0,
@@ -1168,7 +1169,7 @@ class Annotation(AccessControlledModel):
             annotationId = ObjectId(annotationId)
         entry = self.findOne({
             '$or': [{'_id': annotationId}, {'_annotationId': annotationId}],
-            '_version': int(version)
+            '_version': int(version),
         }, fields=['_id'])
         if not entry:
             return None
@@ -1266,12 +1267,12 @@ class Annotation(AccessControlledModel):
         if 'groups' not in annotation:
             annotation['groups'] = Annotationelement().getElementGroupSet(annotation)
             query = {
-                '_id': ObjectId(annotation['_id'])
+                '_id': ObjectId(annotation['_id']),
             }
             update = {
                 '$set': {
-                    'groups': annotation['groups']
-                }
+                    'groups': annotation['groups'],
+                },
             }
             self.collection.update_one(query, update)
         return annotation
@@ -1306,10 +1307,12 @@ class Annotation(AccessControlledModel):
             of any annotation, regardless of age.
         """
         if (remove and minAgeInDays < 7) or minAgeInDays < 0:
-            raise ValidationException('minAgeInDays must be >= 7')
+            msg = 'minAgeInDays must be >= 7'
+            raise ValidationException(msg)
         age = datetime.datetime.utcnow() + datetime.timedelta(-minAgeInDays)
         if keepInactiveVersions < 0:
-            raise ValidationException('keepInactiveVersions mist be non-negative')
+            msg = 'keepInactiveVersions mist be non-negative'
+            raise ValidationException(msg)
         report = {'fromDeletedItems': 0, 'oldVersions': 0, 'active': 0, 'recentVersions': 0}
         if remove:
             report['removedVersions'] = 0

--- a/girder_annotation/girder_large_image_annotation/models/annotationelement.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotationelement.py
@@ -64,20 +64,20 @@ class Annotationelement(Model):
                 ('bbox.highx', SortDir.ASCENDING),
                 ('bbox.size', SortDir.DESCENDING),
             ], {
-                'name': 'annotationBboxIdx'
+                'name': 'annotationBboxIdx',
             }),
             ([
                 ('annotationId', SortDir.ASCENDING),
                 ('bbox.size', SortDir.DESCENDING),
             ], {
-                'name': 'annotationBboxSizeIdx'
+                'name': 'annotationBboxSizeIdx',
             }),
             ([
                 ('annotationId', SortDir.ASCENDING),
                 ('_version', SortDir.DESCENDING),
                 ('element.group', SortDir.ASCENDING),
             ], {
-                'name': 'annotationGroupIdx'
+                'name': 'annotationGroupIdx',
             }),
             ([
                 ('created', SortDir.ASCENDING),
@@ -109,7 +109,7 @@ class Annotationelement(Model):
                 startingId = self.collection.find_one({}, sort=[('_version', SortDir.DESCENDING)])
                 startingId = startingId['_version'] + 1 if startingId else 0
                 self.versionId = self.collection.insert_one(
-                    {'annotationId': 'version_sequence', '_version': startingId}
+                    {'annotationId': 'version_sequence', '_version': startingId},
                 ).inserted_id
             else:
                 self.versionId = versionObject['_id']
@@ -154,9 +154,8 @@ class Annotationelement(Model):
             are returned.
         """
         annotation['_elementQuery'] = {}
-        annotation['annotation']['elements'] = [
-            element for element in self.yieldElements(
-                annotation, region, annotation['_elementQuery'])]
+        annotation['annotation']['elements'] = list(self.yieldElements(
+            annotation, region, annotation['_elementQuery']))
 
     def yieldElements(self, annotation, region=None, info=None):  # noqa
         """
@@ -207,7 +206,7 @@ class Annotationelement(Model):
         region = region or {}
         query = {
             'annotationId': annotation.get('_annotationId', annotation['_id']),
-            '_version': annotation['_version']
+            '_version': annotation['_version'],
         }
         for key in region:
             if key in self.bboxKeys and self.bboxKeys[key][1]:
@@ -283,7 +282,7 @@ class Annotationelement(Model):
                     (bbox['lowx'] + bbox['highx']) / 2,
                     (bbox['lowy'] + bbox['highy']) / 2,
                     bbox['size'] if entry.get('type') != 'point' else 0,
-                    props[prop]
+                    props[prop],
                 ]
                 details += 1
             else:
@@ -341,7 +340,8 @@ class Annotationelement(Model):
         :type query: dict
         """
         if not query:
-            raise Exception('query must be specified')
+            msg = 'query must be specified'
+            raise Exception(msg)
 
         attachedQuery = query.copy()
         attachedQuery['datafile'] = {'$exists': True}
@@ -390,10 +390,9 @@ class Annotationelement(Model):
          during loading the image metadata will result in the tuple (0, 0, 0, 0).
         """
         if overlayElement.get('type') not in ['image', 'pixelmap']:
-            raise ValueError(
-                'Function _overlayBounds only accepts annotation elements of type "image", '
-                '"pixelmap."'
-            )
+            msg = ('Function _overlayBounds only accepts annotation elements '
+                   'of type "image", "pixelmap."')
+            raise ValueError(msg)
 
         import numpy as np
         lowx = highx = lowy = highy = 0
@@ -573,7 +572,7 @@ class Annotationelement(Model):
             '_version': annotation['_version'],
             'created': now,
             'bbox': self._boundingBox(element),
-            'element': element
+            'element': element,
         } for element in elements[chunk:chunk + chunkSize]]
         prepTime = time.time() - chunkStartTime
         if (len(entries) <= MAX_ELEMENT_CHECK and any(
@@ -614,7 +613,7 @@ class Annotationelement(Model):
     def getElementGroupSet(self, annotation):
         query = {
             'annotationId': annotation.get('_annotationId', annotation['_id']),
-            '_version': annotation['_version']
+            '_version': annotation['_version'],
         }
         groups = sorted([
             group for group in self.collection.distinct('element.group', filter=query)

--- a/girder_annotation/girder_large_image_annotation/rest/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/rest/annotation.py
@@ -85,7 +85,7 @@ class AnnotationResource(Resource):
                required=False)
         .pagingParams(defaultSort='lowerName')
         .errorResponse()
-        .errorResponse('Read access was denied on the parent item.', 403)
+        .errorResponse('Read access was denied on the parent item.', 403),
     )
     @access.public(scope=TokenScope.DATA_READ)
     @filtermodel(model='annotation', plugin='large_image')
@@ -111,7 +111,7 @@ class AnnotationResource(Resource):
         fields = list(
             (
                 'annotation.name', 'annotation.description', 'annotation.attributes',
-                'access', 'groups', '_version'
+                'access', 'groups', '_version',
             ) + Annotation().baseFields)
         return Annotation().findWithPermissions(
             query, sort=sort, fields=fields, user=self.getCurrentUser(),
@@ -121,7 +121,7 @@ class AnnotationResource(Resource):
         Description('Get the official Annotation schema')
         .notes('In addition to the schema, if IDs are specified on elements, '
                'all IDs must be unique.')
-        .errorResponse()
+        .errorResponse(),
     )
     @access.public(scope=TokenScope.DATA_READ)
     def getAnnotationSchema(self, params):
@@ -164,7 +164,7 @@ class AnnotationResource(Resource):
                       defaultSortDir=SortDir.ASCENDING)
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the annotation.', 403)
-        .notes('Use "size" or "details" as possible sort keys.')
+        .notes('Use "size" or "details" as possible sort keys.'),
     )
     @access.public(cookie=True, scope=TokenScope.DATA_READ)
     def getAnnotation(self, id, params):
@@ -173,7 +173,8 @@ class AnnotationResource(Resource):
             id, region=params, user=user, level=AccessType.READ, getElements=False)
         _handleETag('getAnnotation', annotation, params, max_age=86400 * 30)
         if annotation is None:
-            raise RestException('Annotation not found', 404)
+            msg = 'Annotation not found'
+            raise RestException(msg, 404)
         return self._getAnnotation(annotation, params)
 
     def _getAnnotation(self, annotation, params):
@@ -217,7 +218,7 @@ class AnnotationResource(Resource):
                     element['id'] = str(element['id'])
                 else:
                     element = struct.pack(
-                        '>QL', int(element[0][:16], 16), int(element[0][16:24], 16)
+                        '>QL', int(element[0][:16], 16), int(element[0][16:24], 16),
                     ) + struct.pack('<fffl', *element[1:])
                 # Use orjson; it is much faster.  The standard json library
                 # could be used in its most default mode instead like so:
@@ -267,7 +268,7 @@ class AnnotationResource(Resource):
         .errorResponse('ID was invalid.')
         .errorResponse('Read access was denied for the item.', 403)
         .errorResponse('Invalid JSON passed in request body.')
-        .errorResponse("Validation Error: JSON doesn't follow schema.")
+        .errorResponse("Validation Error: JSON doesn't follow schema."),
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(map={'itemId': 'item'}, model='item', level=AccessType.READ)
@@ -286,8 +287,8 @@ class AnnotationResource(Resource):
                     "Validation Error: JSON doesn't follow schema (%r)." % (
                         exc.args, ))
         else:
-            raise RestException('Write access and annotation creation access '
-                                'were denied for the item.', code=403)
+            msg = 'Write access and annotation creation access were denied for the item.'
+            raise RestException(msg, code=403)
 
     @describeRoute(
         Description('Copy an annotation from one item to an other.')
@@ -296,7 +297,7 @@ class AnnotationResource(Resource):
         .param('itemId', 'The ID of the destination item.',
                required=True)
         .errorResponse('ID was invalid.')
-        .errorResponse('Write access was denied for the item.', 403)
+        .errorResponse('Write access was denied for the item.', 403),
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='annotation', plugin='large_image', level=AccessType.READ)
@@ -322,7 +323,7 @@ class AnnotationResource(Resource):
                paramType='body', required=False)
         .errorResponse('Write access was denied for the item.', 403)
         .errorResponse('Invalid JSON passed in request body.')
-        .errorResponse("Validation Error: JSON doesn't follow schema.")
+        .errorResponse("Validation Error: JSON doesn't follow schema."),
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='annotation', plugin='large_image', level=AccessType.WRITE)
@@ -364,7 +365,7 @@ class AnnotationResource(Resource):
         Description('Delete an annotation.')
         .param('id', 'The ID of the annotation.', paramType='path')
         .errorResponse('ID was invalid.')
-        .errorResponse('Write access was denied for the annotation.', 403)
+        .errorResponse('Write access was denied for the annotation.', 403),
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     # Load with a limit of 1 so that we don't bother getting most annotations
@@ -389,7 +390,7 @@ class AnnotationResource(Resource):
         .param('creatorId', 'Limit to annotations created by this user', required=False)
         .param('imageName', 'Filter results by image name (case-insensitive)', required=False)
         .pagingParams(defaultSort='updated', defaultSortDir=-1)
-        .errorResponse()
+        .errorResponse(),
     )
     @access.public(scope=TokenScope.DATA_READ)
     def findAnnotatedImages(self, params):
@@ -410,7 +411,7 @@ class AnnotationResource(Resource):
         Description('Get the access control list for an annotation.')
         .param('id', 'The ID of the annotation.', paramType='path')
         .errorResponse('ID was invalid.')
-        .errorResponse('Admin access was denied for the annotation.', 403)
+        .errorResponse('Admin access was denied for the annotation.', 403),
     )
     @access.user(scope=TokenScope.DATA_OWN)
     @loadmodel(model='annotation', plugin='large_image', getElements=False, level=AccessType.ADMIN)
@@ -424,7 +425,7 @@ class AnnotationResource(Resource):
         .param('public', 'Whether the annotation should be publicly visible.',
                dataType='boolean', required=False)
         .errorResponse('ID was invalid.')
-        .errorResponse('Admin access was denied for the annotation.', 403)
+        .errorResponse('Admin access was denied for the annotation.', 403),
     )
     @access.user(scope=TokenScope.DATA_OWN)
     @loadmodel(model='annotation', plugin='large_image', getElements=False, level=AccessType.ADMIN)
@@ -446,7 +447,7 @@ class AnnotationResource(Resource):
         .param('id', 'The ID of the annotation.', paramType='path')
         .pagingParams(defaultSort='_version', defaultLimit=0,
                       defaultSortDir=SortDir.DESCENDING)
-        .errorResponse('Read access was denied for the annotation.', 403)
+        .errorResponse('Read access was denied for the annotation.', 403),
     )
     @access.public(cookie=True, scope=TokenScope.DATA_READ)
     def getAnnotationHistoryList(self, id, limit, offset, sort):
@@ -458,13 +459,14 @@ class AnnotationResource(Resource):
         .param('version', 'The version of the annotation.', paramType='path',
                dataType='integer')
         .errorResponse('Annotation history version not found.')
-        .errorResponse('Read access was denied for the annotation.', 403)
+        .errorResponse('Read access was denied for the annotation.', 403),
     )
     @access.public(cookie=True, scope=TokenScope.DATA_READ)
     def getAnnotationHistory(self, id, version):
         result = Annotation().getVersion(id, version, self.getCurrentUser())
         if result is None:
-            raise RestException('Annotation history version not found.')
+            msg = 'Annotation history version not found.'
+            raise RestException(msg)
         return result
 
     @autoDescribeRoute(
@@ -477,14 +479,15 @@ class AnnotationResource(Resource):
                'not deleted, this reverts to the previous version.',
                required=False, dataType='integer')
         .errorResponse('Annotation history version not found.')
-        .errorResponse('Read access was denied for the annotation.', 403)
+        .errorResponse('Read access was denied for the annotation.', 403),
     )
     @access.public(scope=TokenScope.DATA_WRITE)
     def revertAnnotationHistory(self, id, version):
         setResponseTimeLimit(86400)
         annotation = Annotation().revertVersion(id, version, self.getCurrentUser())
         if not annotation:
-            raise RestException('Annotation history version not found.')
+            msg = 'Annotation history version not found.'
+            raise RestException(msg)
         # Don't return the elements -- it can be too verbose
         if 'elements' in annotation['annotation']:
             del annotation['annotation']['elements']
@@ -495,7 +498,7 @@ class AnnotationResource(Resource):
         .notes('This returns a list of annotation model records.')
         .modelParam('id', model=Item, level=AccessType.READ)
         .errorResponse('ID was invalid.')
-        .errorResponse('Read access was denied for the item.', 403)
+        .errorResponse('Read access was denied for the item.', 403),
     )
     @access.public(cookie=True, scope=TokenScope.DATA_READ)
     def getItemAnnotations(self, item):
@@ -533,7 +536,7 @@ class AnnotationResource(Resource):
         .errorResponse('ID was invalid.')
         .errorResponse('Write access was denied for the item.', 403)
         .errorResponse('Invalid JSON passed in request body.')
-        .errorResponse("Validation Error: JSON doesn't follow schema.")
+        .errorResponse("Validation Error: JSON doesn't follow schema."),
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     def createItemAnnotations(self, item, annotations):
@@ -548,7 +551,8 @@ class AnnotationResource(Resource):
             annotations = [annotations]
         for entry in annotations:
             if not isinstance(entry, dict):
-                raise RestException('Entries in the annotation list must be JSON objects.')
+                msg = 'Entries in the annotation list must be JSON objects.'
+                raise RestException(msg)
             annotation = entry.get('annotation', entry)
             try:
                 Annotation().createAnnotation(item, user, annotation)
@@ -564,7 +568,7 @@ class AnnotationResource(Resource):
         .notes('This deletes all annotation model records.')
         .modelParam('id', model=Item, level=AccessType.WRITE)
         .errorResponse('ID was invalid.')
-        .errorResponse('Write access was denied for the item.', 403)
+        .errorResponse('Write access was denied for the item.', 403),
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     def deleteItemAnnotations(self, item):
@@ -589,15 +593,15 @@ class AnnotationResource(Resource):
                     {'access.users':
                         {'$elemMatch': {
                             'id': user['_id'],
-                            'level': {'$gte': 2}
+                            'level': {'$gte': 2},
                         }}},
                     {'access.groups':
                         {'$elemMatch': {
                             'id': {'$in': user['groups']},
-                            'level': {'$gte': 2}
-                        }}}
-                ]
-            }}
+                            'level': {'$gte': 2},
+                        }}},
+                ],
+            }},
         ] if not user['admin'] else []
         recursivePipeline = [
             {'$match': {'_id': ObjectId(id)}},
@@ -615,7 +619,7 @@ class AnnotationResource(Resource):
                 'as': '__self',
             }},
             {'$project': {'__children': {'$concatArrays': [
-                '$__self', '$__children'
+                '$__self', '$__children',
             ]}}},
             {'$unwind': {'path': '$__children'}},
             {'$replaceRoot': {'newRoot': '$__children'}},
@@ -638,19 +642,19 @@ class AnnotationResource(Resource):
                 'let': {'fid': '$_id'},
                 'pipeline': [
                     {'$match': {'$expr': {'$eq': ['$$fid', '$folderId']}}},
-                    {'$project': {'_id': 1}}
+                    {'$project': {'_id': 1}},
                 ],
-                'as': '__items'
+                'as': '__items',
             }},
             {'$lookup': {
                 'from': 'annotation',
                 'localField': '__items._id',
                 'foreignField': 'itemId',
-                'as': '__annotations'
+                'as': '__annotations',
             }},
             {'$unwind': '$__annotations'},
             {'$replaceRoot': {'newRoot': '$__annotations'}},
-            {'$match': {'_active': {'$ne': False}}}
+            {'$match': {'_active': {'$ne': False}}},
         ] + accessPipeline
 
         if count:
@@ -666,7 +670,7 @@ class AnnotationResource(Resource):
         .param('id', 'The ID of the folder', required=True, paramType='path')
         .param('recurse', 'Whether or not to recursively check '
                'subfolders for annotations', required=False, default=True, dataType='boolean')
-        .errorResponse()
+        .errorResponse(),
     )
     @access.public(scope=TokenScope.DATA_READ)
     def existFolderAnnotations(self, id, recurse):
@@ -686,7 +690,7 @@ class AnnotationResource(Resource):
         .param('recurse', 'Whether or not to retrieve all '
                'annotations from subfolders', required=False, default=False, dataType='boolean')
         .pagingParams(defaultSort='created', defaultSortDir=-1)
-        .errorResponse()
+        .errorResponse(),
     )
     @access.public(scope=TokenScope.DATA_READ)
     def returnFolderAnnotations(self, id, recurse, limit, offset, sort):
@@ -710,7 +714,7 @@ class AnnotationResource(Resource):
     @autoDescribeRoute(
         Description('Check if the user can create annotations in a folder')
         .param('id', 'The ID of the folder', required=True, paramType='path')
-        .errorResponse('ID was invalid.')
+        .errorResponse('ID was invalid.'),
     )
     @access.user(scope=TokenScope.DATA_READ)
     @loadmodel(model='folder', level=AccessType.READ)
@@ -727,7 +731,7 @@ class AnnotationResource(Resource):
                dataType='boolean', required=False)
         .param('recurse', 'Whether or not to retrieve all '
                'annotations from subfolders', required=False, default=False, dataType='boolean')
-        .errorResponse('ID was invalid.')
+        .errorResponse('ID was invalid.'),
     )
     @access.user(scope=TokenScope.DATA_OWN)
     def setFolderAnnotationAccess(self, id, params):
@@ -756,7 +760,7 @@ class AnnotationResource(Resource):
         .param('id', 'The ID of the folder', required=True, paramType='path')
         .param('recurse', 'Whether or not to retrieve all '
                'annotations from subfolders', required=False, default=False, dataType='boolean')
-        .errorResponse('ID was invalid.')
+        .errorResponse('ID was invalid.'),
     )
     @access.user(scope=TokenScope.DATA_WRITE)
     def deleteFolderAnnotations(self, id, params):
@@ -778,7 +782,7 @@ class AnnotationResource(Resource):
                dataType='int', default=30)
         .param('versions', 'Keep at least this many history entries for each '
                'annotation.', required=False, dataType='int', default=10)
-        .errorResponse()
+        .errorResponse(),
     )
     @access.admin(scope=TokenScope.DATA_READ)
     def getOldAnnotations(self, age, versions):
@@ -791,7 +795,7 @@ class AnnotationResource(Resource):
                dataType='int', default=30)
         .param('versions', 'Keep at least this many history entries for each '
                'annotation.', required=False, dataType='int', default=10)
-        .errorResponse()
+        .errorResponse(),
     )
     @access.admin(scope=TokenScope.DATA_WRITE)
     def deleteOldAnnotations(self, age, versions):
@@ -802,7 +806,7 @@ class AnnotationResource(Resource):
     @autoDescribeRoute(
         Description('Get annotation counts for a list of items.')
         .param('items', 'A comma-separated list of item ids.')
-        .errorResponse()
+        .errorResponse(),
     )
     def getItemListAnnotationCounts(self, items):
         user = self.getCurrentUser()
@@ -833,7 +837,7 @@ class AnnotationResource(Resource):
         .errorResponse(('ID was invalid.',
                         'Invalid JSON passed in request body.',
                         'Metadata key name was invalid.'))
-        .errorResponse('Write access was denied for the annotation.', 403)
+        .errorResponse('Write access was denied for the annotation.', 403),
     )
     @loadmodel(model='annotation', plugin='large_image', getElements=False, level=AccessType.WRITE)
     def setMetadata(self, annotation, metadata, allowNull):
@@ -850,14 +854,14 @@ class AnnotationResource(Resource):
             paramType='body', schema={
                 'type': 'array',
                 'items': {
-                    'type': 'string'
-                }
-            }
+                    'type': 'string',
+                },
+            },
         )
         .errorResponse(('ID was invalid.',
                         'Invalid JSON passed in request body.',
                         'Metadata key name was invalid.'))
-        .errorResponse('Write access was denied for the annotation.', 403)
+        .errorResponse('Write access was denied for the annotation.', 403),
     )
     @loadmodel(model='annotation', plugin='large_image', getElements=False, level=AccessType.WRITE)
     def deleteMetadata(self, annotation, fields):

--- a/girder_annotation/setup.py
+++ b/girder_annotation/setup.py
@@ -71,7 +71,7 @@ setup(
     zip_safe=False,
     entry_points={
         'girder.plugin': [
-            'large_image_annotation = girder_large_image_annotation:LargeImageAnnotationPlugin'
-        ]
+            'large_image_annotation = girder_large_image_annotation:LargeImageAnnotationPlugin',
+        ],
     },
 )

--- a/girder_annotation/test_annotation/conftest.py
+++ b/girder_annotation/test_annotation/conftest.py
@@ -14,13 +14,13 @@ def unbindGirderEventsByHandlerName(handlerName):
         events.unbind(eventName, handlerName)
 
 
-@pytest.fixture
+@pytest.fixture()
 def unbindLargeImage(db):
     yield True
     unbindGirderEventsByHandlerName('large_image')
 
 
-@pytest.fixture
+@pytest.fixture()
 def unbindAnnotation(db):
     yield True
     unbindGirderEventsByHandlerName('large_image_annotation')

--- a/girder_annotation/test_annotation/test_annotations.py
+++ b/girder_annotation/test_annotation/test_annotations.py
@@ -36,19 +36,19 @@ sampleAnnotation = {
         'center': [20.0, 25.0, 0],
         'width': 14.0,
         'height': 15.0,
-    }]
+    }],
 }
 sampleAnnotationWithMetadata = {
     'name': 'sample',
     'attributes': {
-        'key1': 'value1'
+        'key1': 'value1',
     },
     'elements': [{
         'type': 'rectangle',
         'center': [20.0, 25.0, 0],
         'width': 14.0,
         'height': 15.0,
-    }]
+    }],
 }
 
 
@@ -97,7 +97,7 @@ class TestLargeImageAnnotation:
                 'center': [10, 20, 0],
                 'width': 5,
                 'height': 10,
-            }]
+            }],
         }
         result = Annotation().createAnnotation(item, admin, annotation)
         assert '_id' in result
@@ -390,8 +390,8 @@ class TestLargeImageAnnotation:
             'name': 'testAnnotation',
             'elements': [{
                 'type': 'heatmap',
-                'points': [[random.random() for _ in range(4)] for _ in range(10240)]
-            }]
+                'points': [[random.random() for _ in range(4)] for _ in range(10240)],
+            }],
         }
         annot = Annotation().createAnnotation(item, admin, annotation)
         assert Annotation().load(annot['_id'], user=admin) is not None
@@ -412,8 +412,8 @@ class TestLargeImageAnnotation:
                 'dx': 3,
                 'dy': 4,
                 'gridWidth': 128,
-                'values': [random.random() for _ in range(10240)]
-            }]
+                'values': [random.random() for _ in range(10240)],
+            }],
         }
         annot = Annotation().createAnnotation(item, admin, annotation)
         assert Annotation().load(annot['_id'], user=admin) is not None
@@ -445,7 +445,7 @@ class TestLargeImageAnnotationElement:
 
         # test no transform
         lowx, highx, lowy, highy = Annotationelement()._overlayBounds({
-            'type': 'image', 'girderId': itemId
+            'type': 'image', 'girderId': itemId,
         })
         assert lowx == 0
         assert lowy == 0
@@ -455,7 +455,7 @@ class TestLargeImageAnnotationElement:
         # test offset
         lowx, highx, lowy, highy = Annotationelement()._overlayBounds({
             'type': 'image', 'girderId': itemId,
-            'transform': {'xoffset': 500, 'yoffset': 1000}
+            'transform': {'xoffset': 500, 'yoffset': 1000},
         })
         assert lowx == 500
         assert lowy == 1000
@@ -466,8 +466,8 @@ class TestLargeImageAnnotationElement:
         lowx, highx, lowy, highy = Annotationelement()._overlayBounds({
             'type': 'image', 'girderId': itemId,
             'transform': {
-                'matrix': [[0.5, 0], [0, 0.5]]
-            }
+                'matrix': [[0.5, 0], [0, 0.5]],
+            },
         })
         assert lowx == 0
         assert lowy == 0
@@ -480,8 +480,8 @@ class TestLargeImageAnnotationElement:
             'transform': {
                 'xoffset': 500,
                 'yoffset': 1000,
-                'matrix': [[0.5, 0], [0, 0.5]]
-            }
+                'matrix': [[0.5, 0], [0, 0.5]],
+            },
         })
         assert lowx == 500
         assert lowy == 1000
@@ -625,16 +625,16 @@ class TestLargeImageAnnotationElement:
             'center': [20.0, 25.0, 0],
             'width': 14.0,
             'height': 15.0,
-            'group': 'a'
+            'group': 'a',
         }, {
             'type': 'rectangle',
             'center': [40.0, 15.0, 0],
             'width': 5.0,
-            'height': 5.0
+            'height': 5.0,
         }]
         annotationWithGroup = {
             'name': 'groups',
-            'elements': elements
+            'elements': elements,
         }
 
         annot = Annotation().createAnnotation(item, admin, annotationWithGroup)

--- a/girder_annotation/test_annotation/test_annotations_rest.py
+++ b/girder_annotation/test_annotation/test_annotations_rest.py
@@ -166,8 +166,8 @@ class TestLargeImageAnnotationRest:
             method='POST',
             user=admin,
             params={
-                'itemId': itemDest.get('_id')
-            }
+                'itemId': itemDest.get('_id'),
+            },
         )
         assert utilities.respStatus(resp) == 200
         itemDest = Item().load(itemDest.get('_id'), level=AccessType.READ)
@@ -179,8 +179,8 @@ class TestLargeImageAnnotationRest:
             user=admin,
             params={
                 'itemId': itemDest.get('_id'),
-                'name': 'sample'
-            }
+                'name': 'sample',
+            },
         )
         assert utilities.respStatus(resp) == 200
         assert resp.json is not None
@@ -195,7 +195,7 @@ class TestLargeImageAnnotationRest:
         # Get all annotations for that item as the user
         resp = server.request(
             path='/annotation/item/{}'.format(itemSrc['_id']),
-            user=user
+            user=user,
         )
         assert utilities.respStatus(resp) == 200
         assert len(resp.json) == 1
@@ -204,7 +204,7 @@ class TestLargeImageAnnotationRest:
         # Get all annotations for that item as the admin
         resp = server.request(
             path='/annotation/item/{}'.format(itemSrc['_id']),
-            user=admin
+            user=admin,
         )
         assert utilities.respStatus(resp) == 200
         annotList = resp.json
@@ -222,7 +222,7 @@ class TestLargeImageAnnotationRest:
             method='POST',
             user=admin,
             type='application/json',
-            body=json.dumps(annotList)
+            body=json.dumps(annotList),
         )
         assert utilities.respStatus(resp) == 200
         assert resp.json == 2
@@ -234,8 +234,8 @@ class TestLargeImageAnnotationRest:
             user=admin,
             params={
                 'itemId': itemDest.get('_id'),
-                'name': 'sample'
-            }
+                'name': 'sample',
+            },
         )
         assert utilities.respStatus(resp) == 200
         assert resp.json is not None
@@ -246,7 +246,7 @@ class TestLargeImageAnnotationRest:
             method='POST',
             user=admin,
             type='application/json',
-            body=json.dumps(['not an object'])
+            body=json.dumps(['not an object']),
         )
         assert utilities.respStatus(resp) == 400
         resp = server.request(
@@ -254,7 +254,7 @@ class TestLargeImageAnnotationRest:
             method='POST',
             user=admin,
             type='application/json',
-            body=json.dumps([{'key': 'not an annotation'}])
+            body=json.dumps([{'key': 'not an annotation'}]),
         )
         assert utilities.respStatus(resp) == 400
 
@@ -262,14 +262,14 @@ class TestLargeImageAnnotationRest:
         resp = server.request(
             path='/annotation/item/{}'.format(itemDest['_id']),
             method='DELETE',
-            user=None
+            user=None,
         )
         assert utilities.respStatus(resp) == 401
 
         resp = server.request(
             path='/annotation/item/{}'.format(itemDest['_id']),
             method='DELETE',
-            user=admin
+            user=admin,
         )
         assert utilities.respStatus(resp) == 200
         assert resp.json == 2
@@ -308,7 +308,7 @@ class TestLargeImageAnnotationRest:
 
         # test default search
         resp = server.request('/annotation/images', user=admin, params={
-            'limit': 100
+            'limit': 100,
         })
         assert utilities.respStatus(resp) == 200
         ids = [image['_id'] for image in resp.json]
@@ -317,7 +317,7 @@ class TestLargeImageAnnotationRest:
         # test filtering by user
         resp = server.request('/annotation/images', user=admin, params={
             'limit': 100,
-            'creatorId': user['_id']
+            'creatorId': user['_id'],
         })
         assert utilities.respStatus(resp) == 200
         ids = [image['_id'] for image in resp.json]
@@ -325,7 +325,7 @@ class TestLargeImageAnnotationRest:
 
         # test getting annotations without admin access
         resp = server.request('/annotation/images', user=user, params={
-            'limit': 100
+            'limit': 100,
         })
         assert utilities.respStatus(resp) == 200
         ids = [image['_id'] for image in resp.json]
@@ -334,7 +334,7 @@ class TestLargeImageAnnotationRest:
         # test sort direction
         resp = server.request('/annotation/images', user=admin, params={
             'limit': 100,
-            'sortdir': 1
+            'sortdir': 1,
         })
         assert utilities.respStatus(resp) == 200
         ids = [image['_id'] for image in resp.json]
@@ -342,14 +342,14 @@ class TestLargeImageAnnotationRest:
 
         # test pagination
         resp = server.request('/annotation/images', user=admin, params={
-            'limit': 1
+            'limit': 1,
         })
         assert utilities.respStatus(resp) == 200
         assert resp.json[0]['_id'] == item4
 
         resp = server.request('/annotation/images', user=admin, params={
             'limit': 1,
-            'offset': 3
+            'offset': 3,
         })
         assert utilities.respStatus(resp) == 200
         assert resp.json[0]['_id'] == item1
@@ -357,7 +357,7 @@ class TestLargeImageAnnotationRest:
         # test filtering by image name
         resp = server.request('/annotation/images', user=admin, params={
             'limit': 100,
-            'imageName': 'image3-aBcd.ptif'
+            'imageName': 'image3-aBcd.ptif',
         })
         assert utilities.respStatus(resp) == 200
         ids = [image['_id'] for image in resp.json]
@@ -366,7 +366,7 @@ class TestLargeImageAnnotationRest:
         # test filtering by image name substring
         resp = server.request('/annotation/images', user=admin, params={
             'limit': 100,
-            'imageName': 'aBc'
+            'imageName': 'aBc',
         })
         assert utilities.respStatus(resp) == 200
         ids = [image['_id'] for image in resp.json]
@@ -375,7 +375,7 @@ class TestLargeImageAnnotationRest:
         # test filtering by image name with unicode
         resp = server.request('/annotation/images', user=admin, params={
             'limit': 100,
-            'imageName': 'Картина'
+            'imageName': 'Картина',
         })
         assert utilities.respStatus(resp) == 200
         ids = [image['_id'] for image in resp.json]
@@ -460,19 +460,19 @@ class TestLargeImageAnnotationRest:
             user=admin,
             params={
                 'access': json.dumps(access),
-                'public': False
-            }
+                'public': False,
+            },
         )
         assert utilities.respStatus(resp) == 200
         resp = server.request(
             '/annotation/%s' % annot['_id'],
-            user=user
+            user=user,
         )
         assert utilities.respStatus(resp) == 403
         # The admin should still be able to get the annotation with elements
         resp = server.request(
             '/annotation/%s' % annot['_id'],
-            user=admin
+            user=admin,
         )
         assert utilities.respStatus(resp) == 200
         assert len(resp.json['annotation']['elements']) == 1
@@ -482,15 +482,15 @@ class TestLargeImageAnnotationRest:
             'login': user['login'],
             'flags': [],
             'id': str(user['_id']),
-            'level': AccessType.ADMIN
+            'level': AccessType.ADMIN,
         })
         resp = server.request(
             '/annotation/%s/access' % annot['_id'],
             method='PUT',
             user=admin,
             params={
-                'access': json.dumps(access)
-            }
+                'access': json.dumps(access),
+            },
         )
         assert utilities.respStatus(resp) == 200
 
@@ -498,7 +498,7 @@ class TestLargeImageAnnotationRest:
         resp = server.request('/annotation/%s/access' % annot['_id'], user=user)
         assert utilities.respStatus(resp) == 200
 
-    @pytest.mark.singular
+    @pytest.mark.singular()
     def testAnnotationHistoryEndpoints(self, server, user, admin):
         privateFolder = utilities.namedFolder(admin, 'Private')
         Setting().set(constants.PluginSettings.LARGE_IMAGE_ANNOTATION_HISTORY, True)
@@ -551,13 +551,13 @@ class TestLargeImageAnnotationRest:
         resp = server.request(
             '/annotation/%s/history/revert' % (annot['_id']),
             method='PUT', user=admin, params={
-                'version': versions[0]['_version'] + 1
+                'version': versions[0]['_version'] + 1,
             })
         assert utilities.respStatus(resp) == 400
         resp = server.request(
             '/annotation/%s/history/revert' % (annot['_id']),
             method='PUT', user=admin, params={
-                'version': versions[1]['_version']
+                'version': versions[1]['_version'],
             })
         assert utilities.respStatus(resp) == 200
         loaded = Annotation().load(annot['_id'], user=admin)
@@ -641,9 +641,9 @@ class TestLargeImageAnnotationElementGroups:
                     'type': 'rectangle',
                     'center': [40.0, 15.0, 0],
                     'width': 5.0,
-                    'height': 5.0
-                }]
-            }
+                    'height': 5.0,
+                }],
+            },
         )
 
         self.notMigrated = annotationModel.createAnnotation(
@@ -655,19 +655,19 @@ class TestLargeImageAnnotationElementGroups:
                     'center': [20.0, 25.0, 0],
                     'width': 14.0,
                     'height': 15.0,
-                    'group': 'b'
+                    'group': 'b',
                 }, {
                     'type': 'rectangle',
                     'center': [40.0, 15.0, 0],
                     'width': 5.0,
                     'height': 5.0,
-                    'group': 'a'
-                }]
-            }
+                    'group': 'a',
+                }],
+            },
         )
         annotationModel.collection.update_one(
             {'_id': self.notMigrated['_id']},
-            {'$unset': {'groups': ''}}
+            {'$unset': {'groups': ''}},
         )
 
         self.hasGroups = annotationModel.createAnnotation(
@@ -679,20 +679,20 @@ class TestLargeImageAnnotationElementGroups:
                     'center': [20.0, 25.0, 0],
                     'width': 14.0,
                     'height': 15.0,
-                    'group': 'a'
+                    'group': 'a',
                 }, {
                     'type': 'rectangle',
                     'center': [40.0, 15.0, 0],
                     'width': 5.0,
                     'height': 5.0,
-                    'group': 'c'
+                    'group': 'c',
                 }, {
                     'type': 'rectangle',
                     'center': [50.0, 10.0, 0],
                     'width': 5.0,
-                    'height': 5.0
-                }]
-            }
+                    'height': 5.0,
+                }],
+            },
         )
         annotationModel._migrateDatabase()
 
@@ -709,7 +709,8 @@ class TestLargeImageAnnotationElementGroups:
             elif annot['_id'] == str(self.hasGroups['_id']):
                 assert annot['groups'] == ['a', 'c', None]
             else:
-                raise Exception('Unexpected annot id')
+                msg = 'Unexpected annot id'
+                raise Exception(msg)
 
     def testLoadAnnotation(self, server, admin):
         self.makeAnnot(admin)
@@ -726,8 +727,8 @@ class TestLargeImageAnnotationElementGroups:
                 'center': [20.0, 25.0, 0],
                 'width': 14.0,
                 'height': 15.0,
-                'group': 'a'
-            }]
+                'group': 'a',
+            }],
         }
         resp = server.request(
             '/annotation',
@@ -735,7 +736,7 @@ class TestLargeImageAnnotationElementGroups:
             method='POST',
             params={'itemId': str(self.item['_id'])},
             type='application/json',
-            body=json.dumps(annot)
+            body=json.dumps(annot),
         )
         assert utilities.respStatus(resp) == 200
 
@@ -752,15 +753,15 @@ class TestLargeImageAnnotationElementGroups:
                 'center': [20.0, 25.0, 0],
                 'width': 14.0,
                 'height': 15.0,
-                'group': 'd'
-            }]
+                'group': 'd',
+            }],
         }
         resp = server.request(
             '/annotation/%s' % str(self.hasGroups['_id']),
             user=admin,
             method='PUT',
             type='application/json',
-            body=json.dumps(annot)
+            body=json.dumps(annot),
         )
         assert utilities.respStatus(resp) == 200
 

--- a/girder_annotation/test_annotation/test_web_client.py
+++ b/girder_annotation/test_annotation/test_web_client.py
@@ -16,11 +16,11 @@ except ImportError:
 
 @pytest.mark.usefixtures('unbindLargeImage', 'unbindAnnotation')
 @pytest.mark.plugin('large_image_annotation')
-@pytest.mark.parametrize('spec', (
+@pytest.mark.parametrize('spec', [
     'annotationListSpec.js',
     'geojsAnnotationSpec.js',
     'geojsSpec.js',
-))
+])
 def testWebClientWithAnnotation(boundServer, fsAssetstore, db, spec):
     spec = os.path.join(os.path.dirname(__file__), 'web_client_specs', spec)
     runWebClientTest(boundServer, spec, 15000)

--- a/large_image/cache_util/__init__.py
+++ b/large_image/cache_util/__init__.py
@@ -63,7 +63,7 @@ def cachesInfo(*args, **kwargs):
             cache = LruCacheMetaclass.namedCaches[name][0]
             info[name] = {
                 'maxsize': cache.maxsize,
-                'used': cache.currsize
+                'used': cache.currsize,
             }
     if isTileCacheSetup():
         tileCache, tileLock = getTileCache()
@@ -73,7 +73,7 @@ def cachesInfo(*args, **kwargs):
                     'maxsize': tileCache.maxsize,
                     'used': tileCache.currsize,
                     'items': getattr(tileCache, 'curritems' if hasattr(
-                        tileCache, 'curritems') else 'currsize', None)
+                        tileCache, 'curritems') else 'currsize', None),
                 }
         except Exception:
             pass

--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -41,7 +41,7 @@ CacheProperties = {
         # The cache timeout is not currently being used, but it is set here in
         # case we ever choose to implement it.
         'cacheTimeout': 300,
-    }
+    },
 }
 
 

--- a/large_image/cache_util/cachefactory.py
+++ b/large_image/cache_util/cachefactory.py
@@ -63,7 +63,7 @@ def loadCaches(entryPointName='large_image.cache', sourceDict=_availableCaches):
             config.getConfig('logprint').debug(f'Loaded cache {entryPoint.name}')
         except Exception:
             config.getConfig('logprint').exception(
-                f'Failed to load cache {entryPoint.name}'
+                f'Failed to load cache {entryPoint.name}',
             )
     # Load memcached last for now
     if MemCache is not None:
@@ -106,7 +106,8 @@ def pickAvailableCache(sizeEach, portion=8, maxItems=None, cacheName=None):
 def getFirstAvailableCache():
     cacheBackend = config.getConfig('cache_backend', None)
     if cacheBackend is not None:
-        raise ValueError('cache_backend already set')
+        msg = 'cache_backend already set'
+        raise ValueError(msg)
     loadCaches()
     cache, cacheLock = None, None
     for cacheBackend in _availableCaches:
@@ -117,7 +118,7 @@ def getFirstAvailableCache():
             continue
     if cache is not None:
         config.getConfig('logprint').info(
-            f'Automatically setting `{cacheBackend}` as cache_backend from availableCaches'
+            f'Automatically setting `{cacheBackend}` as cache_backend from availableCaches',
         )
         config.setConfig('cache_backend', cacheBackend)
     return cache, cacheLock

--- a/large_image/constants.py
+++ b/large_image/constants.py
@@ -49,7 +49,7 @@ TileOutputMimeTypes = {
     'JFIF': 'image/jpeg',
 }
 TileOutputPILFormat = {
-    'JFIF': 'JPEG'
+    'JFIF': 'JPEG',
 }
 
 TileInputUnits = {

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -9,7 +9,7 @@ import threading
 import time
 import types
 
-import numpy
+import numpy as np
 import PIL
 import PIL.Image
 import PIL.ImageCms
@@ -38,14 +38,14 @@ class TileSource(IPyLeafletMixin):
     # to each.  It must contain a None key with a priority for the tile source
     # when the extension does not match.
     extensions = {
-        None: SourcePriority.FALLBACK
+        None: SourcePriority.FALLBACK,
     }
 
     # A dictionary of common mime-types handled by the source and the
     # ``SourcePriority`` given to each.  This are used in place of or in
     # additional to extensions.
     mimeTypes = {
-        None: SourcePriority.FALLBACK
+        None: SourcePriority.FALLBACK,
     }
 
     # A dictionary with regex strings as the keys and the ``SourcePriority``
@@ -173,7 +173,8 @@ class TileSource(IPyLeafletMixin):
         import pickle
 
         if not hasattr(self, '_initValues') or hasattr(self, '_unpickleable'):
-            raise pickle.PicklingError('Source cannot be pickled')
+            msg = 'Source cannot be pickled'
+            raise pickle.PicklingError(msg)
         return functools.partial(type(self), **self._initValues[1]), self._initValues[0]
 
     def __repr__(self):
@@ -207,7 +208,8 @@ class TileSource(IPyLeafletMixin):
                         raise TypeError
                     self._style = JSONDict(style)
                 except TypeError:
-                    raise exceptions.TileSourceError('Style is not a valid json object.')
+                    msg = 'Style is not a valid json object.'
+                    raise exceptions.TileSourceError(msg)
 
     def getBounds(self, *args, **kwargs):
         return {
@@ -363,7 +365,8 @@ class TileSource(IPyLeafletMixin):
             scaleY = metadata['sizeY']
         elif units == 'mag_pixels':
             if not (desiredMagnification or {}).get('scale'):
-                raise ValueError('No magnification to use for units')
+                msg = 'No magnification to use for units'
+                raise ValueError(msg)
             scaleX = scaleY = desiredMagnification['scale']
         elif units == 'mm':
             if (not (desiredMagnification or {}).get('scale') or
@@ -374,7 +377,8 @@ class TileSource(IPyLeafletMixin):
             if (not (desiredMagnification or {}).get('scale') or
                     not (desiredMagnification or {}).get('mm_x') or
                     not (desiredMagnification or {}).get('mm_y')):
-                raise ValueError('No mm_x or mm_y to use for units')
+                msg = 'No mm_x or mm_y to use for units'
+                raise ValueError(msg)
             scaleX = (desiredMagnification['scale'] /
                       desiredMagnification['mm_x'])
             scaleY = (desiredMagnification['scale'] /
@@ -592,8 +596,8 @@ class TileSource(IPyLeafletMixin):
                 (not isinstance(maxWidth, int) or maxWidth < 0)) or
                 (maxHeight is not None and
                  (not isinstance(maxHeight, int) or maxHeight < 0))):
-            raise ValueError(
-                'Invalid output width or height.  Minimum value is 0.')
+            msg = 'Invalid output width or height.  Minimum value is 0.'
+            raise ValueError(msg)
 
         magLevel = None
         mag = None
@@ -664,7 +668,7 @@ class TileSource(IPyLeafletMixin):
             'offset_x': 0,
             'offset_y': 0,
             'range_x': 0,
-            'range_y': 0
+            'range_y': 0,
         }
         if not tile_overlap['edges']:
             # offset by half the overlap
@@ -681,7 +685,8 @@ class TileSource(IPyLeafletMixin):
         tile_size['width'] -= tile_overlap['x']
         tile_size['height'] -= tile_overlap['y']
         if tile_size['width'] <= 0 or tile_size['height'] <= 0:
-            raise ValueError('Invalid tile_size or tile_overlap.')
+            msg = 'Invalid tile_size or tile_overlap.'
+            raise ValueError(msg)
 
         resample = (
             False if round(requestedScale, 2) == 1.0 or
@@ -917,9 +922,9 @@ class TileSource(IPyLeafletMixin):
                         'region_x_max': iterInfo['xmax'] - iterInfo['xmin'],
                         'region_y_max': iterInfo['ymax'] - iterInfo['ymin'],
                         'position': ((iterInfo['xmax'] - iterInfo['xmin']) *
-                                     (iterInfo['ymax'] - iterInfo['ymin']))
+                                     (iterInfo['ymax'] - iterInfo['ymin'])),
                     },
-                    'tile_overlap': overlap
+                    'tile_overlap': overlap,
                 })
                 tile['gx'] = tile['x'] * scale
                 tile['gy'] = tile['y'] * scale
@@ -1009,18 +1014,18 @@ class TileSource(IPyLeafletMixin):
                 lastlog = time.time()
             tile = tile['tile']
             if dtype is not None and tile.dtype != dtype:
-                if tile.dtype == numpy.uint8 and dtype == numpy.uint16:
-                    tile = numpy.array(tile, dtype=numpy.uint16) * 257
+                if tile.dtype == np.uint8 and dtype == np.uint16:
+                    tile = np.array(tile, dtype=np.uint16) * 257
                 else:
                     continue
-            tilemin = numpy.array([
-                numpy.amin(tile[:, :, idx]) for idx in range(tile.shape[2])], tile.dtype)
-            tilemax = numpy.array([
-                numpy.amax(tile[:, :, idx]) for idx in range(tile.shape[2])], tile.dtype)
-            tilesum = numpy.array([
-                numpy.sum(tile[:, :, idx]) for idx in range(tile.shape[2])], float)
-            tilesum2 = numpy.array([
-                numpy.sum(numpy.array(tile[:, :, idx], float) ** 2)
+            tilemin = np.array([
+                np.amin(tile[:, :, idx]) for idx in range(tile.shape[2])], tile.dtype)
+            tilemax = np.array([
+                np.amax(tile[:, :, idx]) for idx in range(tile.shape[2])], tile.dtype)
+            tilesum = np.array([
+                np.sum(tile[:, :, idx]) for idx in range(tile.shape[2])], float)
+            tilesum2 = np.array([
+                np.sum(np.array(tile[:, :, idx], float) ** 2)
                 for idx in range(tile.shape[2])], float)
             tilecount = tile.shape[0] * tile.shape[1]
             if results is None:
@@ -1029,16 +1034,16 @@ class TileSource(IPyLeafletMixin):
                     'max': tilemax,
                     'sum': tilesum,
                     'sum2': tilesum2,
-                    'count': tilecount
+                    'count': tilecount,
                 }
             else:
-                results['min'] = numpy.minimum(results['min'], tilemin[:len(results['min'])])
-                results['max'] = numpy.maximum(results['max'], tilemax[:len(results['min'])])
+                results['min'] = np.minimum(results['min'], tilemin[:len(results['min'])])
+                results['max'] = np.maximum(results['max'], tilemax[:len(results['min'])])
                 results['sum'] += tilesum[:len(results['min'])]
                 results['sum2'] += tilesum2[:len(results['min'])]
                 results['count'] += tilecount
         results['mean'] = results['sum'] / results['count']
-        results['stdev'] = numpy.maximum(
+        results['stdev'] = np.maximum(
             results['sum2'] / results['count'] - results['mean'] ** 2,
             [0] * results['sum2'].shape[0]) ** 0.5
         results.pop('sum', None)
@@ -1058,7 +1063,7 @@ class TileSource(IPyLeafletMixin):
             'bins': bins,
             'density': bool(density),
         } for idx in range(len(results['min']))]
-        if histRange == 'round' and numpy.issubdtype(dtype or self.dtype, numpy.integer):
+        if histRange == 'round' and np.issubdtype(dtype or self.dtype, np.integer):
             for record in results['histogram']:
                 if (record['range'][1] - record['range'][0]) < bins * 10:
                     step = int(math.ceil((record['range'][1] - record['range'][0]) / bins))
@@ -1073,13 +1078,13 @@ class TileSource(IPyLeafletMixin):
                 lastlog = time.time()
             tile = tile['tile']
             if dtype is not None and tile.dtype != dtype:
-                if tile.dtype == numpy.uint8 and dtype == numpy.uint16:
-                    tile = numpy.array(tile, dtype=numpy.uint16) * 257
+                if tile.dtype == np.uint8 and dtype == np.uint16:
+                    tile = np.array(tile, dtype=np.uint16) * 257
                 else:
                     continue
             for idx in range(len(results['min'])):
                 entry = results['histogram'][idx]
-                hist, bin_edges = numpy.histogram(
+                hist, bin_edges = np.histogram(
                     tile[:, :, idx], entry['bins'], entry['range'], density=False)
                 if entry['hist'] is None:
                     entry['hist'] = hist
@@ -1089,7 +1094,7 @@ class TileSource(IPyLeafletMixin):
         for idx in range(len(results['min'])):
             entry = results['histogram'][idx]
             if entry['hist'] is not None:
-                entry['samples'] = numpy.sum(entry['hist'])
+                entry['samples'] = np.sum(entry['hist'])
                 if density:
                     entry['hist'] = entry['hist'].astype(float) / entry['samples']
         return results
@@ -1127,7 +1132,7 @@ class TileSource(IPyLeafletMixin):
             resample=False,
             frame=frame, **kwargs)
         if self._bandRanges[frame]:
-            self.logger.info('Style range is %r' % {
+            self.logger.info('Style range is %r', {
                 k: v for k, v in self._bandRanges[frame].items() if k in {
                     'min', 'max', 'mean', 'stdev'}})
 
@@ -1184,7 +1189,7 @@ class TileSource(IPyLeafletMixin):
         if value == 'full':
             value = 0
             if minmax != 'min':
-                if dtype == numpy.uint16:
+                if dtype == np.uint16:
                     value = 65535
                 elif dtype.kind == 'f':
                     value = 1
@@ -1192,10 +1197,10 @@ class TileSource(IPyLeafletMixin):
                     value = 255
         if value == 'auto':
             if (self._bandRanges.get(frame) and
-                    numpy.all(self._bandRanges[frame]['min'] >= 0) and
-                    numpy.all(self._bandRanges[frame]['min'] <= 254) and
-                    numpy.all(self._bandRanges[frame]['max'] >= 2) and
-                    numpy.all(self._bandRanges[frame]['max'] <= 255)):
+                    np.all(self._bandRanges[frame]['min'] >= 0) and
+                    np.all(self._bandRanges[frame]['min'] <= 254) and
+                    np.all(self._bandRanges[frame]['max'] >= 2) and
+                    np.all(self._bandRanges[frame]['max'] <= 255)):
                 value = 0 if minmax == 'min' else 255
             else:
                 value = minmax
@@ -1215,7 +1220,7 @@ class TileSource(IPyLeafletMixin):
                         self._bandRanges[frame]['histogram'][bandidx], threshold, True)
                 else:
                     value = self._bandRanges[frame]['max'][bandidx]
-            elif dtype == numpy.uint16:
+            elif dtype == np.uint16:
                 value = 65535
             elif dtype.kind == 'f':
                 value = 1
@@ -1279,7 +1284,7 @@ class TileSource(IPyLeafletMixin):
             self._styleFunctionWarnings = getattr(self, '_styleFunctionWarnings', {})
             if function['name'] not in self._styleFunctionWarnings:
                 self._styleFunctionWarnings[function['name']] = exc
-                self.logger.exception('Failed to import style function %s' % function['name'])
+                self.logger.exception('Failed to import style function %s', function['name'])
             return image
         kwargs = function.get('parameters', {}).copy()
         if function.get('context'):
@@ -1290,7 +1295,7 @@ class TileSource(IPyLeafletMixin):
             self._styleFunctionWarnings = getattr(self, '_styleFunctionWarnings', {})
             if function['name'] not in self._styleFunctionWarnings:
                 self._styleFunctionWarnings[function['name']] = exc
-                self.logger.exception('Failed to execute style function %s' % function['name'])
+                self.logger.exception('Failed to execute style function %s', function['name'])
             return image
 
     def getICCProfiles(self, idx=None, onlyInfo=False):
@@ -1366,7 +1371,7 @@ class TileSource(IPyLeafletMixin):
             key = (mode, intent)
             if self._iccprofilesObjects[profileIdx] is None:
                 self._iccprofilesObjects[profileIdx] = {
-                    'profile': self.getICCProfiles(profileIdx)
+                    'profile': self.getICCProfiles(profileIdx),
                 }
                 if key not in self._iccprofilesObjects[profileIdx]:
                     self._iccprofilesObjects[profileIdx][key] = \
@@ -1415,7 +1420,7 @@ class TileSource(IPyLeafletMixin):
         if not style or ('icc' in style and len(style) == 1):
             sc.output = image
         else:
-            sc.output = numpy.zeros((image.shape[0], image.shape[1], 4), float)
+            sc.output = np.zeros((image.shape[0], image.shape[1], 4), float)
         image = self._applyStyleFunction(image, sc, 'pre')
         for eidx, entry in enumerate(sc.style['bands']):
             sc.styleIndex = eidx
@@ -1451,7 +1456,7 @@ class TileSource(IPyLeafletMixin):
             elif entry.get('band') == 'alpha':
                 sc.bandidx = image.shape[2] - 1 if image.shape[2] in (2, 4) else None
                 sc.band = (image[:, :, -1] if image.shape[2] in (2, 4) else
-                           numpy.full(image.shape[:2], 255, numpy.uint8))
+                           np.full(image.shape[:2], 255, np.uint8))
                 sc.composite = entry.get('composite', 'multiply')
             if sc.band is None:
                 sc.band = image[:, :, sc.bandidx]
@@ -1460,7 +1465,7 @@ class TileSource(IPyLeafletMixin):
                 'palette', ['#000', '#FFF']
                 if entry.get('band') != 'alpha' else ['#FFF0', '#FFFF']))
             sc.discrete = entry.get('scheme') == 'discrete'
-            sc.palettebase = numpy.linspace(0, 1, len(sc.palette), endpoint=True)
+            sc.palettebase = np.linspace(0, 1, len(sc.palette), endpoint=True)
             sc.nodata = entry.get('nodata')
             sc.min = self._getMinMax(
                 'min', entry.get('min', 'auto'), image.dtype, sc.bandidx, frame)
@@ -1471,7 +1476,7 @@ class TileSource(IPyLeafletMixin):
             if sc.nodata is not None:
                 sc.mask = sc.band != float(sc.nodata)
             else:
-                sc.mask = numpy.full(image.shape[:2], True)
+                sc.mask = np.full(image.shape[:2], True)
             sc.band = (sc.band - sc.min) / delta
             if not sc.clamp:
                 sc.mask = sc.mask & (sc.band >= 0) & (sc.band <= 1)
@@ -1487,40 +1492,40 @@ class TileSource(IPyLeafletMixin):
             # See https://docs.gimp.org/en/gimp-concepts-layer-modes.html for
             # some details.
             for channel in range(4):
-                if numpy.all(sc.palette[:, channel] == sc.palette[0, channel]):
+                if np.all(sc.palette[:, channel] == sc.palette[0, channel]):
                     if ((sc.palette[0, channel] == 0 and sc.composite != 'multiply') or
                             (sc.palette[0, channel] == 255 and sc.composite == 'multiply')):
                         continue
-                    clrs = numpy.full(sc.band.shape, sc.palette[0, channel], dtype=sc.band.dtype)
+                    clrs = np.full(sc.band.shape, sc.palette[0, channel], dtype=sc.band.dtype)
                 else:
                     # Don't recompute if the sc.palette is repeated two channels
                     # in a row.
-                    if not channel or numpy.any(
+                    if not channel or np.any(
                             sc.palette[:, channel] != sc.palette[:, channel - 1]):
                         if not sc.discrete:
-                            clrs = numpy.interp(sc.band, sc.palettebase, sc.palette[:, channel])
+                            clrs = np.interp(sc.band, sc.palettebase, sc.palette[:, channel])
                         else:
                             clrs = sc.palette[
-                                numpy.floor(sc.band * len(sc.palette)).astype(int).clip(
+                                np.floor(sc.band * len(sc.palette)).astype(int).clip(
                                     0, len(sc.palette) - 1), channel]
                 if sc.composite == 'multiply':
                     if eidx:
-                        sc.output[:sc.mask.shape[0], :sc.mask.shape[1], channel] = numpy.multiply(
+                        sc.output[:sc.mask.shape[0], :sc.mask.shape[1], channel] = np.multiply(
                             sc.output[:sc.mask.shape[0], :sc.mask.shape[1], channel],
-                            numpy.where(sc.mask, clrs / 255, 1))
+                            np.where(sc.mask, clrs / 255, 1))
                 else:
                     if not eidx:
                         sc.output[:sc.mask.shape[0],
                                   :sc.mask.shape[1],
-                                  channel] = numpy.where(sc.mask, clrs, 0)
+                                  channel] = np.where(sc.mask, clrs, 0)
                     else:
-                        sc.output[:sc.mask.shape[0], :sc.mask.shape[1], channel] = numpy.maximum(
+                        sc.output[:sc.mask.shape[0], :sc.mask.shape[1], channel] = np.maximum(
                             sc.output[:sc.mask.shape[0], :sc.mask.shape[1], channel],
-                            numpy.where(sc.mask, clrs, 0))
+                            np.where(sc.mask, clrs, 0))
             sc.output = self._applyStyleFunction(sc.output, sc, 'postband')
         sc.output = self._applyStyleFunction(sc.output, sc, 'main')
         if sc.dtype == 'uint16':
-            sc.output = (sc.output * 65535 / 255).astype(numpy.uint16)
+            sc.output = (sc.output * 65535 / 255).astype(np.uint16)
         elif sc.dtype == 'float':
             sc.output /= 255
         if sc.axis is not None and 0 <= int(sc.axis) < sc.output.shape[2]:
@@ -1545,7 +1550,7 @@ class TileSource(IPyLeafletMixin):
         if applyStyle and (getattr(self, 'style', None) or hasattr(self, '_iccprofiles')):
             tile = self._applyStyle(tile, getattr(self, 'style', None), x, y, z, frame)
         if tile.shape[0] != self.tileHeight or tile.shape[1] != self.tileWidth:
-            extend = numpy.zeros(
+            extend = np.zeros(
                 (self.tileHeight, self.tileWidth, tile.shape[2]),
                 dtype=tile.dtype)
             extend[:min(self.tileHeight, tile.shape[0]),
@@ -1591,7 +1596,7 @@ class TileSource(IPyLeafletMixin):
                 self._dtype = tile.dtype
                 self._bandCount = tile.shape[-1] if len(tile.shape) == 3 else 1
             elif tileEncoding == TILE_FORMAT_PIL:
-                self._dtype = numpy.uint8 if ';16' not in tile.mode else numpy.uint16
+                self._dtype = np.uint8 if ';16' not in tile.mode else np.uint16
                 self._bandCount = len(tile.mode)
             else:
                 _img = _imageToNumpy(tile)[0]
@@ -1616,7 +1621,7 @@ class TileSource(IPyLeafletMixin):
                 tile = tile.copy()
                 tile[:, contentWidth:] = color
                 tile[contentHeight:] = color
-        if isinstance(tile, numpy.ndarray) and numpyAllowed:
+        if isinstance(tile, np.ndarray) and numpyAllowed:
             return tile
         tile = _imageToPIL(tile)
         if pilImageAllowed:
@@ -1842,17 +1847,21 @@ class TileSource(IPyLeafletMixin):
         ``TileSourceXYZRangeError`` exception if not.
         """
         if z < 0 or z >= self.levels:
-            raise exceptions.TileSourceXYZRangeError('z layer does not exist')
+            msg = 'z layer does not exist'
+            raise exceptions.TileSourceXYZRangeError(msg)
         scale = 2 ** (self.levels - 1 - z)
         offsetx = x * self.tileWidth * scale
         if not (0 <= offsetx < self.sizeX):
-            raise exceptions.TileSourceXYZRangeError('x is outside layer')
+            msg = 'x is outside layer'
+            raise exceptions.TileSourceXYZRangeError(msg)
         offsety = y * self.tileHeight * scale
         if not (0 <= offsety < self.sizeY):
-            raise exceptions.TileSourceXYZRangeError('y is outside layer')
+            msg = 'y is outside layer'
+            raise exceptions.TileSourceXYZRangeError(msg)
         if frame is not None and numFrames is not None:
             if frame < 0 or frame >= numFrames:
-                raise exceptions.TileSourceXYZRangeError('Frame does not exist')
+                msg = 'Frame does not exist'
+                raise exceptions.TileSourceXYZRangeError(msg)
 
     def _xyzToCorners(self, x, y, z):
         """
@@ -1897,7 +1906,7 @@ class TileSource(IPyLeafletMixin):
         :returns: either a numpy array, a PIL image, or a memory object with an
             image file.
         """
-        raise NotImplementedError()
+        raise NotImplementedError
 
     def getTileMimeType(self):
         """
@@ -1924,7 +1933,8 @@ class TileSource(IPyLeafletMixin):
         """
         if ((width is not None and (not isinstance(width, int) or width < 2)) or
                 (height is not None and (not isinstance(height, int) or height < 2))):
-            raise ValueError('Invalid width or height.  Minimum value is 2.')
+            msg = 'Invalid width or height.  Minimum value is 2.'
+            raise ValueError(msg)
         if width is None and height is None:
             width = height = 256
         params = dict(kwargs)
@@ -2097,7 +2107,7 @@ class TileSource(IPyLeafletMixin):
                 getattr(PIL.Image, 'Resampling', PIL.Image).BICUBIC
                 if outWidth > regionWidth else
                 getattr(PIL.Image, 'Resampling', PIL.Image).LANCZOS)
-            if dtype == numpy.uint16 and TILE_FORMAT_NUMPY in format:
+            if dtype == np.uint16 and TILE_FORMAT_NUMPY in format:
                 image = _imageToNumpy(image)[0].astype(dtype) * 257
         maxWidth = kwargs.get('output', {}).get('maxWidth')
         maxHeight = kwargs.get('output', {}).get('maxHeight')
@@ -2126,7 +2136,7 @@ class TileSource(IPyLeafletMixin):
             return self._addRegionTileToTiled(image, subimage, x, y, width, height, tile, **kwargs)
         if image is None:
             try:
-                image = numpy.zeros(
+                image = np.zeros(
                     (height, width, subimage.shape[2]),
                     dtype=subimage.dtype)
             except MemoryError:
@@ -2178,7 +2188,7 @@ class TileSource(IPyLeafletMixin):
         if subimage.dtype.char not in dtypeToGValue:
             subimage = subimage.astype('d')
         vimgMem = pyvips.Image.new_from_memory(
-            numpy.ascontiguousarray(subimage).data,
+            np.ascontiguousarray(subimage).data,
             subimage.shape[1], subimage.shape[0], subimage.shape[2],
             dtypeToGValue[subimage.dtype.char])
         vimg = pyvips.Image.new_temp_file('%s.v')
@@ -2421,7 +2431,7 @@ class TileSource(IPyLeafletMixin):
         return {
             'magnification': None,
             'mm_x': None,
-            'mm_y': None
+            'mm_y': None,
         }
 
     def getMagnificationForLevel(self, level=None):

--- a/large_image/tilesource/geo.py
+++ b/large_image/tilesource/geo.py
@@ -174,7 +174,7 @@ class GDALBaseFileTileSource(GeoBaseFileTileSource):
                         'min': 'auto',
                         'max': 'auto',
                         'nodata': 'auto',
-                        'composite': 'multiply' if interp == 'alpha' else 'lighten'
+                        'composite': 'multiply' if interp == 'alpha' else 'lighten',
                     })
         return style
 
@@ -333,10 +333,9 @@ class GDALBaseFileTileSource(GeoBaseFileTileSource):
         # raise an error if the band is not inside the dataset only if
         # requested from the function call
         if exc is True and band is None:
-            raise TileSourceError(
-                'Band has to be a positive integer, -1, or a band '
-                'interpretation found in the source.'
-            )
+            msg = ('Band has to be a positive integer, -1, or a band '
+                   'interpretation found in the source.')
+            raise TileSourceError(msg)
 
         return band
 
@@ -427,7 +426,8 @@ class GDALBaseFileTileSource(GeoBaseFileTileSource):
         if self.projection:
             if ((width is not None and width < 2) or
                     (height is not None and height < 2)):
-                raise ValueError('Invalid width or height.  Minimum value is 2.')
+                msg = 'Invalid width or height.  Minimum value is 2.'
+                raise ValueError(msg)
             if width is None and height is None:
                 width = height = 256
             params = dict(kwargs)

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -227,7 +227,8 @@ class IPyLeafletMixin:
                     # This almost works to fix the x, y reversal, but
                     # - bounds are weird and other issues occur
                     # proj4def='+proj=longlat +axis=seu',
-                    # bounds=[[-metadata['sizeX'],-metadata['sizeY']],[metadata['sizeX'],metadata['sizeY']]],
+                    # bounds=[[-metadata['sizeX'],-metadata['sizeY']],
+                    #         [metadata['sizeX'],metadata['sizeY']]],
                     # origin=[0,0],
                 )
 

--- a/large_image/tilesource/stylefuncs.py
+++ b/large_image/tilesource/stylefuncs.py
@@ -1,6 +1,6 @@
 # This module contains functions for use in styles
 
-import numpy
+import numpy as np
 
 
 def maskPixelValues(image, context, values=None, negative=None, positive=None):
@@ -23,7 +23,7 @@ def maskPixelValues(image, context, values=None, negative=None, positive=None):
     :returns: an RGBA numpy image which is exactly black or transparent white.
     """
     src = context.image
-    mask = numpy.full(src.shape[:2], False)
+    mask = np.full(src.shape[:2], False)
     for val in values:
         if not isinstance(val, (list, tuple)):
             if src.shape[-1] == 1:
@@ -31,9 +31,9 @@ def maskPixelValues(image, context, values=None, negative=None, positive=None):
             else:
                 val = [val % 256, val // 256 % 256, val // 65536 % 256]
         val = (list(val) + [255] * src.shape[2])[:src.shape[2]]
-        match = numpy.array(val)
+        match = np.array(val)
         mask = mask | (src == match).all(axis=-1)
     image[mask != True] = negative or [0, 0, 0, 255]  # noqa E712
     image[mask] = positive or [255, 255, 255, 0]
-    image = image.astype(numpy.uint8)
+    image = image.astype(np.uint8)
     return image

--- a/large_image/tilesource/tiledict.py
+++ b/large_image/tilesource/tiledict.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 import PIL
 import PIL.Image
 import PIL.ImageColor
@@ -129,7 +129,7 @@ class LazyTileDict(dict):
                     numpyAllowed='always', sparseFallback=True, frame=self.frame)
                 tileData, _ = _imageToNumpy(tileData)
                 if retile is None:
-                    retile = numpy.zeros(
+                    retile = np.zeros(
                         (self.height, self.width) if len(tileData.shape) == 2 else
                         (self.height, self.width, tileData.shape[2]),
                         dtype=tileData.dtype)
@@ -185,7 +185,7 @@ class LazyTileDict(dict):
                     if self.resample is True else self.resample)
 
             tileFormat = (TILE_FORMAT_PIL if isinstance(tileData, PIL.Image.Image)
-                          else (TILE_FORMAT_NUMPY if isinstance(tileData, numpy.ndarray)
+                          else (TILE_FORMAT_NUMPY if isinstance(tileData, np.ndarray)
                                 else TILE_FORMAT_IMAGE))
             tileEncoding = None if tileFormat != TILE_FORMAT_IMAGE else (
                 'JPEG' if tileData[:3] == b'\xff\xd8\xff' else
@@ -194,7 +194,7 @@ class LazyTileDict(dict):
                 None)
             # Reformat the image if required
             if (not self.alwaysAllowPIL or
-                    (TILE_FORMAT_NUMPY in self.format and isinstance(tileData, numpy.ndarray))):
+                    (TILE_FORMAT_NUMPY in self.format and isinstance(tileData, np.ndarray))):
                 if (tileFormat in self.format and (tileFormat != TILE_FORMAT_IMAGE or (
                         tileEncoding and
                         tileEncoding == self.imageKwargs.get('encoding', self.encoding)))):

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,63 @@
+exclude = [
+    "build",
+    "docs",
+    "*/web_client/*",
+    "*/*egg*/*",
+]
+ignore = [
+    "B017",
+    "B026",
+    "B904",
+    "B905",
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D200",
+    "D203",
+    "D205",
+    "D212",
+    "D213",
+    "D400",
+    "D401",
+    "D404",
+    "D415",
+    "E741",
+    "C408",
+    "PT011",
+    "PT012",
+    "PT017",
+]
+line-length = 100
+select = [
+    "B",  # bugbear
+    "C90",  # mccabe
+    "D",  # pydocstyle
+    "E",  # pycodestyle errors
+    "F",  # pyflakes
+    "Q",  # flake8-quotes
+    # "I",  # isort
+    "W",  # pycodestyle warnings
+    "YTT",
+    "ASYNC",
+    "COM",
+    "C4",
+    "EM",
+    "EXE",
+    "ISC",
+    "G",
+    "PIE",
+    "PYI",
+    "PT",
+    "RSE",
+]
+
+[flake8-quotes]
+inline-quotes = "single"
+
+[mccabe]
+max-complexity = 14

--- a/sources/bioformats/setup.py
+++ b/sources/bioformats/setup.py
@@ -66,10 +66,10 @@ setup(
     python_requires='>=3.6',
     entry_points={
         'large_image.source': [
-            'bioformats = large_image_source_bioformats:BioformatsFileTileSource'
+            'bioformats = large_image_source_bioformats:BioformatsFileTileSource',
         ],
         'girder_large_image.source': [
-            'bioformats = large_image_source_bioformats.girder_source:BioformatsGirderTileSource'
-        ]
+            'bioformats = large_image_source_bioformats.girder_source:BioformatsGirderTileSource',
+        ],
     },
 )

--- a/sources/deepzoom/large_image_source_deepzoom/__init__.py
+++ b/sources/deepzoom/large_image_source_deepzoom/__init__.py
@@ -41,12 +41,14 @@ class DeepzoomFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         try:
             with builtins.open(self._largeImagePath) as fptr:
                 if fptr.read(1024).strip()[:5] != '<?xml':
-                    raise TileSourceError('File cannot be opened via deepzoom reader.')
+                    msg = 'File cannot be opened via deepzoom reader.'
+                    raise TileSourceError(msg)
                 fptr.seek(0)
             xml = ElementTree.parse(self._largeImagePath).getroot()
             self._info = etreeToDict(xml)['Image']
         except (ElementTree.ParseError, KeyError, UnicodeDecodeError):
-            raise TileSourceError('File cannot be opened via deepzoom reader.')
+            msg = 'File cannot be opened via deepzoom reader.'
+            raise TileSourceError(msg)
         except FileNotFoundError:
             if not os.path.isfile(self._largeImagePath):
                 raise TileSourceFileNotFoundError(self._largeImagePath) from None

--- a/sources/deepzoom/setup.py
+++ b/sources/deepzoom/setup.py
@@ -64,10 +64,10 @@ setup(
     python_requires='>=3.6',
     entry_points={
         'large_image.source': [
-            'deepzoom = large_image_source_deepzoom:DeepzoomFileTileSource'
+            'deepzoom = large_image_source_deepzoom:DeepzoomFileTileSource',
         ],
         'girder_large_image.source': [
-            'deepzoom = large_image_source_deepzoom.girder_source:DeepzoomGirderTileSource'
-        ]
+            'deepzoom = large_image_source_deepzoom.girder_source:DeepzoomGirderTileSource',
+        ],
     },
 )

--- a/sources/dicom/large_image_source_dicom/__init__.py
+++ b/sources/dicom/large_image_source_dicom/__init__.py
@@ -5,7 +5,7 @@ import warnings
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _importlib_version
 
-import numpy
+import numpy as np
 
 from large_image.cache_util import LruCacheMetaclass, methodcache
 from large_image.constants import TILE_FORMAT_PIL, SourcePriority
@@ -36,7 +36,8 @@ def _lazyImport():
             import pydicom
             import wsidicom
         except ImportError:
-            raise TileSourceError('dicom modules not found.')
+            msg = 'dicom modules not found.'
+            raise TileSourceError(msg)
         warnings.filterwarnings('ignore', category=UserWarning, module='wsidicom')
         warnings.filterwarnings('ignore', category=UserWarning, module='pydicom')
 
@@ -130,7 +131,8 @@ class DICOMFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         try:
             self._dicom = wsidicom.WsiDicom.open(self._largeImagePath)
         except Exception:
-            raise TileSourceError('File cannot be opened via dicom tile source.')
+            msg = 'File cannot be opened via dicom tile source.'
+            raise TileSourceError(msg)
         self.sizeX = int(self._dicom.size.width)
         self.sizeY = int(self._dicom.size.height)
         self.tileWidth = int(self._dicom.tile_size.width)
@@ -246,7 +248,7 @@ class DICOMFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         format = TILE_FORMAT_PIL
         if tile.width < bw or tile.height < bh:
             tile = _imageToNumpy(tile)[0]
-            tile = numpy.pad(
+            tile = np.pad(
                 tile,
                 ((0, bh - tile.shape[0]), (0, bw - tile.shape[1]), (0, 0)),
                 'constant', constant_values=0)

--- a/sources/dicom/setup.py
+++ b/sources/dicom/setup.py
@@ -63,10 +63,10 @@ setup(
     python_requires='>=3.8',
     entry_points={
         'large_image.source': [
-            'dicom = large_image_source_dicom:DICOMFileTileSource'
+            'dicom = large_image_source_dicom:DICOMFileTileSource',
         ],
         'girder_large_image.source': [
-            'dicom = large_image_source_dicom.girder_source:DICOMGirderTileSource'
-        ]
+            'dicom = large_image_source_dicom.girder_source:DICOMGirderTileSource',
+        ],
     },
 )

--- a/sources/dummy/large_image_source_dummy/__init__.py
+++ b/sources/dummy/large_image_source_dummy/__init__.py
@@ -33,7 +33,7 @@ except PackageNotFoundError:
 class DummyTileSource(TileSource):
     name = 'dummy'
     extensions = {
-        None: SourcePriority.MANUAL
+        None: SourcePriority.MANUAL,
     }
 
     def __init__(self, *args, **kwargs):

--- a/sources/dummy/setup.py
+++ b/sources/dummy/setup.py
@@ -62,7 +62,7 @@ setup(
     python_requires='>=3.6',
     entry_points={
         'large_image.source': [
-            'dummy = large_image_source_dummy:DummyTileSource'
-        ]
+            'dummy = large_image_source_dummy:DummyTileSource',
+        ],
     },
 )

--- a/sources/gdal/setup.py
+++ b/sources/gdal/setup.py
@@ -68,10 +68,10 @@ setup(
     python_requires='>=3.6',
     entry_points={
         'large_image.source': [
-            'gdal = large_image_source_gdal:GDALFileTileSource'
+            'gdal = large_image_source_gdal:GDALFileTileSource',
         ],
         'girder_large_image.source': [
-            'gdal = large_image_source_gdal.girder_source:GDALGirderTileSource'
-        ]
+            'gdal = large_image_source_gdal.girder_source:GDALGirderTileSource',
+        ],
     },
 )

--- a/sources/mapnik/large_image_source_mapnik/__init__.py
+++ b/sources/mapnik/large_image_source_mapnik/__init__.py
@@ -138,7 +138,7 @@ class MapnikFileTileSource(GDALFileTileSource, metaclass=LruCacheMetaclass):
                 return False
             self._netcdf = {
                 'datasets': datasets,
-                'metadata': self.dataset.GetMetadata_Dict()
+                'metadata': self.dataset.GetMetadata_Dict(),
             }
         if not len(datasets):
             try:
@@ -171,7 +171,7 @@ class MapnikFileTileSource(GDALFileTileSource, metaclass=LruCacheMetaclass):
                 'scheme': 'linear',
                 'palette': ['#000000', '#ffffff'],
                 'min': 'min',
-                'max': 'max'
+                'max': 'max',
             })
         return True
 
@@ -192,8 +192,8 @@ class MapnikFileTileSource(GDALFileTileSource, metaclass=LruCacheMetaclass):
         try:
             step = (float(stop) - float(start)) / (float(count) - 1)
         except ValueError:
-            raise TileSourceError(
-                'Minimum and maximum values should be numbers, "auto", "min", or "max".')
+            msg = 'Minimum and maximum values should be numbers, "auto", "min", or "max".'
+            raise TileSourceError(msg)
         return [float(start + i * step) for i in range(count)]
 
     def getOneBandInformation(self, band):
@@ -223,7 +223,8 @@ class MapnikFileTileSource(GDALFileTileSource, metaclass=LruCacheMetaclass):
             mapnik_scheme = getattr(mapnik, f'COLORIZER_{scheme.upper()}')
         except AttributeError:
             mapnik_scheme = mapnik.COLORIZER_DISCRETE
-            raise TileSourceError('Scheme has to be either "discrete" or "linear".')
+            msg = 'Scheme has to be either "discrete" or "linear".'
+            raise TileSourceError(msg)
         colorizer = mapnik.RasterColorizer(mapnik_scheme, mapnik.Color(0, 0, 0, 0))
         bandInfo = self.getOneBandInformation(style['band'])
         minimum = style.get('min', 0)
@@ -246,7 +247,8 @@ class MapnikFileTileSource(GDALFileTileSource, metaclass=LruCacheMetaclass):
         else:
             colors = self.getHexColors(style.get('palette', ['#000000', '#ffffff']))
             if len(colors) < 2:
-                raise TileSourceError('A palette must have at least 2 colors.')
+                msg = 'A palette must have at least 2 colors.'
+                raise TileSourceError(msg)
             values = self.interpolateMinMax(minimum, maximum, len(colors))
             for value, color in sorted(zip(values, colors)):
                 colorizer.add_stop(value, mapnik.Color(color))

--- a/sources/mapnik/setup.py
+++ b/sources/mapnik/setup.py
@@ -67,10 +67,10 @@ setup(
     python_requires='>=3.6',
     entry_points={
         'large_image.source': [
-            'mapnik = large_image_source_mapnik:MapnikFileTileSource'
+            'mapnik = large_image_source_mapnik:MapnikFileTileSource',
         ],
         'girder_large_image.source': [
-            'mapnik = large_image_source_mapnik.girder_source:MapnikGirderTileSource'
-        ]
+            'mapnik = large_image_source_mapnik.girder_source:MapnikGirderTileSource',
+        ],
     },
 )

--- a/sources/multi/setup.py
+++ b/sources/multi/setup.py
@@ -68,10 +68,10 @@ setup(
     python_requires='>=3.6',
     entry_points={
         'large_image.source': [
-            'multi = large_image_source_multi:MultiFileTileSource'
+            'multi = large_image_source_multi:MultiFileTileSource',
         ],
         'girder_large_image.source': [
-            'multi = large_image_source_multi.girder_source:MultiGirderTileSource'
-        ]
+            'multi = large_image_source_multi.girder_source:MultiGirderTileSource',
+        ],
     },
 )

--- a/sources/nd2/setup.py
+++ b/sources/nd2/setup.py
@@ -66,10 +66,10 @@ setup(
     python_requires='>=3.7',
     entry_points={
         'large_image.source': [
-            'nd2 = large_image_source_nd2:ND2FileTileSource'
+            'nd2 = large_image_source_nd2:ND2FileTileSource',
         ],
         'girder_large_image.source': [
-            'nd2 = large_image_source_nd2.girder_source:ND2GirderTileSource'
-        ]
+            'nd2 = large_image_source_nd2.girder_source:ND2GirderTileSource',
+        ],
     },
 )

--- a/sources/ometiff/setup.py
+++ b/sources/ometiff/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=[
         f'large-image{limit_version}',
         f'large-image-source-tiff{limit_version}',
-        'importlib-metadata<5 ; python_version < "3.8"'
+        'importlib-metadata<5 ; python_version < "3.8"',
     ],
     extras_require={
         'girder': f'girder-large-image{limit_version}',
@@ -66,10 +66,10 @@ setup(
     python_requires='>=3.6',
     entry_points={
         'large_image.source': [
-            'ometiff = large_image_source_ometiff:OMETiffFileTileSource'
+            'ometiff = large_image_source_ometiff:OMETiffFileTileSource',
         ],
         'girder_large_image.source': [
-            'ometiff = large_image_source_ometiff.girder_source:OMETiffGirderTileSource'
-        ]
+            'ometiff = large_image_source_ometiff.girder_source:OMETiffGirderTileSource',
+        ],
     },
 )

--- a/sources/openjpeg/large_image_source_openjpeg/__init__.py
+++ b/sources/openjpeg/large_image_source_openjpeg/__init__.py
@@ -97,10 +97,12 @@ class OpenjpegFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             self._openjpeg = glymur.Jp2k(self._largeImagePath)
             if not self._openjpeg.shape:
                 if not os.path.isfile(self._largeImagePath):
-                    raise FileNotFoundError()
-                raise TileSourceError('File cannot be opened via Glymur and OpenJPEG (no shape).')
+                    raise FileNotFoundError
+                msg = 'File cannot be opened via Glymur and OpenJPEG (no shape).'
+                raise TileSourceError(msg)
         except (glymur.jp2box.InvalidJp2kError, struct.error):
-            raise TileSourceError('File cannot be opened via Glymur and OpenJPEG.')
+            msg = 'File cannot be opened via Glymur and OpenJPEG.'
+            raise TileSourceError(msg)
         except FileNotFoundError:
             if not os.path.isfile(self._largeImagePath):
                 raise TileSourceFileNotFoundError(self._largeImagePath) from None
@@ -214,7 +216,7 @@ class OpenjpegFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
 
         :return: the list of image keys.
         """
-        return list(sorted(self._associatedImages.keys()))
+        return sorted(self._associatedImages.keys())
 
     def _readbox(self, box):
         if box.length > 16 * 1024 * 1024:

--- a/sources/openjpeg/setup.py
+++ b/sources/openjpeg/setup.py
@@ -56,7 +56,7 @@ setup(
         f'large-image{limit_version}',
         'glymur>=0.8.18 ; python_version >= "3.7"',
         'glymur>=0.8.18,<0.9.4 ; python_version < "3.7"',
-        'importlib-metadata<5 ; python_version < "3.8"'
+        'importlib-metadata<5 ; python_version < "3.8"',
     ],
     extras_require={
         'girder': f'girder-large-image{limit_version}',
@@ -67,10 +67,10 @@ setup(
     python_requires='>=3.6',
     entry_points={
         'large_image.source': [
-            'openjpeg = large_image_source_openjpeg:OpenjpegFileTileSource'
+            'openjpeg = large_image_source_openjpeg:OpenjpegFileTileSource',
         ],
         'girder_large_image.source': [
-            'openjpeg = large_image_source_openjpeg.girder_source:OpenjpegGirderTileSource'
-        ]
+            'openjpeg = large_image_source_openjpeg.girder_source:OpenjpegGirderTileSource',
+        ],
     },
 )

--- a/sources/openslide/large_image_source_openslide/__init__.py
+++ b/sources/openslide/large_image_source_openslide/__init__.py
@@ -89,9 +89,11 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         except openslide.lowlevel.OpenSlideUnsupportedFormatError:
             if not os.path.isfile(self._largeImagePath):
                 raise TileSourceFileNotFoundError(self._largeImagePath) from None
-            raise TileSourceError('File cannot be opened via OpenSlide.')
+            msg = 'File cannot be opened via OpenSlide.'
+            raise TileSourceError(msg)
         except openslide.lowlevel.OpenSlideError:
-            raise TileSourceError('File will not be opened via OpenSlide.')
+            msg = 'File will not be opened via OpenSlide.'
+            raise TileSourceError(msg)
         if libtiff_ctypes:
             try:
                 self._tiffinfo = tifftools.read_tiff(self._largeImagePath)
@@ -103,7 +105,8 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
 
         svsAvailableLevels = self._getAvailableLevels(self._largeImagePath)
         if not len(svsAvailableLevels):
-            raise TileSourceError('OpenSlide image size is invalid.')
+            msg = 'OpenSlide image size is invalid.'
+            raise TileSourceError(msg)
         self.sizeX = svsAvailableLevels[0]['width']
         self.sizeY = svsAvailableLevels[0]['height']
         if (self.sizeX != self._openslide.dimensions[0] or
@@ -121,8 +124,8 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             math.log(float(self.sizeX) / self.tileWidth),
             math.log(float(self.sizeY) / self.tileHeight)) / math.log(2))) + 1
         if self.levels < 1:
-            raise TileSourceError(
-                'OpenSlide image must have at least one level.')
+            msg = 'OpenSlide image must have at least one level.'
+            raise TileSourceError(msg)
         self._svslevels = []
         # Precompute which SVS level should be used for our tile levels.  SVS
         # level 0 is the maximum resolution.  The SVS levels are in descending
@@ -158,7 +161,7 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 raise TileSourceError(msg)
             self._svslevels.append({
                 'svslevel': bestlevel,
-                'scale': scale
+                'scale': scale,
             })
         self._populatedLevels = len({l['svslevel'] for l in self._svslevels})
 

--- a/sources/openslide/setup.py
+++ b/sources/openslide/setup.py
@@ -67,10 +67,10 @@ setup(
     python_requires='>=3.6',
     entry_points={
         'large_image.source': [
-            'openslide = large_image_source_openslide:OpenslideFileTileSource'
+            'openslide = large_image_source_openslide:OpenslideFileTileSource',
         ],
         'girder_large_image.source': [
-            'openslide = large_image_source_openslide.girder_source:OpenslideGirderTileSource'
-        ]
+            'openslide = large_image_source_openslide.girder_source:OpenslideGirderTileSource',
+        ],
     },
 )

--- a/sources/pil/large_image_source_pil/girder_source.py
+++ b/sources/pil/large_image_source_pil/girder_source.py
@@ -53,11 +53,14 @@ class PILGirderTileSource(PILFileTileSource, GirderTileSource):
     def getTile(self, x, y, z, pilImageAllowed=False, numpyAllowed=False,
                 mayRedirect=False, **kwargs):
         if z != 0:
-            raise TileSourceError('z layer does not exist')
+            msg = 'z layer does not exist'
+            raise TileSourceError(msg)
         if x != 0:
-            raise TileSourceError('x is outside layer')
+            msg = 'x is outside layer'
+            raise TileSourceError(msg)
         if y != 0:
-            raise TileSourceError('y is outside layer')
+            msg = 'y is outside layer'
+            raise TileSourceError(msg)
         if (mayRedirect and not pilImageAllowed and not numpyAllowed and
                 cherrypy.request and
                 self._pilFormatMatches(self._pilImage, mayRedirect, **kwargs)):

--- a/sources/pil/setup.py
+++ b/sources/pil/setup.py
@@ -66,10 +66,10 @@ setup(
     python_requires='>=3.6',
     entry_points={
         'large_image.source': [
-            'pil = large_image_source_pil:PILFileTileSource'
+            'pil = large_image_source_pil:PILFileTileSource',
         ],
         'girder_large_image.source': [
-            'pil = large_image_source_pil.girder_source:PILGirderTileSource'
-        ]
+            'pil = large_image_source_pil.girder_source:PILGirderTileSource',
+        ],
     },
 )

--- a/sources/rasterio/setup.py
+++ b/sources/rasterio/setup.py
@@ -71,10 +71,10 @@ setup(
     python_requires='>=3.8',
     entry_points={
         'large_image.source': [
-            'rasterio = large_image_source_rasterio:RasterioFileTileSource'
+            'rasterio = large_image_source_rasterio:RasterioFileTileSource',
         ],
         'girder_large_image.source': [
-            'rasterio = large_image_source_rasterio.girder_source:RasterioGirderTileSource'
+            'rasterio = large_image_source_rasterio.girder_source:RasterioGirderTileSource',
         ],
     },
 )

--- a/sources/test/setup.py
+++ b/sources/test/setup.py
@@ -62,10 +62,10 @@ setup(
     python_requires='>=3.6',
     entry_points={
         'large_image.source': [
-            'test = large_image_source_test:TestTileSource'
+            'test = large_image_source_test:TestTileSource',
         ],
         'girder_large_image.source': [
-            'test = large_image_source_test:TestTileSource'
-        ]
+            'test = large_image_source_test:TestTileSource',
+        ],
     },
 )

--- a/sources/tiff/large_image_source_tiff/exceptions.py
+++ b/sources/tiff/large_image_source_tiff/exceptions.py
@@ -7,16 +7,12 @@ class InvalidOperationTiffError(TiffError):
     An exception caused by the user making an invalid request of a TIFF file.
     """
 
-    pass
-
 
 class IOTiffError(TiffError):
     """
     An exception caused by an internal failure, due to an invalid file or other
     error.
     """
-
-    pass
 
 
 class IOOpenTiffError(IOTiffError):
@@ -25,13 +21,9 @@ class IOOpenTiffError(IOTiffError):
     by the main library.
     """
 
-    pass
-
 
 class ValidationTiffError(TiffError):
     """
     An exception caused by the TIFF reader not being able to support a given
     file.
     """
-
-    pass

--- a/sources/tiff/setup.py
+++ b/sources/tiff/setup.py
@@ -67,10 +67,10 @@ setup(
     python_requires='>=3.6',
     entry_points={
         'large_image.source': [
-            'tiff = large_image_source_tiff:TiffFileTileSource'
+            'tiff = large_image_source_tiff:TiffFileTileSource',
         ],
         'girder_large_image.source': [
-            'tiff = large_image_source_tiff.girder_source:TiffGirderTileSource'
-        ]
+            'tiff = large_image_source_tiff.girder_source:TiffGirderTileSource',
+        ],
     },
 )

--- a/sources/tifffile/setup.py
+++ b/sources/tifffile/setup.py
@@ -68,10 +68,10 @@ setup(
     python_requires='>=3.7',
     entry_points={
         'large_image.source': [
-            'tifffile = large_image_source_tifffile:TifffileFileTileSource'
+            'tifffile = large_image_source_tifffile:TifffileFileTileSource',
         ],
         'girder_large_image.source': [
-            'tifffile = large_image_source_tifffile.girder_source:TifffileGirderTileSource'
-        ]
+            'tifffile = large_image_source_tifffile.girder_source:TifffileGirderTileSource',
+        ],
     },
 )

--- a/sources/vips/setup.py
+++ b/sources/vips/setup.py
@@ -68,10 +68,10 @@ setup(
     python_requires='>=3.6',
     entry_points={
         'large_image.source': [
-            'vips = large_image_source_vips:VipsFileTileSource'
+            'vips = large_image_source_vips:VipsFileTileSource',
         ],
         'girder_large_image.source': [
-            'vips = large_image_source_vips.girder_source:VipsGirderTileSource'
-        ]
+            'vips = large_image_source_vips.girder_source:VipsGirderTileSource',
+        ],
     },
 )

--- a/test/datastore.py
+++ b/test/datastore.py
@@ -108,7 +108,7 @@ class DKCPooch(pooch.Pooch):
 
 datastore = DKCPooch(
     path=pooch.utils.cache_location(
-        os.path.join(os.environ.get('TOX_WORK_DIR', pooch.utils.os_cache('pooch')), 'externaldata')
+        os.path.join(os.environ.get('TOX_WORK_DIR', pooch.utils.os_cache('pooch')), 'externaldata'),
     ),
     base_url='https://data.kitware.com/api/v1/file/hashsum/{algo}/{hashvalue}/download',
     registry=registry,

--- a/test/source_geo_base.py
+++ b/test/source_geo_base.py
@@ -3,7 +3,7 @@ import io
 import json
 import os
 
-import numpy
+import numpy as np
 import PIL.Image
 import PIL.ImageChops
 import pytest
@@ -135,7 +135,7 @@ class _BaseGeoTests:
 
         _assertStyleResponse(imagePath, {
             'band': 1,
-            'palette': 'nonexistent.palette'
+            'palette': 'nonexistent.palette',
         }, 'cannot be used as a color palette')
 
         _assertStyleResponse(imagePath, ['style'],
@@ -334,7 +334,7 @@ class _GDALBaseSourceTest(_BaseGeoTests):
         assert tileMetadata['geospatial']
         image = source.getTile(37, 46, 7)
         image = PIL.Image.open(io.BytesIO(image))
-        image = numpy.asarray(image)
+        image = np.asarray(image)
         assert list(image[0, 0, :]) == [0, 0, 0, 0]
         assert list(image[255, 0, :]) == [221, 201, 201, 255]
 
@@ -404,7 +404,7 @@ class _GDALBaseSourceTest(_BaseGeoTests):
             imagePath, projection='EPSG:3857', style=style, encoding='PNG')
         image = source.getTile(22, 51, 7)
         image = PIL.Image.open(io.BytesIO(image))
-        image = numpy.asarray(image)
+        image = np.asarray(image)
         assert list(image[0, 0, :]) == [68, 1, 84, 0]
 
     def testHttpVfsPath(self):

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -59,7 +59,7 @@ def testBadMemcachedUrl():
         cache['(2,)']
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 def testGetTileCachePython():
     large_image.cache_util.cache._tileCache = None
     large_image.cache_util.cache._tileLock = None
@@ -68,7 +68,7 @@ def testGetTileCachePython():
     assert isinstance(tileCache, cachetools.LRUCache)
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 def testGetTileCacheMemcached():
     large_image.cache_util.cache._tileCache = None
     large_image.cache_util.cache._tileLock = None
@@ -134,7 +134,7 @@ class TestClass:
             if isinstance(arg, (int, float)):
                 time.sleep(arg)
 
-    @pytest.mark.singular
+    @pytest.mark.singular()
     def testCachesInfo(self):
         cachesClear()
         large_image.cache_util.cache._tileCache = None
@@ -153,7 +153,7 @@ class TestClass:
         # memcached shows an items record as well
         assert 'items' in cachesInfo()['tileCache']
 
-    @pytest.mark.singular
+    @pytest.mark.singular()
     def testCachesKeyLock(self):
         cachesClear()
         assert cachesInfo()['test']['used'] == 0
@@ -165,7 +165,7 @@ class TestClass:
         assert endtime - starttime < 6
         assert cachesInfo()['test']['used'] == 2
 
-    @pytest.mark.singular
+    @pytest.mark.singular()
     def testCachesClear(self):
         cachesClear()
         large_image.cache_util.cache._tileCache = None

--- a/test/test_cache_source.py
+++ b/test/test_cache_source.py
@@ -6,7 +6,7 @@ from large_image.cache_util import cachesClear
 from .datastore import datastore
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 def testCacheSourceStyle():
     cachesClear()
     imagePath = datastore.fetch('sample_image.ptif')
@@ -29,7 +29,7 @@ def testCacheSourceStyle():
     assert ts1.getTile(0, 0, 4) == tile1
 
 
-@pytest.mark.singular
+@pytest.mark.singular()
 def testCacheSourceStyleFirst():
     cachesClear()
     imagePath = datastore.fetch('sample_image.ptif')

--- a/test/test_cached_tiles.py
+++ b/test/test_cached_tiles.py
@@ -14,7 +14,7 @@ from . import utilities
 from .datastore import datastore
 
 
-@pytest.fixture
+@pytest.fixture()
 def monitorTileCounts():
     large_image_source_test._counters['tiles'] = 0
 
@@ -32,14 +32,15 @@ def monitorTileCounts():
 
 class LargeImageCachedTilesTest:
 
-    @pytest.mark.singular
+    @pytest.mark.singular()
     def testTilesFromTest(self, monitorTileCounts):
         # Create a test tile with the default options
         params = {'encoding': 'JPEG'}
-        source = monitorTileCounts(None, **dict(params, **{
-            'tileWidth': 256, 'tileHeight': 256,
-            'sizeX': 256 * 2 ** 9, 'sizeY': 256 * 2 ** 9, 'levels': 10
-        }))
+        source = monitorTileCounts(None, **dict(
+            params,
+            tileWidth=256, tileHeight=256,
+            sizeX=256 * 2 ** 9, sizeY=256 * 2 ** 9, levels=10,
+        ))
         meta = source.getMetadata()
         utilities.checkTilesZXY(source, meta, params)
         # We should have generated tiles
@@ -57,13 +58,14 @@ class LargeImageCachedTilesTest:
             'tileHeight': 120,
             'sizeX': 5000,
             'sizeY': 3000,
-            'encoding': 'JPEG'
+            'encoding': 'JPEG',
         }
-        source = monitorTileCounts(None, **dict(params, **{
-            'tileWidth': 160, 'tileHeight': 120,
-            'sizeX': 5000, 'sizeY': 3000, 'levels': 6,
-            'minLevel': 2
-        }))
+        source = monitorTileCounts(None, **dict(
+            params,
+            tileWidth=160, tileHeight=120,
+            sizeX=5000, sizeY=3000, levels=6,
+            minLevel=2,
+        ))
         meta = source.getMetadata()
         meta['minLevel'] = 2
         utilities.checkTilesZXY(source, meta, params)
@@ -75,10 +77,11 @@ class LargeImageCachedTilesTest:
         assert large_image_source_test._counters['tiles'] == counter2
         # Test the fractal tiles with PNG
         params = {'fractal': 'true'}
-        source = monitorTileCounts(None, **dict(params, **{
-            'tileWidth': 256, 'tileHeight': 256,
-            'sizeX': 256 * 2 ** 9, 'sizeY': 256 * 2 ** 9, 'levels': 10
-        }))
+        source = monitorTileCounts(None, **dict(
+            params,
+            tileWidth=256, tileHeight=256,
+            sizeX=256 * 2 ** 9, sizeY=256 * 2 ** 9, levels=10,
+        ))
         meta = source.getMetadata()
         utilities.checkTilesZXY(source, meta, params, utilities.PNGHeader)
         # We should have generated tiles
@@ -88,7 +91,7 @@ class LargeImageCachedTilesTest:
         utilities.checkTilesZXY(source, meta, params, utilities.PNGHeader)
         assert large_image_source_test._counters['tiles'] == counter3
 
-    @pytest.mark.singular
+    @pytest.mark.singular()
     def testLargeRegion(self):
         imagePath = datastore.fetch(
             'sample_jp2k_33003_TCGA-CV-7242-11A-01-TS1.1838afb1-9eee-'
@@ -104,12 +107,12 @@ class LargeImageCachedTilesTest:
                 'maxWidth': 480,
                 'maxHeight': 480,
             },
-            'encoding': 'PNG'
+            'encoding': 'PNG',
         }
         image, mimeType = source.getRegion(**params)
         assert image[:len(utilities.PNGHeader)] == utilities.PNGHeader
 
-    @pytest.mark.singular
+    @pytest.mark.singular()
     def testTiffClosed(self):
         # test the Tiff files are properly closed.
         orig_del = TiledTiffDirectory.__del__

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -40,40 +40,40 @@ def testIsVips():
     assert large_image_converter.is_vips(imagePath) is False
 
 
-@pytest.mark.parametrize('convert_args,taglist', [
+@pytest.mark.parametrize(('convert_args', 'taglist'), [
     ({}, {
         tifftools.Tag.Compression.value: tifftools.constants.Compression.LZW.value,
-        tifftools.Tag.TileWidth.value: 256
+        tifftools.Tag.TileWidth.value: 256,
     }),
     ({'compression': 'jpeg'}, {
-        tifftools.Tag.Compression.value: tifftools.constants.Compression.JPEG.value
+        tifftools.Tag.Compression.value: tifftools.constants.Compression.JPEG.value,
     }),
     ({'compression': 'deflate'}, {
-        tifftools.Tag.Compression.value: tifftools.constants.Compression.AdobeDeflate.value
+        tifftools.Tag.Compression.value: tifftools.constants.Compression.AdobeDeflate.value,
     }),
     ({'compression': 'lzw'}, {
-        tifftools.Tag.Compression.value: tifftools.constants.Compression.LZW.value
+        tifftools.Tag.Compression.value: tifftools.constants.Compression.LZW.value,
     }),
     ({'compression': 'packbits'}, {
-        tifftools.Tag.Compression.value: tifftools.constants.Compression.Packbits.value
+        tifftools.Tag.Compression.value: tifftools.constants.Compression.Packbits.value,
     }),
     ({'compression': 'zstd'}, {
-        tifftools.Tag.Compression.value: tifftools.constants.Compression.ZSTD.value
+        tifftools.Tag.Compression.value: tifftools.constants.Compression.ZSTD.value,
     }),
     ({'compression': 'jpeg', 'quality': 50}, {
-        tifftools.Tag.Compression.value: tifftools.constants.Compression.JPEG.value
+        tifftools.Tag.Compression.value: tifftools.constants.Compression.JPEG.value,
     }),
     ({'compression': 'deflate', 'level': 2}, {
-        tifftools.Tag.Compression.value: tifftools.constants.Compression.AdobeDeflate.value
+        tifftools.Tag.Compression.value: tifftools.constants.Compression.AdobeDeflate.value,
     }),
     ({'compression': 'lzw', 'predictor': 'yes'}, {
-        tifftools.Tag.Compression.value: tifftools.constants.Compression.LZW.value
+        tifftools.Tag.Compression.value: tifftools.constants.Compression.LZW.value,
     }),
     ({'compression': 'webp', 'quality': 0}, {
-        tifftools.Tag.Compression.value: tifftools.constants.Compression.WEBP.value
+        tifftools.Tag.Compression.value: tifftools.constants.Compression.WEBP.value,
     }),
     ({'tileSize': 512}, {
-        tifftools.Tag.TileWidth.value: 512
+        tifftools.Tag.TileWidth.value: 512,
     }),
 ])
 def testConvert(tmpdir, convert_args, taglist):

--- a/test/test_jupyter.py
+++ b/test/test_jupyter.py
@@ -16,7 +16,8 @@ def testJupyterIpyleafletGeospatial():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
     source = large_image.open(imagePath, projection='EPSG:3857')
-    assert source.geospatial and source.projection
+    assert source.geospatial
+    assert source.projection
     source._ipython_display_()  # smoke test
     # Run twice to make sure launched only once
     port = source._jupyter_server_manager.port

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -5,7 +5,7 @@ import re
 import sys
 from pathlib import Path
 
-import numpy
+import numpy as np
 import PIL.Image
 import pytest
 
@@ -223,7 +223,7 @@ def testSourcesTilesAndMethods(source, filename):
     cachesClear()
 
 
-@pytest.mark.parametrize('filename,isgeo', [
+@pytest.mark.parametrize(('filename', 'isgeo'), [
     ('04091217_ruc.nc', True),
     ('HENormalN801.czi', False),
     ('landcover_sample_1000.tif', True),
@@ -301,7 +301,7 @@ def testTileOverlap():
     ts = large_image.open(imagePath)
     assert [(
         tiles['x'], tiles['x'] + tiles['width'], tiles['width'],
-        tiles['tile_overlap']['left'], tiles['tile_overlap']['right']
+        tiles['tile_overlap']['left'], tiles['tile_overlap']['right'],
     ) for tiles in ts.tileIterator(
         tile_size=dict(width=75, height=180), tile_overlap=dict(x=60))
     ] == [
@@ -312,7 +312,7 @@ def testTileOverlap():
     ]
     assert [(
         tiles['x'], tiles['x'] + tiles['width'], tiles['width'],
-        tiles['tile_overlap']['left'], tiles['tile_overlap']['right']
+        tiles['tile_overlap']['left'], tiles['tile_overlap']['right'],
     ) for tiles in ts.tileIterator(
         tile_size=dict(width=75, height=180), tile_overlap=dict(x=60, edges=True))
     ] == [
@@ -327,12 +327,12 @@ def testTileOverlap():
     ]
     assert [(
         tiles['x'], tiles['x'] + tiles['width'], tiles['width'],
-        tiles['tile_overlap']['left'], tiles['tile_overlap']['right']
+        tiles['tile_overlap']['left'], tiles['tile_overlap']['right'],
     ) for tiles in ts.tileIterator(
         tile_size=dict(width=60, height=60), tile_overlap=dict(x=40, y=40),
         region=dict(left=55, top=65, width=15, height=15))
     ] == [
-        (55, 70, 15, 0, 0)
+        (55, 70, 15, 0, 0),
     ]
 
 
@@ -368,7 +368,9 @@ def testTileOverlapWithRegionOffset():
     assert firstTile['tile_overlap']['right'] == 200
 
 
-@pytest.mark.parametrize('options,lensrc,lenquads,frame10,src0,srclast,quads10', [
+@pytest.mark.parametrize((
+    'options', 'lensrc', 'lenquads', 'frame10', 'src0', 'srclast', 'quads10',
+), [
     ({'maxTextureSize': 16384}, 1, 250, 10, {
         'encoding': 'JPEG',
         'exact': False,
@@ -471,7 +473,7 @@ def testTileOverlapWithRegionOffset():
         'maxTextures': 8,
         'maxTextureSize': 4096,
         'frameGroup': 250,
-        'frameGroupFactor': 4
+        'frameGroupFactor': 4,
     }, 8, 250, 10, {
         'framesAcross': 5,
         'height': 576,
@@ -485,7 +487,7 @@ def testTileOverlapWithRegionOffset():
         'maxTextures': 8,
         'maxTextureSize': 4096,
         'frameGroup': 50,
-        'frameGroupStride': 5
+        'frameGroupStride': 5,
     }, 5, 250, 50, {
         'framesAcross': 7,
         'height': 432,
@@ -531,7 +533,7 @@ def testGetTileFramesQuadInfo(options, lensrc, lenquads, frame10, src0, srclast,
         'sizeX': 100000,
         'sizeY': 75000,
         'tileHeight': 256,
-        'tileWidth': 256
+        'tileWidth': 256,
     }
     results = large_image.tilesource.utilities.getTileFramesQuadInfo(metadata, options)
     assert len(results['src']) == lensrc
@@ -620,7 +622,7 @@ def testStyleFunctions():
     region2, _ = sourceFunc2.getRegion(
         output=dict(maxWidth=50),
         format=large_image.constants.TILE_FORMAT_NUMPY)
-    assert numpy.any(region2 != region1)
+    assert np.any(region2 != region1)
     sourceFunc3 = large_image.open(imagePath, style={
         'function': {
             'name': 'large_image.tilesource.stylefuncs.maskPixelValues',
@@ -630,7 +632,7 @@ def testStyleFunctions():
     region3, _ = sourceFunc3.getRegion(
         output=dict(maxWidth=50),
         format=large_image.constants.TILE_FORMAT_NUMPY)
-    assert numpy.any(region3 != region2)
+    assert np.any(region3 != region2)
     sourceFunc4 = large_image.open(imagePath, style={
         'function': [{
             'name': 'large_image.tilesource.stylefuncs.maskPixelValues',
@@ -640,7 +642,7 @@ def testStyleFunctions():
     region4, _ = sourceFunc4.getRegion(
         output=dict(maxWidth=50),
         format=large_image.constants.TILE_FORMAT_NUMPY)
-    assert numpy.all(region4 == region2)
+    assert np.all(region4 == region2)
 
 
 def testStyleFunctionsWarnings():

--- a/test/test_source_deepzoom.py
+++ b/test/test_source_deepzoom.py
@@ -8,7 +8,7 @@ from . import utilities
 from .datastore import datastore
 
 
-@pytest.fixture
+@pytest.fixture()
 def vipsToDzi(tmpdir):
     def convert(imagePath, options=None):
         if options is None:
@@ -18,7 +18,7 @@ def vipsToDzi(tmpdir):
         image.dzsave(outputPath, **options)
         outputPath += '.dzi'
         return outputPath
-    yield convert
+    return convert
 
 
 @pytest.mark.parametrize('dzoptions', [

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -2,7 +2,7 @@ import os
 from unittest import TestCase
 
 import large_image_source_gdal
-import numpy
+import numpy as np
 import pytest
 
 from .datastore import datastore
@@ -116,7 +116,7 @@ class GDALSourceTests(_GDALBaseSourceTest, TestCase):
             imagePath, projection='EPSG:3857')
         base = source.getThumbnail(encoding='PNG')[0]
         basenp = source.getThumbnail(format='numpy')[0]
-        assert numpy.count_nonzero(basenp[:, :, 3] == 255) > 30000
+        assert np.count_nonzero(basenp[:, :, 3] == 255) > 30000
         source = self.basemodule.open(
             imagePath, projection='EPSG:3857',
             style={'bands': [
@@ -127,4 +127,4 @@ class GDALSourceTests(_GDALBaseSourceTest, TestCase):
         assert not (source.getThumbnail(format='numpy')[0] - basenp).any()
         source = self.basemodule.open(
             imagePath)
-        assert numpy.count_nonzero(source.getThumbnail(format='numpy')[0][:, :, 3] == 255) > 30000
+        assert np.count_nonzero(source.getThumbnail(format='numpy')[0][:, :, 3] == 255) > 30000

--- a/test/test_source_multi.py
+++ b/test/test_source_multi.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 import large_image_source_multi
-import numpy
+import numpy as np
 import pytest
 
 import large_image
@@ -12,7 +12,7 @@ from . import utilities
 from .datastore import datastore
 
 
-@pytest.fixture
+@pytest.fixture()
 def multiSourceImagePath():
     """
     Make sure we have the components for the multi_source.yml test.
@@ -21,7 +21,7 @@ def multiSourceImagePath():
     datastore.fetch('DDX58_AXL_EGFR_well2_XY01.ome.tif')
     datastore.fetch('ITGA3Hi_export_crop2.nd2')
     datastore.fetch('sample_Easy1.png')
-    yield datastore.fetch('multi_source.yml')
+    return datastore.fetch('multi_source.yml')
 
 
 @pytest.mark.parametrize('filename', [
@@ -248,7 +248,7 @@ def testTilesWithMoreComplexBands():
         output=dict(maxWidth=50),
         format=large_image.constants.TILE_FORMAT_NUMPY)
     assert region1.shape == (30, 50, 4)
-    assert region1.dtype == numpy.uint16
+    assert region1.dtype == np.uint16
 
 
 def testStyleFrameBase():
@@ -256,11 +256,11 @@ def testStyleFrameBase():
     imagePath = os.path.join(testDir, 'test_files', 'multi_test_source.yml')
     source = large_image_source_multi.open(
         imagePath, style=json.dumps({'bands': [{
-            'frame': 8, 'palette': '#0000FF'
+            'frame': 8, 'palette': '#0000FF',
         }, {
-            'frame': 10, 'palette': '#FF0000'
+            'frame': 10, 'palette': '#FF0000',
         }, {
-            'frame': 11, 'palette': '#FF8000'
+            'frame': 11, 'palette': '#FF8000',
         }]}))
     image = source.getTile(0, 0, 2)
     imageB = source.getTile(0, 0, 2, frame=8)

--- a/test/test_source_ometiff.py
+++ b/test/test_source_ometiff.py
@@ -2,7 +2,7 @@ import json
 from xml.etree import ElementTree
 
 import large_image_source_ometiff
-import numpy
+import numpy as np
 
 from large_image.constants import TILE_FORMAT_NUMPY
 from large_image.tilesource import dictToEtree, etreeToDict
@@ -71,11 +71,11 @@ def testOMETiffAre16Bit():
     imagePath = datastore.fetch('DDX58_AXL_EGFR_well2_XY01.ome.tif')
     source = large_image_source_ometiff.open(imagePath)
     tile = next(source.tileIterator(format=TILE_FORMAT_NUMPY))['tile']
-    assert tile.dtype == numpy.uint16
+    assert tile.dtype == np.uint16
     assert tile[15][15][0] == 17852
 
     region, _ = source.getRegion(format=TILE_FORMAT_NUMPY)
-    assert region.dtype == numpy.uint16
+    assert region.dtype == np.uint16
     assert region[300][300][0] == 17816
 
 
@@ -89,8 +89,8 @@ def testStyleAutoMinMax():
     imageB, _ = sourceB.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=TILE_FORMAT_NUMPY, frame=1)
     imageB = imageB[:, :, :1]
-    assert numpy.any(image != imageB)
-    imageB = imageB.astype(numpy.uint16) * 257
+    assert np.any(image != imageB)
+    imageB = imageB.astype(np.uint16) * 257
     assert image.shape == imageB.shape
     assert image[128][128][0] < imageB[128][128][0]
     assert image[0][128][0] < imageB[0][128][0]
@@ -116,7 +116,7 @@ def testStyleFrame():
         }]}))
     imageB, _ = sourceB.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=TILE_FORMAT_NUMPY, frame=1)
-    assert numpy.all(image == imageB)
+    assert np.all(image == imageB)
     assert image.shape == imageB.shape
     sourceC = large_image_source_ometiff.open(
         imagePath, style=json.dumps({'bands': [{
@@ -127,7 +127,7 @@ def testStyleFrame():
         }]}))
     imageC, _ = sourceC.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=TILE_FORMAT_NUMPY, frame=1)
-    assert numpy.any(image != imageC)
+    assert np.any(image != imageC)
     assert image.shape == imageC.shape
 
 
@@ -150,7 +150,7 @@ def testStyleFrameDelta():
         }]}))
     imageB, _ = sourceB.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=TILE_FORMAT_NUMPY, frame=1)
-    assert numpy.any(image != imageB)
+    assert np.any(image != imageB)
     assert image.shape == imageB.shape
     sourceC = large_image_source_ometiff.open(
         imagePath, style=json.dumps({'bands': [{
@@ -161,7 +161,7 @@ def testStyleFrameDelta():
         }]}))
     imageC, _ = sourceC.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=TILE_FORMAT_NUMPY, frame=2)
-    assert numpy.all(imageB == imageC)
+    assert np.all(imageB == imageC)
     assert imageB.shape == imageC.shape
 
 
@@ -182,7 +182,7 @@ def testXMLParsing():
             'IndexStride': {'IndexC': 1},
             'channelmap': {'Blue': 2, 'Green': 1, 'Red': 0},
             'channels': ['Red', 'Green', 'Blue'],
-        }
+        },
     }]
     # Create a source so we can use internal functions for testing
     imagePath = datastore.fetch('sample.ome.tif')

--- a/test/test_source_openslide.py
+++ b/test/test_source_openslide.py
@@ -2,7 +2,7 @@ import os
 import struct
 
 import large_image_source_openslide
-import numpy
+import numpy as np
 import PIL.Image
 import pytest
 
@@ -150,12 +150,12 @@ def testTileIterator():
     tileCount = 0
     for tile in source.tileIterator(scale={'magnification': 5}):
         tileCount += 1
-        assert isinstance(tile['tile'], numpy.ndarray)
+        assert isinstance(tile['tile'], np.ndarray)
         assert tile['tile'].shape == (
             256 if tile['level_y'] < 11 else 79,
             256 if tile['level_x'] < 11 else 61,
             4)
-        assert tile['tile'].dtype == numpy.dtype('uint8')
+        assert tile['tile'].dtype == np.dtype('uint8')
     assert tileCount == 144
     # Ask for either PIL or IMAGE data, we should get PIL data
     tileCount = 0
@@ -199,7 +199,7 @@ def testGetRegion():
         scale={'magnification': 2.5},
         format=constants.TILE_FORMAT_NUMPY)
     assert imageFormat == constants.TILE_FORMAT_NUMPY
-    assert isinstance(image, numpy.ndarray)
+    assert isinstance(image, np.ndarray)
     assert image.shape == (1447, 1438, 4)
 
     # We should be able to get a PIL image
@@ -277,7 +277,7 @@ def testConvertRegionScale():
         sourceRegion, sourceScale, targetScale,
         format=constants.TILE_FORMAT_NUMPY)
     assert imageFormat == constants.TILE_FORMAT_NUMPY
-    assert isinstance(image, numpy.ndarray)
+    assert isinstance(image, np.ndarray)
     assert image.shape == (506, 575, 4)
     with pytest.raises(TypeError):
         source.getRegionAtAnotherScale(
@@ -292,10 +292,9 @@ def testConvertRegionScale():
         tileCount += 1
     assert tileCount == 72
     with pytest.raises(TypeError):
-        for _tile in source.tileIteratorAtAnotherScale(
-                sourceRegion, sourceScale, region=sourceRegion,
-                format=constants.TILE_FORMAT_NUMPY):
-            tileCount += 1
+        list(source.tileIteratorAtAnotherScale(
+            sourceRegion, sourceScale, region=sourceRegion,
+            format=constants.TILE_FORMAT_NUMPY))
 
 
 def testConvertPointScale():

--- a/test/test_source_tiff.py
+++ b/test/test_source_tiff.py
@@ -4,7 +4,7 @@ import os
 import struct
 
 import large_image_source_tiff
-import numpy
+import numpy as np
 import pytest
 import tifftools
 
@@ -361,7 +361,7 @@ def testThumbnails():
             source.getThumbnail(**entry[0])
 
 
-@pytest.mark.parametrize('badParams,errMessage', [
+@pytest.mark.parametrize(('badParams', 'errMessage'), [
     ({'encoding': 'invalid', 'width': 10}, 'Invalid encoding'),
     ({'output': {'maxWidth': 'invalid'}}, 'ValueError'),
     ({'output': {'maxWidth': -5}}, 'Invalid output width or height'),
@@ -381,9 +381,9 @@ def testThumbnails():
 def testRegionBadParameters(badParams, errMessage):
     imagePath = datastore.fetch('sample_image.ptif')
     source = large_image_source_tiff.open(imagePath)
+    params = {'output': {'maxWidth': 400}}
+    nestedUpdate(params, badParams)
     with pytest.raises(Exception):
-        params = {'output': {'maxWidth': 400}}
-        nestedUpdate(params, badParams)
         source.getRegion(**params)
 
 
@@ -602,7 +602,7 @@ def testOrientations():
             image[11][11][0], image[11][-11][0],
             image[image.shape[0] // 2][11][0], image[image.shape[0] // 2][-11][0],
             image[11][image.shape[1] // 2][0], image[-11][image.shape[1] // 2][0],
-            image[-11][11][0], image[-11][-11][0]
+            image[-11][11][0], image[-11][-11][0],
         ) == testResults[orient]['pixels']
 
 
@@ -633,11 +633,11 @@ def testStyleSwapChannels():
     imageB, _ = sourceB.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=constants.TILE_FORMAT_NUMPY)
     imageB = imageB[:, :, :3]
-    assert numpy.any(image != imageB)
-    assert numpy.all(image[:, :, 0] == imageB[:, :, 0])
-    assert numpy.any(image[:, :, 1] != imageB[:, :, 1])
-    assert numpy.all(image[:, :, 1] == imageB[:, :, 2])
-    assert numpy.all(image[:, :, 2] == imageB[:, :, 1])
+    assert np.any(image != imageB)
+    assert np.all(image[:, :, 0] == imageB[:, :, 0])
+    assert np.any(image[:, :, 1] != imageB[:, :, 1])
+    assert np.all(image[:, :, 1] == imageB[:, :, 2])
+    assert np.all(image[:, :, 2] == imageB[:, :, 1])
 
 
 def testStyleClamp():
@@ -650,8 +650,8 @@ def testStyleClamp():
         imagePath, style=json.dumps({'min': 100, 'max': 200, 'clamp': False}))
     imageB, _ = sourceB.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=constants.TILE_FORMAT_NUMPY)
-    assert numpy.all(image[:, :, 3] == 255)
-    assert numpy.any(imageB[:, :, 3] != 255)
+    assert np.all(image[:, :, 3] == 255)
+    assert np.any(imageB[:, :, 3] != 255)
     assert image[0][0][3] == 255
     assert imageB[0][0][3] == 0
 
@@ -666,14 +666,14 @@ def testStyleMinMaxThreshold():
         imagePath, style=json.dumps({'min': 'min:0.02', 'max': 'max:0.02'}))
     imageB, _ = sourceB.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=constants.TILE_FORMAT_NUMPY)
-    assert numpy.any(image != imageB)
+    assert np.any(image != imageB)
     assert image[0][0][0] == 252
     assert imageB[0][0][0] == 246
     sourceC = large_image_source_tiff.open(
         imagePath, style=json.dumps({'min': 'full', 'max': 'full'}))
     imageC, _ = sourceC.getRegion(
         output={'maxWidth': 256, 'maxHeight': 256}, format=constants.TILE_FORMAT_NUMPY)
-    assert numpy.any(image != imageC)
+    assert np.any(image != imageC)
     assert imageC[0][0][0] == 253
 
 
@@ -697,14 +697,14 @@ def testStyleNoData():
     imageB = image
     # Pillow 9.0.0 changed how they decode JPEGs, so find a nodata value that
     # will cause a difference
-    while numpy.all(imageB == image):
+    while np.all(imageB == image):
         nodata += 1
         sourceB = large_image_source_tiff.open(
             imagePath, style=json.dumps({'nodata': nodata}))
         imageB, _ = sourceB.getRegion(
             output={'maxWidth': 256, 'maxHeight': 256}, format=constants.TILE_FORMAT_NUMPY)
-    assert numpy.all(image[:, :, 3] == 255)
-    assert numpy.any(imageB[:, :, 3] != 255)
+    assert np.all(image[:, :, 3] == 255)
+    assert np.any(imageB[:, :, 3] != 255)
 
 
 def testHistogram():

--- a/test/utils/compression_test_summary.py
+++ b/test/utils/compression_test_summary.py
@@ -4,7 +4,7 @@ import json
 import os
 import sys
 
-import pandas
+import pandas as pd
 import tifftools
 
 if not len(sys.argv[1:]) or '--help' in sys.argv[1:]:
@@ -47,5 +47,5 @@ for file in os.listdir(sys.argv[1]):
         print(entry)
         continue
     print(entry)
-df = pandas.DataFrame.from_dict(results)
+df = pd.DataFrame.from_dict(results)
 df.to_csv(sys.argv[2], index=False)

--- a/tox.ini
+++ b/tox.ini
@@ -110,6 +110,21 @@ commands =
 deps = {[testenv:core]deps}
 commands = {[testenv:core]commands}
 
+[testenv:lint]
+description = Lint python code
+skipsdist = true
+skip_install = true
+deps =
+  flake8
+  flake8-bugbear
+  flake8-docstrings
+  flake8-isort
+  flake8-quotes
+  ruff
+commands =
+  ruff large_image sources utilities girder girder_annotation examples docs test
+  flake8
+
 [testenv:flake8]
 description = Lint python code
 skipsdist = true
@@ -120,7 +135,17 @@ deps =
   flake8-docstrings
   flake8-isort
   flake8-quotes
-commands = flake8 {posargs}
+commands =
+  flake8 {posargs}
+
+[testenv:ruff]
+description = Lint python code
+skipsdist = true
+skip_install = true
+deps =
+  ruff
+commands =
+  ruff large_image sources utilities girder girder_annotation examples docs test {posargs}
 
 [testenv:format]
 description = Autoformat import order and autopep8
@@ -128,12 +153,16 @@ skipsdist = true
 skip_install = true
 deps =
   autopep8
+  pycodestyle<2.11.0
   isort
   unify
+  ruff
+# Remove pycodestyle line when autopep8 is fixed
 commands =
-  isort {posargs:.}
+  isort .
   autopep8 -ria large_image sources utilities girder girder_annotation examples docs test
   unify --in-place --recursive large_image sources utilities girder girder_annotation examples docs test
+  ruff large_image sources utilities girder girder_annotation examples docs test --fix
 
 [testenv:lintclient]
 description = Lint the girder large_image plugin client

--- a/utilities/converter/large_image_converter/__main__.py
+++ b/utilities/converter/large_image_converter/__main__.py
@@ -141,7 +141,7 @@ def compute_error_metrics(original, altered, results, converterOpts=None):
     from tempfile import TemporaryDirectory
 
     import large_image_source_tiff
-    import numpy
+    import numpy as np
     import packaging
     import skimage.metrics
 
@@ -167,7 +167,7 @@ def compute_error_metrics(original, altered, results, converterOpts=None):
                 tileAlt = next(tiAlt)
                 do = tileOrig['tile']
                 da = tileAlt['tile']
-                if do.dtype != da.dtype and da.dtype == numpy.uint8:
+                if do.dtype != da.dtype and da.dtype == np.uint8:
                     da = da.astype(int) * 257
                 do = do.astype(int)
                 da = da.astype(int)
@@ -176,11 +176,11 @@ def compute_error_metrics(original, altered, results, converterOpts=None):
                     do = do[:, :, :da.shape[2]]
                 if da.shape[2] > do.shape[2]:
                     da = da[:, :, :do.shape[2]]
-                diff = numpy.absolute(do - da)
+                diff = np.absolute(do - da)
                 maxdiff = max(maxdiff, diff.max())
                 sum += diff.sum()
                 count += diff.size
-                last_mse = numpy.mean(diff ** 2)
+                last_mse = np.mean(diff ** 2)
                 mse += last_mse * diff.size
                 last_ssim = 0
                 try:
@@ -192,7 +192,7 @@ def compute_error_metrics(original, altered, results, converterOpts=None):
                         kwargs['multichannel'] = len(do.shape) > 2
                     last_ssim = skimage.metrics.structural_similarity(
                         do.astype(float), da.astype(float),
-                        data_range=255 if tileOrig['tile'].dtype == numpy.uint8 else 65535,
+                        data_range=255 if tileOrig['tile'].dtype == np.uint8 else 65535,
                         gaussian_weights=True, sigma=1.5, use_sample_covariance=False,
                         **kwargs)
                     ssim += last_ssim * diff.size
@@ -202,12 +202,12 @@ def compute_error_metrics(original, altered, results, converterOpts=None):
                 if time.time() - lastlog >= 10 and ssim_count:
                     logger.debug(
                         'Calculating error (%d/%d): rmse %4.2f ssim %6.4f  '
-                        'last rmse %4.2f ssim %6.4f' % (
-                            tileOrig['tile_position']['position'] + 1 +
-                            tileOrig['iterator_range']['position'] * frame,
-                            tileOrig['iterator_range']['position'] * numFrames,
-                            (mse / count) ** 0.5, ssim / ssim_count,
-                            last_mse ** 0.5, last_ssim))
+                        'last rmse %4.2f ssim %6.4f',
+                        tileOrig['tile_position']['position'] + 1 +
+                        tileOrig['iterator_range']['position'] * frame,
+                        tileOrig['iterator_range']['position'] * numFrames,
+                        (mse / count) ** 0.5, ssim / ssim_count,
+                        last_mse ** 0.5, last_ssim)
                     lastlog = time.time()
         results['maximum_error'] = maxdiff
         results['average_error'] = sum / count
@@ -216,8 +216,8 @@ def compute_error_metrics(original, altered, results, converterOpts=None):
             maxval ** 2 / (mse / count)) if mse else None
         if ssim_count:
             results['ssim'] = ssim / ssim_count
-            logger.debug('Calculated error: rmse %4.2f psnr %3.1f ssim %6.4f' % (
-                results['rmse'], results['psnr'] or 0, results['ssim']))
+            logger.debug('Calculated error: rmse %4.2f psnr %3.1f ssim %6.4f',
+                         results['rmse'], results['psnr'] or 0, results['ssim'])
 
 
 def main(args=sys.argv[1:]):
@@ -234,7 +234,7 @@ def main(args=sys.argv[1:]):
         li_logger.setLevel(max(1, logging.CRITICAL - (opts.verbose - opts.silent) * 10))
     except ImportError:
         pass
-    logger.debug('Command line options: %r' % opts)
+    logger.debug('Command line options: %r', opts)
     if not os.path.isfile(opts.source) and not opts.source.startswith('large_image://test'):
         logger.error('Source is not a file (%s)', opts.source)
         return 1

--- a/utilities/converter/large_image_converter/format_aperio.py
+++ b/utilities/converter/large_image_converter/format_aperio.py
@@ -22,7 +22,8 @@ def adjust_params(geospatial, params, **kwargs):
     :returns: suffix: the recommended suffix for the new file.
     """
     if geospatial:
-        raise Exception('Aperio format cannot be used with geospatial sources.')
+        msg = 'Aperio format cannot be used with geospatial sources.'
+        raise Exception(msg)
     if params.get('subifds') is None:
         params['subifds'] = False
     return '.svs'
@@ -189,7 +190,7 @@ def create_thumbnail_and_label(tempPath, info, ifdCount, needsLabel, labelPositi
             }
             ifd['tags'][tifftools.Tag.NewSubfileType.value] = {
                 'data': [
-                    tifftools.constants.NewSubfileType.ReducedImage.value
+                    tifftools.constants.NewSubfileType.ReducedImage.value,
                 ],
                 'datatype': tifftools.Datatype.LONG,
             }
@@ -253,7 +254,7 @@ def modify_tiff_before_write(info, ifdIndices, tempPath, lidata, **kwargs):
             'data': [
                 tifftools.constants.NewSubfileType.ReducedImage.value if assocKey == 'label' else
                 (tifftools.constants.NewSubfileType.ReducedImage.value |
-                 tifftools.constants.NewSubfileType.Macro.value)
+                 tifftools.constants.NewSubfileType.Macro.value),
             ],
             'datatype': tifftools.Datatype.LONG,
         }

--- a/utilities/converter/setup.py
+++ b/utilities/converter/setup.py
@@ -80,7 +80,7 @@ setup(
     },
     packages=find_packages(),
     entry_points={
-        'console_scripts': ['large_image_converter = large_image_converter.__main__:main']
+        'console_scripts': ['large_image_converter = large_image_converter.__main__:main'],
     },
     python_requires='>=3.6',
 )

--- a/utilities/tasks/large_image_tasks/tasks.py
+++ b/utilities/tasks/large_image_tasks/tasks.py
@@ -67,12 +67,13 @@ def create_tiff(self, inputFile, outputName=None, outputDir=None, quality=90,
     large_image_converter.convert(
         inputPath, outputPath, quality=quality, tileSize=tileSize, **kwargs)
     if not os.path.exists(outputPath):
-        raise Exception('Conversion command failed to produce output')
+        msg = 'Conversion command failed to produce output'
+        raise Exception(msg)
     if renameOutput != outputName:
         renamePath = os.path.join(outputDir, renameOutput)
         shutil.move(outputPath, renamePath)
         outputPath = renamePath
-    logger.info('Created a file of size %d' % os.path.getsize(outputPath))
+    logger.info('Created a file of size %d', os.path.getsize(outputPath))
     return outputPath
 
 

--- a/utilities/tasks/setup.py
+++ b/utilities/tasks/setup.py
@@ -78,7 +78,7 @@ setup(
     entry_points={
         'girder_worker_plugins': [
             'large_image_tasks = large_image_tasks:LargeImageTasks',
-        ]
+        ],
     },
     packages=find_packages(),
 )


### PR DESCRIPTION
ruff and isort disagree about how to sort imports.  flake8-isort seems to always fail if ruff reformats imports; ruff fails if isort reformats imports.

ruff doesn't completely format spacing, so autopep8 is still needed for formatting.
