### PR TITLE
Reduce pyvips log level.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changes
 - Minor code changes based on suggestions from ruff linting ([#1257](../../pull/1257))
+- Reduce pyvips log level ([#1258](../../pull/1258))
 
 ### Bug Fixes
 - Guard against ICC profiles that won't parse ([#1245](../../pull/1245))

--- a/sources/vips/large_image_source_vips/__init__.py
+++ b/sources/vips/large_image_source_vips/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import os
 import threading
@@ -16,6 +17,8 @@ from large_image.constants import (NEW_IMAGE_PATH_FLAG, TILE_FORMAT_NUMPY,
 from large_image.exceptions import TileSourceError, TileSourceFileNotFoundError
 from large_image.tilesource import FileTileSource
 from large_image.tilesource.utilities import _imageToNumpy
+
+logging.getLogger('pyvips').setLevel(logging.ERROR)
 
 # Default to ignoring files with no extension and some specific extensions.
 config.ConfigValues['source_vips_ignored_names'] = \


### PR DESCRIPTION
On python 3.11 it is noisy on our test suite (maybe on other versions, too).