### PR TITLE
Add [common] extra_requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.23.7
 
+### Improvements
+- Add [common] extra_requires ([#1288](../../pull/1288))
+
 ### Changes
 - Internal metadata get endpoint is now public ([#1285](../../pull/1285))
 

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,15 @@ extraReqs['all'] = list(set(itertools.chain.from_iterable(extraReqs.values())) |
     f'large-image-source-pil[all]{limit_version}',
     f'large-image-source-rasterio[all]{limit_version} ; python_version >= "3.8"',
 })
+# The common packages are ones that will install on Ubuntu, OSX, and Windows
+# from pypi with all needed dependencies.
+extraReqs['common'] = list(set(itertools.chain.from_iterable(extraReqs[key] for key in {
+    'memcached', 'colormaps', 'performance',
+    'deepzoom', 'dicom', 'multi', 'nd2', 'test', 'tifffile',
+})) | {
+    f'large-image-source-pil[all]{limit_version}',
+    f'large-image-source-rasterio[all]{limit_version} ; python_version >= "3.8"',
+})
 
 setup(
     name='large-image',


### PR DESCRIPTION
This makes it easier to install on other OSes.

In HistomicsTK, for example, we had been just using one source on non-linux OSes; this lets that more intelligently use available sources.