### PR TITLE
Preset defaults

### DIFF
--- a/docs/girder_config_options.rst
+++ b/docs/girder_config_options.rst
@@ -198,7 +198,7 @@ By default, item metadata can contain any keys and values.  These can be given b
 Image Frame Presets
 ....................
 
-This is used to specify a list of default presets for viewing images in the folder.
+This is used to specify a list of presets for viewing images in the folder.
 Presets can be customized and saved in the GeoJS Image Viewer.
 To retrieve saved presets, use http://[serverURL]/api/v1/item/[itemID]/internal_metadata/presets.
 You can convert the response to YAML and paste it into the ``imageFramePresets`` key in your config file.
@@ -338,6 +338,40 @@ The YAML below includes some example presets.
         - autoRange: 0.2
           framedelta: 6
           palette: "#FF8000"
+
+
+Image Frame Preset Defaults
+...........................
+This is used to specify a list of preset defaults, in order of precedence.
+These presets are to be automatically applied to an image in this folder if they are applicable.
+In the case that a preset is not applicable to an image, the next item in this list will be used.
+
+** Important: the presets named in this list must have corresponding entries in the `imageFramePresets` configuration, else this configuration will have no effect. **
+
+::
+
+    ---
+    # The preset named "Primary Preset" will be applied to all images in this folder.
+    # Any images for which "Primary Preset" does not apply will have "Secondary Preset" applied.
+    # Any images for which neither "Primary Preset" nor "Secondary Preset" apply will have "Tertiary Preset" applied.
+    imageFramePresetDefaults:
+    - name: Primary Preset
+    - name: Secondary Preset
+    - name: Tertiary Preset
+
+::
+
+    ---
+    # This example would be used with the example for `imageFramePresets` shown above.
+    # Images with 7 or more channels would use "Auto Ranged Channels"
+    # Images with fewer than 7 but at least 4 channels would use "Channels with Min and Max"
+    # Images with 3 channels would use "3 channels"
+    # Images with fewer than 3 channels would not have a default preset applied.
+    imageFramePresetDefaults:
+    - name: Auto Ranged Channels
+    - name: Channels with Min and Max
+    - name: 3 channels
+
 
 
 Editing Configuration Files

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -104,6 +104,18 @@ export default {
                 }
                 if (this.liConfig.imageFramePresets) {
                     this.folderPresets = this.liConfig.imageFramePresets.filter(this.presetApplicable);
+                    if(this.liConfig.imageFramePresetDefaults) {
+                        this.liConfig.imageFramePresetDefaults.every(({ name }) => {
+                            const presetMatch = this.folderPresets.find((p) => p.name === name)
+                            if (presetMatch) {
+                                // found applicable preset in defaults list
+                                // set as selected then return
+                                this.selectedPreset = name;
+                                return false;
+                            }
+                            return true;
+                        })
+                    }
                 }
                 return undefined;
             });

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -73,13 +73,23 @@ export default {
                 !this.availableModes.includes(preset.mode.id)
             ) {
                 return false;
-            } else if (
-                preset.style && preset.style.bands &&
-                this.imageMetadata.IndexRange &&
-                this.imageMetadata.IndexRange.IndexC &&
-                preset.style.bands.some((b) => b.framedelta > this.imageMetadata.IndexRange.IndexC)
-            ) {
-                return false;
+            } else if (preset.style && preset.style.bands){
+                if (preset.mode.id === 2) {
+                    // Channel compositing, compare to num channels
+                    if (this.imageMetadata.IndexRange &&
+                        this.imageMetadata.IndexRange.IndexC &&
+                        preset.style.bands.some((b) => b.framedelta >= this.imageMetadata.IndexRange.IndexC)
+                    ) {
+                        return false;
+                    }
+                } else if (preset.mode.id === 3) {
+                    // Band compositing, compare to num bands
+                    if (this.imageMetadata.bandCount &&
+                        preset.style.bands.some((b) => b.band >= this.imageMetadata.bandCount)
+                    ) {
+                        return false;
+                    }
+                }
             }
 
             return true;

--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -73,7 +73,7 @@ export default {
                 !this.availableModes.includes(preset.mode.id)
             ) {
                 return false;
-            } else if (preset.style && preset.style.bands){
+            } else if (preset.style && preset.style.bands) {
                 if (preset.mode.id === 2) {
                     // Channel compositing, compare to num channels
                     if (this.imageMetadata.IndexRange &&
@@ -104,9 +104,9 @@ export default {
                 }
                 if (this.liConfig.imageFramePresets) {
                     this.folderPresets = this.liConfig.imageFramePresets.filter(this.presetApplicable);
-                    if(this.liConfig.imageFramePresetDefaults) {
-                        this.liConfig.imageFramePresetDefaults.every(({ name }) => {
-                            const presetMatch = this.folderPresets.find((p) => p.name === name)
+                    if (this.liConfig.imageFramePresetDefaults) {
+                        this.liConfig.imageFramePresetDefaults.every(({name}) => {
+                            const presetMatch = this.folderPresets.find((p) => p.name === name);
                             if (presetMatch) {
                                 // found applicable preset in defaults list
                                 // set as selected then return
@@ -114,7 +114,7 @@ export default {
                                 return false;
                             }
                             return true;
-                        })
+                        });
                     }
                 }
                 return undefined;


### PR DESCRIPTION
Resolves #1239 by completing the last requirement for the feature, a way to specify default presets.

A user may specify a list of preset names in order of precedence. The first applicable preset in the defaults list will be applied automatically.