### PR TITLE
Closing some styled sources could premature close file handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Improvements
 - Allow scheduling histogram computation in Girder ([#1282](../../pull/1282))
 
+### Bug Fixes
+- Closing some styled sources could lead to prematurely closing file handles ([#1283](../../pull/1283))
+
 ## 1.23.5
 
 ### Improvements

--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -208,11 +208,12 @@ class LruCacheMetaclass(type):
                 with subresult._sourceLock:
                     result.__dict__ = subresult.__dict__.copy()
                     result._sourceLock = threading.RLock()
-                result._setStyle(kwargs['style'])
                 result._classkey = key
-                result._unstyledInstance = subresult
                 # for pickling
                 result._initValues = (args, kwargs.copy())
+                result._unstyledInstance = subresult
+                # Has to be after setting the _unstyledInstance
+                result._setStyle(kwargs['style'])
                 with cacheLock:
                     cache[key] = result
                     return result

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -203,11 +203,12 @@ class TileSource(IPyLeafletMixin):
                 self._jsonstyle = json.dumps(style, sort_keys=True, separators=(',', ':'))
             else:
                 try:
+                    self._style = None
                     style = json.loads(style)
                     if not isinstance(style, dict):
                         raise TypeError
                     self._style = JSONDict(style)
-                except TypeError:
+                except (TypeError, json.decoder.JSONDecodeError):
                     msg = 'Style is not a valid json object.'
                     raise exceptions.TileSourceError(msg)
 

--- a/sources/dicom/large_image_source_dicom/__init__.py
+++ b/sources/dicom/large_image_source_dicom/__init__.py
@@ -144,7 +144,10 @@ class DICOMFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         self._populatedLevels = len(self._dicom.levels)
 
     def __del__(self):
-        if getattr(self, '_dicom', None) is not None:
+        # If we have an _unstyledInstance attribute, this is not the owner of
+        # the _docim handle, so we can't close it.  Otherwise, we need to close
+        # it or the _dicom library may prevent shutting down.
+        if getattr(self, '_dicom', None) is not None and not hasattr(self, '_unstyledInstance'):
             try:
                 self._dicom.close()
             finally:

--- a/sources/nd2/large_image_source_nd2/__init__.py
+++ b/sources/nd2/large_image_source_nd2/__init__.py
@@ -191,7 +191,10 @@ class ND2FileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         self._tileLock = threading.RLock()
 
     def __del__(self):
-        if hasattr(self, '_nd2'):
+        # If we have an _unstyledInstance attribute, this is not the owner of
+        # the _nd2 handle, so we can't close it.  Otherwise, we need to close
+        # it or the nd2 library complains that we didn't explicitly close it.
+        if hasattr(self, '_nd2') and not hasattr(self, '_unstyledInstance'):
             self._nd2.close()
             del self._nd2
 


### PR DESCRIPTION
This could be reproduced by opening an nd2 file, opening another instance of it with a bad style, then trying to open another instance of it with a good style.  The file handles would get closed with the bad style, and then subsequent reads of a good style would fail (and even could segfault).