### PR TITLE
Band order could matter in styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug Fixes
 - Closing some styled sources could lead to prematurely closing file handles ([#1283](../../pull/1283))
+- Band order could matter in styles ([#1284](../../pull/1284))
 
 ## 1.23.5
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1438,7 +1438,7 @@ class TileSource(IPyLeafletMixin):
             sc.bandidx = 0 if image.shape[2] <= 2 else 1
             sc.band = None
             if ((entry.get('frame') is None and not entry.get('framedelta')) or
-                    entry.get('frame') == frame):
+                    entry.get('frame') == sc.mainFrame):
                 image = sc.mainImage
                 frame = sc.mainFrame
             else:

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -764,3 +764,45 @@ def testStyleFunctionsWarnings():
         output=dict(maxWidth=50),
         format=large_image.constants.TILE_FORMAT_NUMPY)
     assert source._styleFunctionWarnings
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason='requires python >= 3.7 for the source')
+@pytest.mark.singular()
+def testStyleRepeatedFrame():
+    imagePath = datastore.fetch('ITGA3Hi_export_crop2.nd2')
+    ts1 = large_image.open(imagePath, style={'bands': [
+        {'frame': 0, 'min': 'min', 'max': 'max', 'palette': 'R'},
+        {'frame': 0, 'min': 'min', 'max': 'max', 'palette': 'G'},
+        {'frame': 1, 'min': 'min', 'max': 'max', 'palette': 'B'},
+    ]})
+    ts2 = large_image.open(imagePath, style={'bands': [
+        {'frame': 0, 'min': 'min', 'max': 'max', 'palette': 'G'},
+        {'frame': 1, 'min': 'min', 'max': 'max', 'palette': 'B'},
+        {'frame': 0, 'min': 'min', 'max': 'max', 'palette': 'R'},
+    ]})
+    ts3 = large_image.open(imagePath, style={'bands': [
+        {'frame': 1, 'min': 'min', 'max': 'max', 'palette': 'B'},
+        {'frame': 0, 'min': 'min', 'max': 'max', 'palette': 'R'},
+        {'frame': 0, 'min': 'min', 'max': 'max', 'palette': 'G'},
+    ]})
+    ts4 = large_image.open(imagePath, style={'bands': [
+        {'frame': 0, 'min': 'min', 'max': 'max', 'palette': 'R'},
+        {'frame': 1, 'min': 'min', 'max': 'max', 'palette': 'B'},
+        {'frame': 0, 'min': 'min', 'max': 'max', 'palette': 'G'},
+    ]})
+    ts5 = large_image.open(imagePath, style={'bands': [
+        {'frame': 0, 'min': 'min', 'max': 'max', 'palette': 'G'},
+        {'frame': 0, 'min': 'min', 'max': 'max', 'palette': 'R'},
+        {'frame': 1, 'min': 'min', 'max': 'max', 'palette': 'B'},
+    ]})
+    ts6 = large_image.open(imagePath, style={'bands': [
+        {'frame': 1, 'min': 'min', 'max': 'max', 'palette': 'B'},
+        {'frame': 0, 'min': 'min', 'max': 'max', 'palette': 'G'},
+        {'frame': 0, 'min': 'min', 'max': 'max', 'palette': 'R'},
+    ]})
+    tile1 = ts1.getTile(0, 0, 0)
+    assert ts2.getTile(0, 0, 0) == tile1
+    assert ts3.getTile(0, 0, 0) == tile1
+    assert ts4.getTile(0, 0, 0) == tile1
+    assert ts5.getTile(0, 0, 0) == tile1
+    assert ts6.getTile(0, 0, 0) == tile1


### PR DESCRIPTION
If the first band used a different frame than subsequent bands, and subsequent bands repeated a frame, the wrong frame could be used in a style.