### PR TITLE
Fix uploading javascript coverage to codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ commands:
       - run:
           name: Upload coverage
           command: |
-              ./codecov --disable search pycov gcov --file build/test/coverage/py_coverage.xml build/test/coverage/cobertura-coverage.xml
+              ./codecov --disable search pycov gcov --file build/test/coverage/py_coverage.xml,build/test/coverage/cobertura-coverage.xml
 
 jobs:
   testdocker:

--- a/tox.ini
+++ b/tox.ini
@@ -315,7 +315,9 @@ source =
 data_file = build/coverage/.coverage
 dynamic_context = test_function
 branch = True
-omit = test/*
+omit =
+  test/*
+  sources/dicom/test_dicom/*
 include =
   large_image/*
   examples/*


### PR DESCRIPTION
This makes our reported coverage look lower, but after some codecov change we no longer were including js coverage.