### PR TITLE
Better expose ipyleaflet maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Harden internal retiling.  This sometimes affected histograms ([#1269](../../pull/1269))
 - Set annotation update user in client so it appears faster ([#1270](../../pull/1270))
 - Harden reading with tifffile on images with bad axes information ([#1273](../../pull/1273))
-- Include projection in metadata ([#1277](../../pull/1277)
+- Include projection in metadata ([#1277](../../pull/1277))
+- Better expose ipyleaflet maps ([#1278](../../pull/1278))
 
 ### Changes
 - Adjust tifffile log level ([#1265](../../pull/1265))


### PR DESCRIPTION
There are now several ways to invoke ipyleafet maps:
- using JupyterLab and proxying a local file from the JupyerLab instance
- using JupyterLab and proxying a file from a non-large_image girder server on the JupyerLab instance
- using Jupyter or Jupyter lab and accessing data on a large_image girder server by item or file id
- using Jupyter or Jupyter lab and accessing data on a large_image girder server by resource path

There are now utility functions to convert to/from pixel coordinates and to grab the locally proxied map.  (ts.to_map / ts.from_map / ts.iplmap for the proxied tile source, or map.to_map / map.from_map for the girder server rendered map).

This should get documented by including samples in a jupyter notebook (see issue #1274).