### PR TITLE
Add an option to not cache sources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.24.0
+
+### Features
+- Added a noCache option to opening tile sources ([#1296](../../pull/1296))
+
 ## 1.23.7
 
 ### Improvements

--- a/docs/config_options.rst
+++ b/docs/config_options.rst
@@ -23,6 +23,8 @@ Configuration parameters:
 
 - ``cache_tilesource_maximum``: If this is non-zero, this further limits the number of tilesources than can be cached to this value.
 
+- ``cache_sources``: If set to False, the default will be to not cache tile sources.  This has substantial performance penalties if sources are used multiple times, so should only be set in singular dynamic environments such as experimental notebooks.
+
 - ``max_small_image_size``: The PIL tilesource is used for small images if they are no more than this many pixels along their maximum dimension.
 
 - ``source_bioformats_ignored_names``, ``source_pil_ignored_names``, ``source_vips_ignored_names``: Some tile sources can read some files that are better read by other tilesources.  Since reading these files is suboptimal, these tile sources have a setting that, by default, ignores files without extensions or with particular extensions.  This setting is a Python regular expressions.  For bioformats this defaults to ``r'(^[!.]*|\.(jpg|jpeg|jpe|png|tif|tiff|ndpi))$'``.

--- a/girder/girder_large_image/girder_tilesource.py
+++ b/girder/girder_large_image/girder_tilesource.py
@@ -190,7 +190,7 @@ def getGirderTileSourceName(item, file=None, *args, **kwargs):  # noqa
             for k, v in properties.items())
         sourceList.append((propertiesClash, fallback, priority, sourceName))
     for _clash, _fallback, _priority, sourceName in sorted(sourceList):
-        if availableSources[sourceName].canRead(item):
+        if availableSources[sourceName].canRead(item, *args, **kwargs):
             return sourceName
 
 

--- a/girder/girder_large_image/models/image_item.py
+++ b/girder/girder_large_image/models/image_item.py
@@ -80,7 +80,7 @@ class ImageItem(Item):
         logger.debug(
             'createImageItem checking if item %s (%s) can be used directly',
             item['_id'], item['name'])
-        sourceName = girder_tilesource.getGirderTileSourceName(item, fileObj)
+        sourceName = girder_tilesource.getGirderTileSourceName(item, fileObj, noCache=True)
         if sourceName:
             logger.info(
                 'createImageItem using source %s for item %s (%s)',

--- a/large_image/config.py
+++ b/large_image/config.py
@@ -25,6 +25,12 @@ ConfigValues = {
     'cache_memcached_username': None,
     'cache_memcached_password': None,
 
+    # If set to False, the default will be to not cache tile sources.  This has
+    # substantial performance penalties if sources are used multiple times, so
+    # should only be set in singular dynamic environments such as experimental
+    # notebooks.
+    'cache_sources': True,
+
     # Generally, these keys are the form of "cache_<cacheName>_<key>"
 
     # For tilesources.  These are also limited by available file handles.

--- a/large_image/tilesource/__init__.py
+++ b/large_image/tilesource/__init__.py
@@ -178,6 +178,9 @@ def canRead(*args, **kwargs):
     """
     Check if large_image can read a path or uri.
 
+    If there is no intention to open the image immediately, conisder adding
+    `noCache=True` to the kwargs to avoid cycling the cache unnecessarily.
+
     :returns: True if any appropriate source reports it can read the path or
         uri.
     """
@@ -191,6 +194,9 @@ def canRead(*args, **kwargs):
 def canReadList(pathOrUri, mimeType=None, *args, **kwargs):
     """
     Check if large_image can read a path or uri via each source.
+
+    If there is no intention to open the image immediately, conisder adding
+    `noCache=True` to the kwargs to avoid cycling the cache unnecessarily.
 
     :param pathOrUri: either a file path or a fixed source via
         large_image://<source>.

--- a/sources/dicom/large_image_source_dicom/__init__.py
+++ b/sources/dicom/large_image_source_dicom/__init__.py
@@ -147,7 +147,7 @@ class DICOMFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         # If we have an _unstyledInstance attribute, this is not the owner of
         # the _docim handle, so we can't close it.  Otherwise, we need to close
         # it or the _dicom library may prevent shutting down.
-        if getattr(self, '_dicom', None) is not None and not hasattr(self, '_unstyledInstance'):
+        if getattr(self, '_dicom', None) is not None and not hasattr(self, '_derivedSource'):
             try:
                 self._dicom.close()
             finally:

--- a/sources/nd2/large_image_source_nd2/__init__.py
+++ b/sources/nd2/large_image_source_nd2/__init__.py
@@ -194,7 +194,7 @@ class ND2FileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         # If we have an _unstyledInstance attribute, this is not the owner of
         # the _nd2 handle, so we can't close it.  Otherwise, we need to close
         # it or the nd2 library complains that we didn't explicitly close it.
-        if hasattr(self, '_nd2') and not hasattr(self, '_unstyledInstance'):
+        if hasattr(self, '_nd2') and not hasattr(self, '_derivedSource'):
             self._nd2.close()
             del self._nd2
 


### PR DESCRIPTION
When opening a tile source, pass `noCache=True`.  In this mode, the tile source can directly have its style modified (e.g., `source.style = <new value>`).  This is also used when importing images into girder to avoid flushing the cache of tile sources that are in active use.

This closes #1294.

This closes #1145.

There is a config value `cache_sources`, that, if False, makes `noCache` functionally default to False.

This closes #1206.