### PR TITLE
Style functions after band compositing had a styleIndex value set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Bug Fixes
 - Allow users with only annotation access to edit annotations ([#1267](../../pull/1267))
 - Fix filtering item lists in Girder by multiple phrases ([#1272](../../pull/1272))
+- Style functions after band compositing had a styleIndex value set ([#1274](../../pull/1274))
 
 ## 1.23.3
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1531,6 +1531,8 @@ class TileSource(IPyLeafletMixin):
                             sc.output[:sc.mask.shape[0], :sc.mask.shape[1], channel],
                             np.where(sc.mask, clrs, 0))
             sc.output = self._applyStyleFunction(sc.output, sc, 'postband')
+        if hasattr(sc, 'styleIndex'):
+            del sc.styleIndex
         sc.output = self._applyStyleFunction(sc.output, sc, 'main')
         if sc.dtype == 'uint16':
             sc.output = (sc.output * 65535 / 255).astype(np.uint16)

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -645,6 +645,89 @@ def testStyleFunctions():
     assert np.all(region4 == region2)
 
 
+def testStyleFunctionsStage():
+    imagePath = datastore.fetch('d042-353.crop.small.jpg')
+    source = large_image.open(imagePath, style={
+        'bands': [{
+            'band': 1, 'palette': 'R',
+        }, {
+            'band': 2, 'palette': 'G',
+        }, {
+            'band': 3, 'palette': 'B',
+        }]})
+    region1, _ = source.getRegion(
+        output=dict(maxWidth=50),
+        format=large_image.constants.TILE_FORMAT_NUMPY)
+    sourceFunc2 = large_image.open(imagePath, style={
+        'function': {
+            'name': 'large_image.tilesource.stylefuncs.medianFilter',
+            'parameters': {'kernel': 5, 'weight': 1.5},
+            'stage': 'main',
+        },
+        'bands': [{
+            'band': 1, 'palette': 'R',
+        }, {
+            'band': 2, 'palette': 'G',
+        }, {
+            'band': 3, 'palette': 'B',
+        }]})
+    region2, _ = sourceFunc2.getRegion(
+        output=dict(maxWidth=50),
+        format=large_image.constants.TILE_FORMAT_NUMPY)
+    assert np.any(region2 != region1)
+    sourceFunc3 = large_image.open(imagePath, style={
+        'bands': [{
+            'band': 1, 'palette': 'R',
+            'function': {
+                'name': 'large_image.tilesource.stylefuncs.medianFilter',
+                'parameters': {'kernel': 5, 'weight': 1.5},
+                'stage': 'band',
+            },
+        }, {
+            'band': 2, 'palette': 'G',
+        }, {
+            'band': 3, 'palette': 'B',
+        }]})
+    region3, _ = sourceFunc3.getRegion(
+        output=dict(maxWidth=50),
+        format=large_image.constants.TILE_FORMAT_NUMPY)
+    assert np.any(region3 != region1)
+    assert np.any(region3 != region2)
+
+    sourceFunc2a = large_image.open(imagePath, style={
+        'function': {
+            'name': 'large_image.tilesource.stylefuncs.medianFilter',
+            'parameters': {'kernel': 5, 'weight': 1.5},
+        },
+        'bands': [{
+            'band': 1, 'palette': 'R',
+        }, {
+            'band': 2, 'palette': 'G',
+        }, {
+            'band': 3, 'palette': 'B',
+        }]})
+    region2a, _ = sourceFunc2a.getRegion(
+        output=dict(maxWidth=50),
+        format=large_image.constants.TILE_FORMAT_NUMPY)
+    assert np.all(region2a == region2)
+    sourceFunc3a = large_image.open(imagePath, style={
+        'bands': [{
+            'band': 1, 'palette': 'R',
+            'function': {
+                'name': 'large_image.tilesource.stylefuncs.medianFilter',
+                'parameters': {'kernel': 5, 'weight': 1.5},
+            },
+        }, {
+            'band': 2, 'palette': 'G',
+        }, {
+            'band': 3, 'palette': 'B',
+        }]})
+    region3a, _ = sourceFunc3a.getRegion(
+        output=dict(maxWidth=50),
+        format=large_image.constants.TILE_FORMAT_NUMPY)
+    assert np.all(region3a == region3)
+
+
 def testStyleFunctionsWarnings():
     imagePath = datastore.fetch('extraoverview.tiff')
     source = large_image.open(imagePath, style={


### PR DESCRIPTION
Add a medianFilter example styling function to test style function stages.

This could be applied like so: `style={"bands": [{"band":1, "function":
{"name": "large_image.tilesource.stylefuncs.medianFilter", "parameters":
{"kernel": 5, "weight": 2}}}]}}`