### PR TITLE
Change the cdn used with the SlideAtlas viewer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 - Added a noCache option to opening tile sources ([#1296](../../pull/1296))
 
+### Changes
+- Changed the cdn used for the SlideAtlas viewer ([#1297](../../pull/1297))
+
 ## 1.23.7
 
 ### Improvements

--- a/girder/girder_large_image/web_client/views/imageViewerWidget/slideatlas.js
+++ b/girder/girder_large_image/web_client/views/imageViewerWidget/slideatlas.js
@@ -5,7 +5,8 @@ import {parseQueryString, splitRoute} from '@girder/core/misc';
 
 import ImageViewerWidget from './base';
 
-var baseSAUrl = 'https://unpkg.com/slideatlas-viewer@4.4.1/dist/';
+// var baseSAUrl = 'https://unpkg.com/slideatlas-viewer@4.4.1/dist/';
+var baseSAUrl = 'https://cdn.jsdelivr.net/npm/slideatlas-viewer@4/dist/';
 
 var SlideAtlasImageViewerWidget = ImageViewerWidget.extend({
     initialize: function (settings) {


### PR DESCRIPTION
This was one of the primary causes of transient client test failures. We should check if anyone actually uses this, and, if not, remove it from the default viewer list.