### PR TITLE
Reduce memory allocation during some styling operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add an endpoint to make it easier to replace thumbnails ([#1253](../../pull/1253))
 - Presets from Large Image Configuration file ([#1248](../../pull/1248), [#1256](../../pull/1256))
 - Reduce memory allocation during some region tiling operations ([#1261](../../pull/1261))
+- Reduce memory allocation during some styling operations ([#1262](../../pull/1262))
 
 ### Changes
 - Minor code changes based on suggestions from ruff linting ([#1257](../../pull/1257))

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1420,7 +1420,9 @@ class TileSource(IPyLeafletMixin):
         if not style or ('icc' in style and len(style) == 1):
             sc.output = image
         else:
-            sc.output = np.zeros((image.shape[0], image.shape[1], 4), float)
+            sc.output = np.zeros(
+                (image.shape[0], image.shape[1], 4),
+                np.float32 if image.dtype != np.float64 else image.dtype)
         image = self._applyStyleFunction(image, sc, 'pre')
         for eidx, entry in enumerate(sc.style['bands']):
             sc.styleIndex = eidx


### PR DESCRIPTION
Specifically, when we apply a style, in some instances the tile or region is converted from one dtype to a float in order to preserve some of the transform properties through the process.  We had been using `float`, which internally is `np.float64`.  But, `np.float32` gives sufficient accuracy for our styles.  With this change, `np.float32` is used unless the base datatype is `float64`, in which we do not reduce the precision.