### PR TITLE
Reduce memory allocation during some region tiling operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Allow caching rounded histograms ([#1252](../../pull/1252))
 - Add an endpoint to make it easier to replace thumbnails ([#1253](../../pull/1253))
 - Presets from Large Image Configuration file ([#1248](../../pull/1248), [#1256](../../pull/1256))
+- Reduce memory allocation during some region tiling operations ([#1261](../../pull/1261))
 
 ### Changes
 - Minor code changes based on suggestions from ruff linting ([#1257](../../pull/1257))

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -2135,6 +2135,8 @@ class TileSource(IPyLeafletMixin):
         if tiled:
             return self._addRegionTileToTiled(image, subimage, x, y, width, height, tile, **kwargs)
         if image is None:
+            if (x, y, width, height) == (0, 0, subimage.shape[1], subimage.shape[0]):
+                return subimage
             try:
                 image = np.zeros(
                     (height, width, subimage.shape[2]),


### PR DESCRIPTION
This skips a numpy alloc and copy