### PR TITLE
Allow scheduling histogram computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.23.6
+
+### Improvements
+- Allow scheduling histogram computation in Girder ([#1282](../../pull/1282))
+
 ## 1.23.5
 
 ### Improvements


### PR DESCRIPTION
For multi-frame files, precomputing histograms can speed up UI.  This extends the Girder item/{id}/tiles/histogram option with another option.  If `cache=report`, a list corresponding to all frames is returned showing which frames have a histogram with the remaining API call parameters computed and cached.  If `cache=schedule`, if there are any such frames that are not cached (and eligible to be cached), then a local job is created to do so.

Note that histograms that use a range value other than the default or `round` are not cached.