### PR TITLE
Style can specify a dtype of 'source'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.25.1
+
+### Improvements
+- Style can specify a dtype of 'source' to maintain the original dtype even when compositing frames ([#1326](../../pull/1326))
+
 ## 1.25.0
 
 ### Features
@@ -8,7 +13,7 @@
 ### Improvements
 - Frame selection presets have configurable defaults ([#1301](../../pull/1301))
 - Improved DICOM metadata extraction ([#1305](../../pull/1305))
-- Support more region shapes in the annotation widget  ([#1323](../../pull/1323))
+- Support more region shapes in the annotation widget ([#1323](../../pull/1323))
 
 ### Changes
 - Remove a needless guard around getting an icc profile ([#1316](../../pull/1316))

--- a/docs/tilesource_options.rst
+++ b/docs/tilesource_options.rst
@@ -60,7 +60,7 @@ A band definition is an object which can contain the following keys:
 
 - ``clamp``: either True to clamp (also called clip or crop) values outside of the [min, max] to the ends of the palette or False to make outside values transparent.
 
-- ``dtype``: if specified, cast the intermediate results to this data type.  Only the first such value is used, and this can be specified as a base key if ``bands`` is specified.  Normally, if a style is applied, the intermediate data is a numpy float array with values from [0,255].  If this is ``uint16``, the results are multiplied by 65535 / 255 and cast to that dtype.  If ``float``, the results are divided by 255.
+- ``dtype``: if specified, cast the intermediate results to this data type.  Only the first such value is used, and this can be specified as a base key if ``bands`` is specified.  Normally, if a style is applied, the intermediate data is a numpy float array with values from [0,255].  If this is ``uint16``, the results are multiplied by 65535 / 255 and cast to that dtype.  If ``float``, the results are divided by 255.  If ``source``, this uses the dtype of the source image.
 
 - ``axis``: if specified, keep on the specified axis (channel) of the intermediate numpy array.  This is typically between 0 and 3 for the red, green, blue, and alpha channels.  Only the first such value is used, and this can be specified as a base key if ``bands`` is specified.
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -120,7 +120,7 @@ class TileSource(IPyLeafletMixin):
                     intermediately a float numpy array with a value range of
                     [0,255].  If this is 'uint16', it will be cast to that and
                     multiplied by 65535/255.  If 'float', it will be divided by
-                    255.
+                    255.  If 'source', this uses the dtype of the source image.
                 :axis: keep only the specified axis from the numpy intermediate
                     results.  This can be used to extract a single channel
                     after compositing.
@@ -1460,6 +1460,11 @@ class TileSource(IPyLeafletMixin):
         for eidx, entry in enumerate(sc.style['bands']):
             sc.styleIndex = eidx
             sc.dtype = sc.dtype if sc.dtype is not None else entry.get('dtype')
+            if sc.dtype == 'source':
+                if sc.mainImage.dtype == np.uint16:
+                    sc.dtype = 'uint16'
+                elif sc.mainImage.dtype.kind == 'f':
+                    sc.dtype = 'float'
             sc.axis = sc.axis if sc.axis is not None else entry.get('axis')
             sc.bandidx = 0 if image.shape[2] <= 2 else 1
             sc.band = None

--- a/test/test_source_tiff.py
+++ b/test/test_source_tiff.py
@@ -686,6 +686,13 @@ def testStyleDtypeAxis():
     assert image.shape[2] == 1
     assert image[0][0][0] == 65021
 
+    source = large_image_source_tiff.open(
+        imagePath, style=json.dumps({'dtype': 'source', 'axis': 1}))
+    image, _ = source.getRegion(
+        output={'maxWidth': 456, 'maxHeight': 96}, format=constants.TILE_FORMAT_NUMPY)
+    assert image.shape[2] == 1
+    assert image[0][0][0] == 253
+
 
 def testStyleNoData():
     imagePath = datastore.fetch('sample_image.ptif')


### PR DESCRIPTION
This maintains the original dtype even when compositing frames