### PR TITLE
Minor refactor of the how we access the tiff reader class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changes
 - Remove a needless guard around getting an icc profile ([#1316](../../pull/1316))
 - Refactor fetching extra associated images from openslide ([#1318](../../pull/1318))
+- Minor refactor of some of the internals of the tiff source ([#1322](../../pull/1322))
 
 ### Bug Fixes
 - Guard against potential bad event stream timestamp ([#1306](../../pull/1306))


### PR DESCRIPTION
There is much we are doing with libtiff that could be switch to the python dictionaries returned by tifftools.  Would this speed things up in common use cases?  It would make a fallback to PIL if libtiff is unavailable easier.  Some of this refactor will make that easier to test.