### PR TITLE
For greyscale images styled to the white palette, use 1 band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Add an endpoint to make it easier to replace thumbnails ([#1253](../../pull/1253))
 - Presets from Large Image Configuration file ([#1248](../../pull/1248), [#1256](../../pull/1256))
 - Reduce memory allocation during some region tiling operations ([#1261](../../pull/1261))
-- Reduce memory allocation during some styling operations ([#1262](../../pull/1262))
+- Reduce memory allocation during some styling operations ([#1262](../../pull/1262), [#1263](../../pull/1263))
 
 ### Changes
 - Minor code changes based on suggestions from ruff linting ([#1257](../../pull/1257))

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1420,8 +1420,14 @@ class TileSource(IPyLeafletMixin):
         if not style or ('icc' in style and len(style) == 1):
             sc.output = image
         else:
+            newwidth = 4
+            if (len(sc.style['bands']) == 1 and sc.style['bands'][0].get('band') != 'alpha' and
+                    image.shape[-1] == 1):
+                palette = getPaletteColors(sc.style['bands'][0].get('palette', ['#000', '#FFF']))
+                if np.array_equal(palette, getPaletteColors('#fff')):
+                    newwidth = 1
             sc.output = np.zeros(
-                (image.shape[0], image.shape[1], 4),
+                (image.shape[0], image.shape[1], newwidth),
                 np.float32 if image.dtype != np.float64 else image.dtype)
         image = self._applyStyleFunction(image, sc, 'pre')
         for eidx, entry in enumerate(sc.style['bands']):
@@ -1493,7 +1499,7 @@ class TileSource(IPyLeafletMixin):
             # divide.
             # See https://docs.gimp.org/en/gimp-concepts-layer-modes.html for
             # some details.
-            for channel in range(4):
+            for channel in range(sc.output.shape[2]):
                 if np.all(sc.palette[:, channel] == sc.palette[0, channel]):
                     if ((sc.palette[0, channel] == 0 and sc.composite != 'multiply') or
                             (sc.palette[0, channel] == 255 and sc.composite == 'multiply')):

--- a/sources/multi/large_image_source_multi/__init__.py
+++ b/sources/multi/large_image_source_multi/__init__.py
@@ -520,6 +520,9 @@ class MultiFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 self._resolvePathPatterns(sources, source)
             else:
                 self._resolveSourcePath(sources, source)
+        for source in sources:
+            if hasattr(source.get('path'), 'resolve'):
+                source['path'] = source['path'].resolve(False)
         return sources
 
     def _sourceBoundingBox(self, source, width, height):
@@ -936,6 +939,8 @@ class MultiFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             if base.shape[2] == 2 or base.shape[2] == 4:
                 hfill[:, :, -1] = 1
             base = np.hstack((base, hfill))
+        if base.flags.writeable is False:
+            base = base.copy()
         base[y:y + tile.shape[0], x:x + tile.shape[1], :] = tile
         return base
 


### PR DESCRIPTION
For multi source files, resolve paths to improve cache hits.