### PR TITLE
Use a newer version of the hammerjs touch events library in Girder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 - Adjust tifffile log level ([#1265](../../pull/1265))
+- Use a newer version of the hammerjs touch events library in Girder ([#1266](../../pull/1266))
 
 ## 1.23.3
 

--- a/girder/girder_large_image/web_client/package.json
+++ b/girder/girder_large_image/web_client/package.json
@@ -19,7 +19,7 @@
         "copy-webpack-plugin": "^4.5.2",
         "d3": "^3.5.16",
         "geojs": "^1.8.6",
-        "hammerjs": "^2.0.8",
+        "@egjs/hammerjs": "^2.0.8",
         "js-yaml": "^4.1.0",
         "jsonlint-mod": "^1.7.6",
         "sinon": "^2.1.0",

--- a/girder/girder_large_image/web_client/views/imageViewerWidget/geojs.js
+++ b/girder/girder_large_image/web_client/views/imageViewerWidget/geojs.js
@@ -3,7 +3,7 @@
 import $ from 'jquery';
 import _ from 'underscore';
 // Import hammerjs for geojs touch events
-import Hammer from 'hammerjs';
+import Hammer from '@egjs/hammerjs';
 import d3 from 'd3';
 
 import {restRequest} from '@girder/core/rest';


### PR DESCRIPTION
This has less conflicts with some other newer packages.