### PR TITLE
Don't use dask threads when using nd2 to fetch tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### Changes
 - Minor code changes based on suggestions from ruff linting ([#1257](../../pull/1257))
-- Reduce pyvips log level ([#1258](../../pull/1258))
+- Reduce pyvips log level ([#1259](../../pull/1259))
+- Don't use dask threads when using nd2 to fetch tiles ([#1260](../../pull/1260))
 
 ### Bug Fixes
 - Guard against ICC profiles that won't parse ([#1245](../../pull/1245))

--- a/sources/nd2/large_image_source_nd2/__init__.py
+++ b/sources/nd2/large_image_source_nd2/__init__.py
@@ -131,8 +131,6 @@ class ND2FileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
 
         self._largeImagePath = str(self._getLargeImagePath())
 
-        self._pixelInfo = {}
-
         _lazyImport()
         try:
             self._nd2 = nd2.ND2File(self._largeImagePath, validate_frames=True)
@@ -205,7 +203,7 @@ class ND2FileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             axisSize = self._nd2.sizes[axis]
             check[axisidx] = axisSize - 1
             try:
-                self._nd2array[tuple(check)].compute()
+                self._nd2array[tuple(check)].compute(scheduler='single-threaded')
                 if axis not in {'X', 'Y', 'S'}:
                     count *= axisSize
                 continue
@@ -218,7 +216,7 @@ class ND2FileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 nextval = (minval + maxval) // 2
                 check[axisidx] = nextval
                 try:
-                    self._nd2array[tuple(check)].compute()
+                    self._nd2array[tuple(check)].compute(scheduler='single-threaded')
                     minval = nextval
                 except Exception:
                     maxval = nextval

--- a/sources/tiff/large_image_source_tiff/__init__.py
+++ b/sources/tiff/large_image_source_tiff/__init__.py
@@ -651,7 +651,7 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 exception=e, **kwargs)
 
     def _getDirFromCache(self, dirnum, subdir=None):
-        if not hasattr(self, '_directoryCache'):
+        if not hasattr(self, '_directoryCache') or not hasattr(self, '_directoryCacheMaxSize'):
             self._directoryCache = {}
             self._directoryCacheMaxSize = max(20, self.levels * (2 + (
                 self.metadata.get('IndexRange', {}).get('IndexC', 1))))


### PR DESCRIPTION
We were still using them to verify the file; this reduces overhead and prevents the dask threadpool from blocking girder restarts.