### PR TITLE
Add initial DICOMweb support

### DIFF
--- a/sources/dicom/large_image_source_dicom/assetstore/__init__.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/__init__.py
@@ -1,0 +1,85 @@
+from girder import events
+from girder.api import access
+from girder.api.v1.assetstore import Assetstore as AssetstoreResource
+from girder.constants import AssetstoreType
+from girder.models.assetstore import Assetstore
+from girder.utility.assetstore_utilities import setAssetstoreAdapter
+
+from .dicomweb_assetstore_adapter import DICOMWEB_META_KEY, DICOMwebAssetstoreAdapter
+from .rest import DICOMwebAssetstoreResource
+
+__all__ = [
+    'DICOMWEB_META_KEY',
+    'DICOMwebAssetstoreAdapter',
+    'load',
+]
+
+
+@access.admin
+def createAssetstore(event):
+    """
+    When an assetstore is created, make sure it has a well-formed DICOMweb
+    information record.
+
+    :param event: Girder rest.post.assetstore.before event.
+    """
+    params = event.info['params']
+
+    if params.get('type') == AssetstoreType.DICOMWEB:
+        event.addResponse(Assetstore().save({
+            'type': AssetstoreType.DICOMWEB,
+            'name': params.get('name'),
+            DICOMWEB_META_KEY: {
+                'url': params['url'],
+                'qido_prefix': params.get('qido_prefix'),
+                'wado_prefix': params.get('wado_prefix'),
+                'auth_type': params.get('auth_type'),
+            },
+        }))
+        event.preventDefault()
+
+
+def updateAssetstore(event):
+    """
+    When an assetstore is updated, make sure the result has a well-formed set
+    of DICOMweb information.
+
+    :param event: Girder assetstore.update event.
+    """
+    params = event.info['params']
+    store = event.info['assetstore']
+
+    if store['type'] == AssetstoreType.DICOMWEB:
+        store[DICOMWEB_META_KEY] = {
+            'url': params['url'],
+            'qido_prefix': params.get('qido_prefix'),
+            'wado_prefix': params.get('wado_prefix'),
+            'auth_type': params.get('auth_type'),
+        }
+
+
+def load(info):
+    """
+    Load the plugin into Girder.
+
+    :param info: a dictionary of plugin information.  The name key contains the
+                 name of the plugin according to Girder.
+    """
+    AssetstoreType.DICOMWEB = 'dicomweb'
+    setAssetstoreAdapter(AssetstoreType.DICOMWEB, DICOMwebAssetstoreAdapter)
+    events.bind('assetstore.update', 'dicomweb_assetstore', updateAssetstore)
+    events.bind('rest.post.assetstore.before', 'dicomweb_assetstore',
+                createAssetstore)
+
+    (AssetstoreResource.createAssetstore.description
+        .param('url', 'The base URL for the DICOMweb server (for DICOMweb)',
+               required=False)
+        .param('qido_prefix', 'The QIDO URL prefix for the server, if needed (for DICOMweb)',
+               required=False)
+        .param('wado_prefix', 'The WADO URL prefix for the server, if needed (for DICOMweb)',
+               required=False)
+        .param('auth_type',
+               'The authentication type required for the server, if needed (for DICOMweb)',
+               required=False))
+
+    info['apiRoot'].dicomweb_assetstore = DICOMwebAssetstoreResource()

--- a/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
@@ -1,0 +1,221 @@
+from requests.exceptions import HTTPError
+
+from girder.exceptions import ValidationException
+from girder.models.file import File
+from girder.models.folder import Folder
+from girder.models.item import Item
+from girder.utility.abstract_assetstore_adapter import AbstractAssetstoreAdapter
+
+from ..dicom_tags import dicom_key_to_tag
+
+DICOMWEB_META_KEY = 'dicomweb_meta'
+
+
+class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
+    """
+    This defines the interface to be used by all assetstore adapters.
+    """
+
+    def __init__(self, assetstore):
+        super().__init__(assetstore)
+
+    @staticmethod
+    def validateInfo(doc):
+        # Ensure that the assetstore is marked read-only
+        doc['readOnly'] = True
+
+        required_fields = [
+            'url',
+        ]
+
+        info = doc.get(DICOMWEB_META_KEY, {})
+
+        for field in required_fields:
+            if field not in info:
+                raise ValidationException('Missing field: ' + field)
+
+        # If these are empty, they need to be converted to None
+        convert_empty_fields_to_none = [
+            'qido_prefix',
+            'wado_prefix',
+            'auth_type',
+        ]
+
+        for field in convert_empty_fields_to_none:
+            if isinstance(info.get(field), str) and not info[field].strip():
+                info[field] = None
+
+        # Now, if there is no authentication, verify that we can connect to the server.
+        # If there is authentication, we may need to prompt the user for their
+        # username and password sometime before here.
+        if info['auth_type'] is None:
+            study_instance_uid_tag = dicom_key_to_tag('StudyInstanceUID')
+            series_instance_uid_tag = dicom_key_to_tag('SeriesInstanceUID')
+
+            client = _create_dicomweb_client(info)
+            # Try to search for series. If we get an http error, raise
+            # a validation exception.
+            try:
+                series = client.search_for_series(
+                    limit=1,
+                    fields=(study_instance_uid_tag, series_instance_uid_tag),
+                )
+            except HTTPError as e:
+                raise ValidationException('Failed to validate DICOMweb server settings: ' + str(e))
+
+            # If we found a series, then test the wado prefix as well
+            if series:
+                # The previous query should have obtained uids for a specific
+                # study and series.
+                study_uid = series[0][study_instance_uid_tag]['Value'][0]
+                series_uid = series[0][series_instance_uid_tag]['Value'][0]
+                try:
+                    # Retrieve the metadata of this series as a wado prefix test
+                    client.retrieve_series_metadata(
+                        study_instance_uid=study_uid,
+                        series_instance_uid=series_uid,
+                    )
+                except HTTPError as e:
+                    raise ValidationException('Failed to validate DICOMweb WADO prefix: ' + str(e))
+
+        return doc
+
+    def initUpload(self, upload):
+        msg = 'DICOMweb assetstores are import only.'
+        raise NotImplementedError(msg)
+
+    def finalizeUpload(self, upload, file):
+        msg = 'DICOMweb assetstores are import only.'
+        raise NotImplementedError(msg)
+
+    def deleteFile(self, file):
+        # We don't actually need to do anything special
+        pass
+
+    def downloadFile(self, file, offset=0, headers=True, endByte=None,
+                     contentDisposition=None, extraParameters=None, **kwargs):
+        # FIXME: do we want to support downloading files? We probably
+        # wouldn't download them the regular way, but we could instead
+        # use a dicomweb-client like so:
+        # instance = client.retrieve_instance(
+        #     study_instance_uid=...,
+        #     series_instance_uid=...,
+        #     sop_instance_uid=...,
+        # )
+        # pydicom.filewriter.write_file('output_name.dcm', instance)
+        msg = 'Download support not yet implemented for DICOMweb files.'
+        raise NotImplementedError(
+            msg,
+        )
+
+    def importData(self, parent, parentType, params, progress, user, **kwargs):
+        """
+        Import DICOMweb WSI instances from a DICOMweb server.
+
+        :param parent: The parent object to import into.
+        :param parentType: The model type of the parent object.
+        :type parentType: str
+        :param params: Additional parameters required for the import process.
+            This dictionary may include the following keys:
+
+            :auth: (optional) if the DICOMweb server requires authentication,
+                this should be an authentication handler derived from
+                requests.auth.AuthBase.
+            :search_filters: (optional) a dictionary of additional search
+                filters to use with dicomweb_client's `search_for_series()`
+                function.
+
+        :type params: dict
+        :param progress: Object on which to record progress if possible.
+        :type progress: :py:class:`girder.utility.progress.ProgressContext`
+        :param user: The Girder user performing the import.
+        :type user: dict or None
+        :return: a list of items that were created
+        """
+        if parentType not in ('folder', 'user', 'collection'):
+            msg = f'Invalid parent type: {parentType}'
+            raise RuntimeError(msg)
+
+        from wsidicom.uid import WSI_SOP_CLASS_UID
+
+        search_filters = params.get('search_filters', {})
+
+        meta = self.assetstore[DICOMWEB_META_KEY]
+
+        client = _create_dicomweb_client(meta, auth=params.get('auth'))
+
+        study_uid_key = dicom_key_to_tag('StudyInstanceUID')
+        series_uid_key = dicom_key_to_tag('SeriesInstanceUID')
+
+        # We are only searching for WSI datasets. Ignore all others.
+        # FIXME: is this actually working?
+        search_filters = {
+            'SOPClassUID': WSI_SOP_CLASS_UID,
+            **search_filters,
+        }
+        fields = [
+            study_uid_key,
+            series_uid_key,
+        ]
+        if progress:
+            progress.update(message='Searching for series...')
+
+        # FIXME: might need to search in chunks for larger web servers
+        series_results = client.search_for_series(
+            fields=fields, search_filters=search_filters)
+
+        items = []
+        for i, result in enumerate(series_results):
+            if progress:
+                progress.update(total=len(series_results), current=i,
+                                message='Importing series...')
+
+            study_uid = result[study_uid_key]['Value'][0]
+            series_uid = result[series_uid_key]['Value'][0]
+
+            # Create a folder for the study, and an item for the series
+            folder = Folder().createFolder(parent, parentType=parentType,
+                                           name=study_uid, creator=user,
+                                           reuseExisting=True)
+            item = Item().createItem(name=series_uid, creator=user, folder=folder,
+                                     reuseExisting=True)
+
+            # Create a placeholder file with the same name
+            file = File().createFile(
+                name=f'{series_uid}.dcm',
+                creator=user,
+                item=item,
+                reuseExisting=True,
+                assetstore=self.assetstore,
+                mimeType=None,
+                size=0,
+                saveFile=False,
+            )
+            file['dicomweb_meta'] = {
+                'study_uid': study_uid,
+                'series_uid': series_uid,
+            }
+            file['imported'] = True
+            File().save(file)
+
+            # FIXME: should we return a list of items (like this), or should
+            # we return files?
+            items.append(item)
+
+        return items
+
+
+def _create_dicomweb_client(meta, auth=None):
+    from dicomweb_client.api import DICOMwebClient
+    from dicomweb_client.session_utils import create_session_from_auth
+
+    # Create the authentication session
+    session = create_session_from_auth(auth)
+
+    # Make the DICOMwebClient
+    return DICOMwebClient(
+        url=meta['url'],
+        qido_url_prefix=meta.get('qido_prefix'),
+        wado_url_prefix=meta.get('wado_prefix'),
+        session=session,
+    )

--- a/sources/dicom/large_image_source_dicom/assetstore/rest.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/rest.py
@@ -1,0 +1,72 @@
+from girder.api import access
+from girder.api.describe import Description, describeRoute
+from girder.api.rest import Resource, loadmodel
+from girder.exceptions import RestException
+from girder.utility import assetstore_utilities
+from girder.utility.model_importer import ModelImporter
+from girder.utility.progress import ProgressContext
+
+
+class DICOMwebAssetstoreResource(Resource):
+    def __init__(self):
+        super().__init__()
+        self.resourceName = 'dicomweb_assetstore'
+        self.route('PUT', (':id', 'import'), self.importData)
+
+    def _importData(self, assetstore, params):
+        """
+
+        :param assetstore: the destination assetstore.
+        :param params: a dictionary of parameters including parentId,
+            parentType, progress, and filters.
+        """
+        self.requireParams(('parentId'), params)
+
+        user = self.getCurrentUser()
+
+        parentType = params.get('parentType', 'folder')
+        if parentType not in ('folder', 'user', 'collection'):
+            msg = f'Invalid parentType: {parentType}'
+            raise RestException(msg)
+
+        parent = ModelImporter.model(parentType).load(params['parentId'], force=True,
+                                                      exc=True)
+
+        progress = self.boolParam('progress', params, default=False)
+
+        adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
+
+        with ProgressContext(
+            progress, user=user, title='Importing DICOM references',
+        ) as ctx:
+            adapter.importData(
+                parent,
+                parentType,
+                {
+                    'search_filters': params.get('filters', {}),
+                    'auth': None,
+                },
+                ctx,
+                user,
+            )
+
+    @access.admin
+    @loadmodel(model='assetstore')
+    @describeRoute(
+        Description('Import references to DICOM objects from a DICOMweb server')
+        .param('id', 'The ID of the assetstore representing the DICOMweb server.',
+               paramType='path')
+        .param('parentId', 'The ID of the parent folder, collection, or user '
+               'in the Girder data hierarchy under which to import the files.')
+        .param('parentType', 'The type of the parent object to import into.',
+               enum=('folder', 'user', 'collection'),
+               required=False)
+        .param('filters', 'Any search parameters to filter DICOM objects.',
+               required=False)
+        .param('progress', 'Whether to record progress on this operation ('
+               'default=False)', required=False, dataType='boolean')
+        .errorResponse()
+        .errorResponse('You are not an administrator.', 403),
+    )
+    def importData(self, assetstore, params):
+        return self._importData(assetstore, params)

--- a/sources/dicom/large_image_source_dicom/dicom_tags.py
+++ b/sources/dicom/large_image_source_dicom/dicom_tags.py
@@ -1,0 +1,11 @@
+# Cache these so we only look them up once per run
+DICOM_TAGS = {}
+
+
+def dicom_key_to_tag(key):
+    if key not in DICOM_TAGS:
+        import pydicom
+        from pydicom.tag import Tag
+        DICOM_TAGS[key] = Tag(pydicom.datadict.tag_for_keyword(key)).json_key
+
+    return DICOM_TAGS[key]

--- a/sources/dicom/large_image_source_dicom/girder_plugin.py
+++ b/sources/dicom/large_image_source_dicom/girder_plugin.py
@@ -1,0 +1,11 @@
+from girder.plugin import GirderPlugin
+
+from . import assetstore
+
+
+class DICOMwebPlugin(GirderPlugin):
+    DISPLAY_NAME = 'DICOMweb Plugin'
+    CLIENT_SOURCE_PATH = 'web_client'
+
+    def load(self, info):
+        assetstore.load(info)

--- a/sources/dicom/large_image_source_dicom/girder_source.py
+++ b/sources/dicom/large_image_source_dicom/girder_source.py
@@ -1,10 +1,12 @@
 from girder_large_image.girder_tilesource import GirderTileSource
 
+from girder.constants import AssetstoreType
 from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item
 
 from . import DICOMFileTileSource
+from .assetstore import DICOMWEB_META_KEY
 
 
 class DICOMGirderTileSource(DICOMFileTileSource, GirderTileSource):
@@ -18,7 +20,28 @@ class DICOMGirderTileSource(DICOMFileTileSource, GirderTileSource):
 
     _mayHaveAdjacentFiles = True
 
+    def _getAssetstore(self):
+        files = Item().childFiles(self.item, limit=1)
+        if not files:
+            return None
+
+        assetstore_id = files[0].get('assetstoreId')
+        if not assetstore_id:
+            return None
+
+        return File()._getAssetstoreModel(files[0]).load(assetstore_id)
+
     def _getLargeImagePath(self):
+        # Look at a single file and see what type of assetstore it came from
+        # If it came from a DICOMweb assetstore, then we will use that method.
+        assetstore = self._getAssetstore()
+        assetstore_type = assetstore['type'] if assetstore else None
+        if assetstore_type == getattr(AssetstoreType, 'DICOMWEB', '__undefined__'):
+            return self._getDICOMwebLargeImagePath(assetstore)
+        else:
+            return self._getFilesystemLargeImagePath()
+
+    def _getFilesystemLargeImagePath(self):
         filelist = [
             File().getLocalFilePath(file) for file in Item().childFiles(self.item)
             if self._pathMightBeDicom(file['name'])]
@@ -32,3 +55,18 @@ class DICOMGirderTileSource(DICOMFileTileSource, GirderTileSource):
                 if self._pathMightBeDicom(file['name']):
                     filelist.append(File().getLocalFilePath(file))
         return filelist
+
+    def _getDICOMwebLargeImagePath(self, assetstore):
+        meta = assetstore[DICOMWEB_META_KEY]
+        file = Item().childFiles(self.item, limit=1)[0]
+        file_meta = file['dicomweb_meta']
+
+        return {
+            'url': meta['url'],
+            'study_uid': file_meta['study_uid'],
+            'series_uid': file_meta['series_uid'],
+            # The following are optional
+            'qido_prefix': meta.get('qido_prefix'),
+            'wado_prefix': meta.get('wado_prefix'),
+            'auth': meta.get('auth'),
+        }

--- a/sources/dicom/large_image_source_dicom/web_client/constants.js
+++ b/sources/dicom/large_image_source_dicom/web_client/constants.js
@@ -1,0 +1,3 @@
+import { AssetstoreType } from '@girder/core/constants';
+
+AssetstoreType.DICOMWEB = 'dicomweb';

--- a/sources/dicom/large_image_source_dicom/web_client/main.js
+++ b/sources/dicom/large_image_source_dicom/web_client/main.js
@@ -1,0 +1,7 @@
+import './routes';
+
+// Extends and overrides API
+import './constants';
+import './views/AssetstoresView';
+import './views/EditAssetstoreWidget';
+import './views/NewAssetstoreWidget';

--- a/sources/dicom/large_image_source_dicom/web_client/models/AssetstoreModel.js
+++ b/sources/dicom/large_image_source_dicom/web_client/models/AssetstoreModel.js
@@ -1,0 +1,20 @@
+import AssetstoreModel from '@girder/core/models/AssetstoreModel';
+import { restRequest } from '@girder/core/rest';
+
+/**
+ * Extends the core assetstore model to add DICOMweb-specific functionality.
+ */
+AssetstoreModel.prototype.dicomwebImport = function (params) {
+    return restRequest({
+        url: 'dicomweb_assetstore/' + this.get('_id') + '/import',
+        type: 'PUT',
+        data: params,
+        error: null
+    }).done(() => {
+        this.trigger('g:imported');
+    }).fail((err) => {
+        this.trigger('g:error', err);
+    });
+};
+
+export default AssetstoreModel;

--- a/sources/dicom/large_image_source_dicom/web_client/package.json
+++ b/sources/dicom/large_image_source_dicom/web_client/package.json
@@ -1,0 +1,165 @@
+{
+    "name": "@girder/dicomweb",
+    "version": "1.0.0",
+    "peerDependencies": {
+        "@girder/core": "*",
+        "@girder/jobs": "*"
+    },
+    "girderPlugin": {
+        "name": "dicomweb",
+        "main": "./main.js",
+        "dependencies": [
+            "jobs"
+        ]
+    },
+    "devDependencies": {
+        "@girder/eslint-config": "3.0.0-rc1",
+        "@girder/pug-lint-config": "^3.0.0-rc1",
+        "eslint": "^8.20.0",
+        "eslint-config-semistandard": "^17.0.0",
+        "eslint-config-standard": "^17.0.0",
+        "eslint-plugin-backbone": "^2.1.1",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-n": "^15.3.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "eslint-plugin-underscore": "^0.0.10",
+        "nyc": "^15.1.0",
+        "phantomjs-prebuilt": "^2.1.16",
+        "pug-lint": "^2.6.0",
+        "stylint": "^2.0.0"
+    },
+    "scripts": {
+        "lint": "eslint --cache . && pug-lint . && stylint",
+        "format": "eslint --cache --fix . && stylint --fix"
+    },
+    "eslintConfig": {
+        "extends": "@girder",
+        "root": true
+    },
+    "eslintIgnore": [
+        "build/",
+        "**/node_modules/"
+    ],
+    "pugLintConfig": {
+        "extends": "@girder/pug-lint-config",
+        "excludeFiles": [
+            "**/node_modules/",
+            "**/.tox/"
+        ]
+    },
+    "stylintrc": {
+        "blocks": false,
+        "brackets": {
+            "expect": "never",
+            "error": true
+        },
+        "colons": {
+            "expect": "never",
+            "error": true
+        },
+        "colors": false,
+        "commaSpace": {
+            "expect": "always",
+            "error": true
+        },
+        "commentSpace": {
+            "expect": "always",
+            "error": true
+        },
+        "cssLiteral": {
+            "expect": "never",
+            "error": true
+        },
+        "depthLimit": false,
+        "duplicates": {
+            "expect": true,
+            "error": true
+        },
+        "efficient": {
+            "expect": "always",
+            "error": true
+        },
+        "exclude": [
+            "**/node_modules/**",
+            "**/.tox/**"
+        ],
+        "extendPref": "@extend",
+        "globalDupe": false,
+        "groupOutputByFile": {
+            "expect": true,
+            "error": true
+        },
+        "indentPref": {
+            "expect": 2,
+            "error": true
+        },
+        "leadingZero": {
+            "expect": "always",
+            "error": true
+        },
+        "maxErrors": false,
+        "maxWarnings": false,
+        "mixed": false,
+        "mixins": [],
+        "namingConvention": false,
+        "namingConventionStrict": false,
+        "none": {
+            "expect": "always",
+            "error": true
+        },
+        "noImportant": false,
+        "parenSpace": {
+            "expect": "never",
+            "error": true
+        },
+        "placeholders": false,
+        "prefixVarsWithDollar": {
+            "expect": "always",
+            "error": true
+        },
+        "quotePref": {
+            "expect": "double",
+            "error": true
+        },
+        "reporterOptions": {
+            "columns": [
+                "lineData",
+                "severity",
+                "description",
+                "rule"
+            ],
+            "columnSplitter": "  ",
+            "showHeaders": false,
+            "truncate": true
+        },
+        "semicolons": {
+            "expect": "never",
+            "error": true
+        },
+        "sortOrder": false,
+        "stackedProperties": {
+            "expect": "never",
+            "error": true
+        },
+        "trailingWhitespace": {
+            "expect": "never",
+            "error": true
+        },
+        "universal": {
+            "expect": "never",
+            "error": true
+        },
+        "valid": {
+            "expect": true,
+            "error": true
+        },
+        "zeroUnits": {
+            "expect": "never",
+            "error": true
+        },
+        "zIndexNormalize": {
+            "expect": 5,
+            "error": true
+        }
+    }
+}

--- a/sources/dicom/large_image_source_dicom/web_client/routes.js
+++ b/sources/dicom/large_image_source_dicom/web_client/routes.js
@@ -1,0 +1,17 @@
+import router from '@girder/core/router';
+import events from '@girder/core/events';
+
+import AssetstoreModel from './models/AssetstoreModel';
+import AssetstoreImportView from './views/AssetstoreImportView';
+
+router.route('dicomweb_assetstore/:id/import', 'dwasImport', function (id) {
+    // Fetch the assetstore by id, then render the view.
+    const assetstore = new AssetstoreModel({ _id: id });
+    assetstore.once('g:fetched', function () {
+        events.trigger('g:navigateTo', AssetstoreImportView, {
+            model: assetstore
+        });
+    }).once('g:error', function () {
+        router.navigate('assetstores', { trigger: true });
+    }).fetch();
+});

--- a/sources/dicom/large_image_source_dicom/web_client/templates/assetstoreImport.pug
+++ b/sources/dicom/large_image_source_dicom/web_client/templates/assetstoreImport.pug
@@ -1,0 +1,27 @@
+.g-body-title Import references to DICOM objects on a DICOMweb Server
+
+.g-import-instructions.
+  Use this page to import references to DICOM objects on a DICOMweb server
+  into the girder assetstore system. An existing folder must be used as the
+  destination for the DICOM references.
+
+form.g-dwas-import-form
+  .form-group
+    label(for="g-dwas-import-dest-type") Destination type
+    select#g-dwas-import-dest-type.form-control
+      option(value="folder", selected=true) Folder
+      option(value="user") User
+      option(value="collection") Collection
+  .form-group
+    label(for="g-dwas-import-dest-id") Destination ID
+    .input-group.input-group-sm
+      input#g-dwas-import-dest-id.form-control.input-sm(
+          type="text",
+          placeholder="Existing folder, user, or collection ID to use as the destination")
+      .input-group-btn
+        button.g-open-browser.btn.btn-default(type="button")
+          i.icon-folder-open
+  .g-validation-failed-message
+  button.g-submit-assetstore-import.btn.btn-success(type="submit")
+    i.icon-link-ext
+    |  Begin import

--- a/sources/dicom/large_image_source_dicom/web_client/templates/dicomwebAssetstoreCreate.pug
+++ b/sources/dicom/large_image_source_dicom/web_client/templates/dicomwebAssetstoreCreate.pug
@@ -1,0 +1,26 @@
+include dicomwebAssetstoreMixins
+
+.panel.panel-default
+  .panel-heading(
+      data-toggle="collapse",
+      data-parent="#g-assetstore-accordion",
+      data-target="#g-create-dwas-tab")
+    .panel-title
+      a
+        i.icon-server
+        span Create new #[b DICOMweb] assetstore
+  #g-create-dwas-tab.panel-collapse.collapse
+    .panel-body
+      p.
+        The DICOMweb assetstore can be used to search for and view WSI DICOM
+        files on a DICOMweb server. Each DICOMweb assetstore should point to a
+        particular DICOMweb server.
+      form#g-new-dwas-form(role="form")
+        label.control-label(for="g-new-dwas-name") Assetstore name
+        input#g-new-dwas-name.input-sm.form-control(
+            type="text",
+            placeholder="Name")
+        +g-dwas-parameters
+        p#g-new-dwas-error.g-validation-failed-message
+        input.g-new-assetstore-submit.btn.btn-sm.btn-primary(
+          type="submit", value="Create")

--- a/sources/dicom/large_image_source_dicom/web_client/templates/dicomwebAssetstoreEditFields.pug
+++ b/sources/dicom/large_image_source_dicom/web_client/templates/dicomwebAssetstoreEditFields.pug
@@ -1,0 +1,3 @@
+include dicomwebAssetstoreMixins
+
++g-dwas-parameters

--- a/sources/dicom/large_image_source_dicom/web_client/templates/dicomwebAssetstoreImportButton.pug
+++ b/sources/dicom/large_image_source_dicom/web_client/templates/dicomwebAssetstoreImportButton.pug
@@ -1,0 +1,5 @@
+a.g-dwas-import-button.btn.btn-sm.btn-success(
+    href=`#dicomweb_assetstore/${assetstore.get('_id')}/import`,
+    title="Import references to DICOM objects from a DICOMweb server")
+  i.icon-link-ext
+  |  Import

--- a/sources/dicom/large_image_source_dicom/web_client/templates/dicomwebAssetstoreMixins.pug
+++ b/sources/dicom/large_image_source_dicom/web_client/templates/dicomwebAssetstoreMixins.pug
@@ -1,0 +1,19 @@
+mixin g-dwas-parameters
+  .form-group
+    label.control-label(for="g-edit-dwas-url") DICOMweb server URL
+    input#g-edit-dwas-url.input-sm.form-control(
+        type="text",
+        placeholder="URL")
+    label.control-label(for="g-edit-dwas-qido-prefix") DICOMweb QIDO prefix (optional)
+    input#g-edit-dwas-qido-prefix.input-sm.form-control(
+        type="text",
+        placeholder="QIDO prefix")
+    label.control-label(for="g-edit-dwas-wado-prefix") DICOMweb WADO prefix (optional)
+    input#g-edit-dwas-wado-prefix.input-sm.form-control(
+        type="text",
+        placeholder="WADO prefix")
+  //- COMMENTED OUT UNTIL WE ADD AUTHENTICATION
+    label.control-label(for="g-edit-dwas-auth-type") DICOMweb authentation type (optional)
+    input#g-edit-dwas-auth-type.input-sm.form-control(
+        type="text",
+        placeholder="Authentication type")

--- a/sources/dicom/large_image_source_dicom/web_client/views/AssetstoreImportView.js
+++ b/sources/dicom/large_image_source_dicom/web_client/views/AssetstoreImportView.js
@@ -1,0 +1,85 @@
+import $ from 'jquery';
+
+import BrowserWidget from '@girder/core/views/widgets/BrowserWidget';
+import router from '@girder/core/router';
+import View from '@girder/core/views/View';
+import { restRequest } from '@girder/core/rest';
+
+import AssetstoreImportTemplate from '../templates/assetstoreImport.pug';
+
+const AssetstoreImportView = View.extend({
+    events: {
+        'submit .g-dwas-import-form': function (e) {
+            e.preventDefault();
+            this.$('.g-validation-failed-message').empty();
+            this.$('.g-submit-dwas-import').addClass('disabled');
+
+            const parentType = this.$('#g-dwas-import-dest-type').val();
+            const parentId = this.$('#g-dwas-import-dest-id').val().trim().split(/\s/)[0];
+
+            this.model.off().on('g:imported', function () {
+                router.navigate(parentType + '/' + parentId, { trigger: true });
+            }, this).on('g:error', function (err) {
+                this.$('.g-submit-dwas-import').removeClass('disabled');
+                this.$('.g-validation-failed-message').html(err.responseText);
+            }, this).dicomwebImport({
+                parentId,
+                parentType,
+                progress: true
+            });
+        },
+        'click .g-open-browser': '_openBrowser'
+    },
+
+    initialize: function () {
+        this._browserWidgetView = new BrowserWidget({
+            parentView: this,
+            titleText: 'Destination',
+            helpText: 'Browse to a location to select it as the destination.',
+            submitText: 'Select Destination',
+            validate: function (model) {
+                const isValid = $.Deferred();
+                if (!model) {
+                    isValid.reject('Please select a valid root.');
+                } else {
+                    isValid.resolve();
+                }
+                return isValid.promise();
+            }
+        });
+
+        this.listenTo(this._browserWidgetView, 'g:saved', function (val) {
+            this.$('#g-dwas-import-dest-id').val(val.id);
+            const model = this._browserWidgetView._hierarchyView.parentModel;
+            const modelType = model.get('_modelType');
+            this.$('#g-dwas-import-dest-type').val(modelType);
+
+            // Make a rest request to get the resource path
+            restRequest({
+                url: `resource/${val.id}/path`,
+                method: 'GET',
+                data: { type: modelType }
+            }).done((result) => {
+                // Only add the resource path if the value wasn't altered
+                if (this.$('#g-dwas-import-dest-id').val() === val.id) {
+                    this.$('#g-dwas-import-dest-id').val(`${val.id} (${result})`);
+                }
+            });
+        });
+        this.render();
+    },
+
+    render: function () {
+        this.$el.html(AssetstoreImportTemplate({
+            assetstore: this.model
+        }));
+
+        return this;
+    },
+
+    _openBrowser: function () {
+        this._browserWidgetView.setElement($('#g-dialog-container')).render();
+    }
+});
+
+export default AssetstoreImportView;

--- a/sources/dicom/large_image_source_dicom/web_client/views/AssetstoresView.js
+++ b/sources/dicom/large_image_source_dicom/web_client/views/AssetstoresView.js
@@ -1,0 +1,33 @@
+import _ from 'underscore';
+
+import AssetstoresView from '@girder/core/views/body/AssetstoresView';
+import { AssetstoreType } from '@girder/core/constants';
+import { wrap } from '@girder/core/utilities/PluginUtils';
+
+import AssetstoreImportButtonTemplate from '../templates/dicomwebAssetstoreImportButton.pug';
+
+/**
+ * Adds DICOMweb-specific info and an import button to the assetstore list
+ * view.
+ */
+wrap(AssetstoresView, 'render', function (render) {
+    render.call(this);
+
+    const selector = '.g-assetstore-info-section[assetstore-type="' + AssetstoreType.DICOMWEB + '"]';
+
+    _.each(this.$(selector), function (el) {
+        const $el = this.$(el);
+        const assetstore = this.collection.get($el.attr('cid'));
+
+        $el.parent().find('.g-assetstore-buttons').append(
+            AssetstoreImportButtonTemplate({
+                assetstore
+            })
+        );
+    }, this);
+
+    this.$('.g-dwas-import-button').tooltip({
+        delay: 100
+    });
+    return this;
+});

--- a/sources/dicom/large_image_source_dicom/web_client/views/EditAssetstoreWidget.js
+++ b/sources/dicom/large_image_source_dicom/web_client/views/EditAssetstoreWidget.js
@@ -1,0 +1,39 @@
+import EditAssetstoreWidget from '@girder/core/views/widgets/EditAssetstoreWidget';
+import { AssetstoreType } from '@girder/core/constants';
+import { wrap } from '@girder/core/utilities/PluginUtils';
+
+import AssetstoreEditFieldsTemplate from '../templates/dicomwebAssetstoreEditFields.pug';
+
+/**
+ * Adds DICOMweb-specific fields to the edit dialog.
+ */
+wrap(EditAssetstoreWidget, 'render', function (render) {
+    render.call(this);
+
+    if (this.model.get('type') === AssetstoreType.DICOMWEB) {
+        this.$('.g-assetstore-form-fields').append(
+            AssetstoreEditFieldsTemplate({
+                assetstore: this.model
+            })
+        );
+    }
+    return this;
+});
+
+EditAssetstoreWidget.prototype.fieldsMap[AssetstoreType.DICOMWEB] = {
+    get: function () {
+        return {
+            url: this.$('#g-edit-dwas-url').val(),
+            qido_prefix: this.$('#g-edit-dwas-qido-prefix').val(),
+            wado_prefix: this.$('#g-edit-dwas-wado-prefix').val(),
+            auth_type: this.$('#g-edit-dwas-auth-type').val()
+        };
+    },
+    set: function () {
+        const dwInfo = this.model.get('dicomweb_meta');
+        this.$('#g-edit-dwas-url').val(dwInfo.url);
+        this.$('#g-edit-dwas-qido-prefix').val(dwInfo.qido_prefix);
+        this.$('#g-edit-dwas-wado-prefix').val(dwInfo.wado_prefix);
+        this.$('#g-edit-dwas-auth-type').val(dwInfo.auth_type);
+    }
+};

--- a/sources/dicom/large_image_source_dicom/web_client/views/NewAssetstoreWidget.js
+++ b/sources/dicom/large_image_source_dicom/web_client/views/NewAssetstoreWidget.js
@@ -1,0 +1,26 @@
+import NewAssetstoreWidget from '@girder/core/views/widgets/NewAssetstoreWidget';
+import { AssetstoreType } from '@girder/core/constants';
+import { wrap } from '@girder/core/utilities/PluginUtils';
+
+import AssetstoreCreateTemplate from '../templates/dicomwebAssetstoreCreate.pug';
+
+/**
+ * Add UI for creating new DICOMweb assetstore.
+ */
+wrap(NewAssetstoreWidget, 'render', function (render) {
+    render.call(this);
+
+    this.$('#g-assetstore-accordion').append(AssetstoreCreateTemplate());
+    return this;
+});
+
+NewAssetstoreWidget.prototype.events['submit #g-new-dwas-form'] = function (e) {
+    this.createAssetstore(e, this.$('#g-new-dwas-error'), {
+        type: AssetstoreType.DICOMWEB,
+        name: this.$('#g-new-dwas-name').val(),
+        url: this.$('#g-edit-dwas-url').val(),
+        qido_prefix: this.$('#g-edit-dwas-qido-prefix').val(),
+        wado_prefix: this.$('#g-edit-dwas-wado-prefix').val(),
+        auth_type: this.$('#g-edit-dwas-auth-type').val()
+    });
+};

--- a/sources/dicom/setup.py
+++ b/sources/dicom/setup.py
@@ -57,8 +57,9 @@ setup(
     extras_require={
         'girder': f'girder-large-image{limit_version}',
     },
+    include_package_data=True,
     keywords='large_image, tile source',
-    packages=find_packages(exclude=['test', 'test.*']),
+    packages=find_packages(exclude=['test', 'test.*', 'test_dicom', 'test_dicom.*']),
     url='https://github.com/girder/large_image',
     python_requires='>=3.8',
     entry_points={
@@ -67,6 +68,9 @@ setup(
         ],
         'girder_large_image.source': [
             'dicom = large_image_source_dicom.girder_source:DICOMGirderTileSource',
+        ],
+        'girder.plugin': [
+            'dicomweb = large_image_source_dicom.girder_plugin:DICOMwebPlugin',
         ],
     },
 )

--- a/sources/dicom/test_dicom/test_web_client.py
+++ b/sources/dicom/test_dicom/test_web_client.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+import pytest
+
+pytestmark = [
+    pytest.mark.skipif(sys.version_info < (3, 8), reason='requires python3.8 or higher'),
+]
+
+
+@pytest.mark.girder()
+@pytest.mark.girder_client()
+@pytest.mark.plugin('large_image')
+@pytest.mark.plugin('dicomweb')
+def testDICOMWebClient(boundServer, fsAssetstore, db):
+    from pytest_girder.web_client import runWebClientTest
+
+    spec = os.path.join(os.path.dirname(__file__), 'web_client_specs', 'dicomWebSpec.js')
+    runWebClientTest(boundServer, spec, 15000)

--- a/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
+++ b/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
@@ -1,0 +1,34 @@
+girderTest.importPlugin('jobs', 'large_image', 'dicomweb');
+
+girderTest.startApp();
+
+describe('DICOMWeb assetstore', function () {
+    // maybe see how this is done in other tests -- it may not be necessary
+    it('register a user (first is admin)',
+        girderTest.createUser('admin',
+            'admin@girder.test',
+            'Admin',
+            'Admin',
+            'adminpassword!'));
+    it('go to assetstore page', function () {
+        runs(function () {
+            $('a.g-nav-link[g-target="admin"]').trigger('click');
+        });
+
+        waitsFor(function () {
+            return $('.g-assetstore-config:visible').length > 0;
+        }, 'navigate to admin page');
+
+        runs(function () {
+            $('a.g-assetstore-config').trigger('click');
+        });
+
+        waitsFor(function () {
+            return $('#g-create-dwas-tab').length > 0;
+        }, 'create to be visible');
+
+        runs(function () {
+            expect($('#g-create-dwas-tab').length);
+        });
+    });
+});

--- a/test/test_source_dicomweb.py
+++ b/test/test_source_dicomweb.py
@@ -1,0 +1,38 @@
+import sys
+
+import pytest
+
+from large_image.cache_util import cachesClear
+
+from . import utilities
+
+pytestmark = [
+    pytest.mark.skipif(sys.version_info < (3, 8), reason='requires python3.8 or higher'),
+]
+
+
+@pytest.mark.plugin('large_image_source_dicom')
+def testTilesFromDICOMweb():
+    import large_image_source_dicom
+
+    # Hopefully this URL and file will work for a long time. But we might need
+    # to update it at some point.
+    dicomweb_file = {
+        'url': 'https://idc-external-006.uc.r.appspot.com/dcm4chee-arc/aets/DCM4CHEE/rs',
+        'study_uid': '2.25.18199272949575141157802058345697568861',
+        'series_uid': '1.3.6.1.4.1.5962.99.1.3510881361.982628633.1635598486609.2.0',
+    }
+
+    source = large_image_source_dicom.open(dicomweb_file)
+    tileMetadata = source.getMetadata()
+
+    assert tileMetadata['tileWidth'] == 256
+    assert tileMetadata['tileHeight'] == 256
+    assert tileMetadata['sizeX'] == 46336
+    assert tileMetadata['sizeY'] == 44288
+    assert tileMetadata['levels'] == 9
+
+    utilities.checkTilesZXY(source, tileMetadata)
+
+    source = None
+    cachesClear()

--- a/tox.ini
+++ b/tox.ini
@@ -193,8 +193,10 @@ allowlist_externals =
 commands =
   npm --prefix {toxinidir}/girder/girder_large_image/web_client install --no-package-lock
   npm --prefix {toxinidir}/girder_annotation/girder_large_image_annotation/web_client install --no-package-lock
+  npm --prefix {toxinidir}/sources/dicom/large_image_source_dicom/web_client install --no-package-lock
   npm --prefix {toxinidir}/girder/girder_large_image/web_client run lint
   npm --prefix {toxinidir}/girder_annotation/girder_large_image_annotation/web_client run lint
+  npm --prefix {toxinidir}/sources/dicom/large_image_source_dicom/web_client run lint
 
 [testenv:formatclient]
 description = Autoformat client
@@ -205,8 +207,10 @@ allowlist_externals =
 commands =
   npm --prefix {toxinidir}/girder/girder_large_image/web_client install --no-package-lock
   npm --prefix {toxinidir}/girder_annotation/girder_large_image_annotation/web_client install --no-package-lock
+  npm --prefix {toxinidir}/sources/dicom/large_image_source_dicom/web_client install --no-package-lock
   npm --prefix {toxinidir}/girder/girder_large_image/web_client run format
   npm --prefix {toxinidir}/girder_annotation/girder_large_image_annotation/web_client run format
+  npm --prefix {toxinidir}/sources/dicom/large_image_source_dicom/web_client run format
 
 # You can use "tox devenv -e dev <venv path>" to create a development
 # environment.  This will only work on python base versions that support all
@@ -264,6 +268,7 @@ testpaths =
   test
   girder/test_girder
   girder_annotation/test_annotation
+  sources/dicom/test_dicom
 markers =
   singular: mark a test to run in a non-parallel environment.
   girder: mark a test as requiring girder


### PR DESCRIPTION
This creates a new DICOMweb assetstore that is used to track resources on a DICOMweb server. The user provides the DICOMweb server URL and optionally QIDO and WADO prefixes (if the server requires them). The user is then able to import references to the objects on the DICOMweb server.

The files that are created via this assetstore are able to be viewed with the dicom tile source, which has been extended to handle files on a DICOMweb server.

A test was also added that utilizes the public DICOMweb server located [here](https://imagingdatacommons.github.io/slim/).

There is still more work to do in future PRs, including:

* Adding a search/filter capability
* Adding authentication for non-public servers
* Query and store metadata from the DICOMweb objects

Fixes: #1204