### PR TITLE
Update the test python versions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
     steps:
       - checkout
       - allservices:
-          version: 3.6.15
+          version: "3.6"
           node: v14
       - tox:
           env: test-py36
@@ -138,7 +138,7 @@ jobs:
     steps:
       - checkout
       - allservices:
-          version: 3.7.17
+          version: "3.7"
           node: v14
       - tox:
           env: test-py37
@@ -151,7 +151,7 @@ jobs:
     steps:
       - checkout
       - allservices:
-          version: 3.8.17
+          version: "3.8"
           node: v14
       - tox:
           env: test-py38
@@ -164,7 +164,7 @@ jobs:
     steps:
       - checkout
       - allservices:
-          version: 3.9.17
+          version: "3.9"
           node: v14
       - tox:
           env: test-py39
@@ -177,7 +177,7 @@ jobs:
     steps:
       - checkout
       - allservices:
-          version: 3.10.12
+          version: "3.10"
           node: v14
       - tox:
           env: test-py310
@@ -190,7 +190,7 @@ jobs:
     steps:
       - checkout
       - allservices:
-          version: 3.11.4
+          version: "3.11"
           node: v14
       - tox:
           env: test-py311

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Bug Fixes
 - Band compositing wasn't working ([#1300](../../pull/1300))
-  
+
 ## 1.23.7
 
 ### Improvements

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -14,7 +14,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYENV_ROOT="/.pyenv" \
     PATH="/.pyenv/bin:/.pyenv/shims:$PATH" \
     OLD_PYTHON_VERSIONS="3.6.15" \
-    PYTHON_VERSIONS="3.9.17 3.8.17 3.7.17 3.10.12 3.11.4"
+    PYTHON_VERSIONS="3.9 3.8 3.7 3.10 3.11"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
pyenv doesn't need the patch version anymore; it will just use the latest.