### PR TITLE
Add token authentication option for DICOMweb

### DIFF
--- a/sources/dicom/large_image_source_dicom/__init__.py
+++ b/sources/dicom/large_image_source_dicom/__init__.py
@@ -195,7 +195,7 @@ class DICOMFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                                           requested_transfer_syntax=transfer_syntax)
 
     def _identify_dicomweb_transfer_syntax(self, client, study_uid, series_uid):
-        # "client" is a DICOMwebClient
+        # "client" is a dicomweb_client.DICOMwebClient
 
         # This is how we select the JPEG type to return
         # The available transfer syntaxes used by wsidicom may be found here:

--- a/sources/dicom/large_image_source_dicom/__init__.py
+++ b/sources/dicom/large_image_source_dicom/__init__.py
@@ -180,7 +180,7 @@ class DICOMFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             # The following are optional keys
             qido_url_prefix=info.get('qido_prefix'),
             wado_url_prefix=info.get('wado_prefix'),
-            session=info.get('auth'),
+            session=info.get('session'),
         )
 
         wsidicom_client = wsidicom.WsiDicomWebClient(client)

--- a/sources/dicom/large_image_source_dicom/assetstore/__init__.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/__init__.py
@@ -32,6 +32,7 @@ def createAssetstore(event):
                 'qido_prefix': params.get('qido_prefix'),
                 'wado_prefix': params.get('wado_prefix'),
                 'auth_type': params.get('auth_type'),
+                'auth_token': params.get('auth_token'),
             },
         }))
         event.preventDefault()
@@ -53,6 +54,7 @@ def updateAssetstore(event):
             'qido_prefix': params.get('qido_prefix'),
             'wado_prefix': params.get('wado_prefix'),
             'auth_type': params.get('auth_type'),
+            'auth_token': params.get('auth_token'),
         }
 
 
@@ -78,6 +80,9 @@ def load(info):
                required=False)
         .param('auth_type',
                'The authentication type required for the server, if needed (for DICOMweb)',
+               required=False)
+        .param('auth_token',
+               'Token for authentication if needed (for DICOMweb)',
                required=False))
 
     info['apiRoot'].dicomweb_assetstore = DICOMwebAssetstoreResource()

--- a/sources/dicom/large_image_source_dicom/assetstore/rest.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/rest.py
@@ -26,7 +26,7 @@ class DICOMwebAssetstoreResource(Resource):
         """
         user = self.getCurrentUser()
 
-        destinationType = params.get('destinationType', 'folder')
+        destinationType = params['destinationType']
         if destinationType not in ('folder', 'user', 'collection'):
             msg = f'Invalid destinationType: {destinationType}'
             raise RestException(msg)
@@ -76,7 +76,7 @@ class DICOMwebAssetstoreResource(Resource):
                'in the Girder data hierarchy under which to import the files.')
         .param('destinationType', 'The type of the parent object to import into.',
                enum=('folder', 'user', 'collection'),
-               required=True)
+               required=False, default='folder')
         .param('limit', 'The maximum number of results to import.',
                required=False, default=None)
         .param('filters', 'Any search parameters to filter DICOM objects.',

--- a/sources/dicom/large_image_source_dicom/assetstore/rest.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/rest.py
@@ -58,7 +58,6 @@ class DICOMwebAssetstoreResource(Resource):
             {
                 'limit': limit,
                 'search_filters': search_filters,
-                'auth': None,
             },
             progress,
             user,

--- a/sources/dicom/large_image_source_dicom/girder_source.py
+++ b/sources/dicom/large_image_source_dicom/girder_source.py
@@ -4,6 +4,7 @@ from girder.constants import AssetstoreType
 from girder.models.file import File
 from girder.models.folder import Folder
 from girder.models.item import Item
+from girder.utility import assetstore_utilities
 
 from . import DICOMFileTileSource
 from .assetstore import DICOMWEB_META_KEY
@@ -61,6 +62,8 @@ class DICOMGirderTileSource(DICOMFileTileSource, GirderTileSource):
         file = Item().childFiles(self.item, limit=1)[0]
         file_meta = file['dicomweb_meta']
 
+        adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
+
         return {
             'url': meta['url'],
             'study_uid': file_meta['study_uid'],
@@ -68,5 +71,5 @@ class DICOMGirderTileSource(DICOMFileTileSource, GirderTileSource):
             # The following are optional
             'qido_prefix': meta.get('qido_prefix'),
             'wado_prefix': meta.get('wado_prefix'),
-            'auth': meta.get('auth'),
+            'session': adapter.auth_session,
         }

--- a/sources/dicom/large_image_source_dicom/web_client/templates/dicomwebAssetstoreCreate.pug
+++ b/sources/dicom/large_image_source_dicom/web_client/templates/dicomwebAssetstoreCreate.pug
@@ -20,7 +20,7 @@ include dicomwebAssetstoreMixins
         input#g-new-dwas-name.input-sm.form-control(
             type="text",
             placeholder="Name")
-        +g-dwas-parameters
+        +g-dwas-parameters("new")
         p#g-new-dwas-error.g-validation-failed-message
         input.g-new-assetstore-submit.btn.btn-sm.btn-primary(
           type="submit", value="Create")

--- a/sources/dicom/large_image_source_dicom/web_client/templates/dicomwebAssetstoreEditFields.pug
+++ b/sources/dicom/large_image_source_dicom/web_client/templates/dicomwebAssetstoreEditFields.pug
@@ -1,3 +1,3 @@
 include dicomwebAssetstoreMixins
 
-+g-dwas-parameters
++g-dwas-parameters("edit")

--- a/sources/dicom/large_image_source_dicom/web_client/templates/dicomwebAssetstoreMixins.pug
+++ b/sources/dicom/large_image_source_dicom/web_client/templates/dicomwebAssetstoreMixins.pug
@@ -1,19 +1,52 @@
-mixin g-dwas-parameters
+mixin g-dwas-parameters(label_key)
+  - const key = label_key;
+
+  //- We need to make sure the html elements all have unique ids when this
+  //- mixin is reused in different places, so that we can locate the correct
+  //- html elements in the script.
+  - const url_id = `g-${key}-dwas-url`;
+  - const qido_id = `g-${key}-dwas-qido-prefix`;
+  - const wado_id = `g-${key}-dwas-wado-prefix`;
+  - const auth_type_id = `g-${key}-dwas-auth-type`;
+  - const auth_type_container_id = `g-${key}-dwas-auth-type-container`;
+  - const auth_token_id = `g-${key}-dwas-auth-token`;
+  - const auth_token_container_id = `g-${key}-dwas-auth-token-container`;
+
   .form-group
-    label.control-label(for="g-edit-dwas-url") DICOMweb server URL
-    input#g-edit-dwas-url.input-sm.form-control(
+    label.control-label(for=url_id) DICOMweb server URL
+    input.input-sm.form-control(
+        id=url_id,
         type="text",
         placeholder="URL")
-    label.control-label(for="g-edit-dwas-qido-prefix") DICOMweb QIDO prefix (optional)
-    input#g-edit-dwas-qido-prefix.input-sm.form-control(
+    label.control-label(for=qido_id) DICOMweb QIDO prefix (optional)
+    input.input-sm.form-control(
+        id=qido_id,
         type="text",
         placeholder="QIDO prefix")
-    label.control-label(for="g-edit-dwas-wado-prefix") DICOMweb WADO prefix (optional)
-    input#g-edit-dwas-wado-prefix.input-sm.form-control(
+    label.control-label(for=wado_id) DICOMweb WADO prefix (optional)
+    input.input-sm.form-control(
+        id=wado_id,
         type="text",
         placeholder="WADO prefix")
-  //- COMMENTED OUT UNTIL WE ADD AUTHENTICATION
-    label.control-label(for="g-edit-dwas-auth-type") DICOMweb authentication type (optional)
-    input#g-edit-dwas-auth-type.input-sm.form-control(
-        type="text",
-        placeholder="Authentication type")
+    label.control-label(for=auth_type_id) DICOMweb authentication type (optional)
+    - const auth_type = (assetstore && assetstore.attributes.dicomweb_meta.auth_type) || null;
+    - const updateFuncName = `${key}UpdateVisibilities`;
+    script.
+      var #{updateFuncName} = function () {
+         const isToken = document.getElementById('#{auth_type_id}').value === 'token';
+         const display = isToken ? 'block' : 'none';
+         document.getElementById('#{auth_token_container_id}').style.display = display;
+      };
+    div(id=auth_type_container_id)
+      select.form-control(
+          id=auth_type_id,
+          onchange=updateFuncName + '()')
+        each auth_option in authOptions
+          option(value=auth_option.value, selected=(auth_type === auth_option.value)) #{auth_option.label}
+    - const display = auth_type === 'token' ? 'block': 'none';
+    div(id=auth_token_container_id, style='display: ' + display + ';')
+      label.control-label(for=auth_token_id) DICOMweb authentication token
+      input.input-sm.form-control(
+          id=auth_token_id,
+          type="text",
+          placeholder="Token")

--- a/sources/dicom/large_image_source_dicom/web_client/views/AuthOptions.js
+++ b/sources/dicom/large_image_source_dicom/web_client/views/AuthOptions.js
@@ -1,0 +1,13 @@
+const authOptions = [
+    {
+        // HTML can't accept null, but it can accept an empty string
+        value: '',
+        label: 'None'
+    },
+    {
+        value: 'token',
+        label: 'Token'
+    }
+];
+
+export default authOptions;

--- a/sources/dicom/large_image_source_dicom/web_client/views/EditAssetstoreWidget.js
+++ b/sources/dicom/large_image_source_dicom/web_client/views/EditAssetstoreWidget.js
@@ -15,7 +15,7 @@ wrap(EditAssetstoreWidget, 'render', function (render) {
     if (this.model.get('type') === AssetstoreType.DICOMWEB) {
         this.$('.g-assetstore-form-fields').append(
             DWASEditFieldsTemplate({
-                assetstore: this.model
+                assetstore: this.model,
                 authOptions
             })
         );

--- a/sources/dicom/large_image_source_dicom/web_client/views/EditAssetstoreWidget.js
+++ b/sources/dicom/large_image_source_dicom/web_client/views/EditAssetstoreWidget.js
@@ -4,6 +4,8 @@ import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import DWASEditFieldsTemplate from '../templates/dicomwebAssetstoreEditFields.pug';
 
+import authOptions from './AuthOptions';
+
 /**
  * Adds DICOMweb-specific fields to the edit dialog.
  */
@@ -14,6 +16,7 @@ wrap(EditAssetstoreWidget, 'render', function (render) {
         this.$('.g-assetstore-form-fields').append(
             DWASEditFieldsTemplate({
                 assetstore: this.model
+                authOptions
             })
         );
     }
@@ -26,7 +29,8 @@ EditAssetstoreWidget.prototype.fieldsMap[AssetstoreType.DICOMWEB] = {
             url: this.$('#g-edit-dwas-url').val(),
             qido_prefix: this.$('#g-edit-dwas-qido-prefix').val(),
             wado_prefix: this.$('#g-edit-dwas-wado-prefix').val(),
-            auth_type: this.$('#g-edit-dwas-auth-type').val()
+            auth_type: this.$('#g-edit-dwas-auth-type').val(),
+            auth_token: this.$('#g-edit-dwas-auth-token').val()
         };
     },
     set: function () {
@@ -34,6 +38,8 @@ EditAssetstoreWidget.prototype.fieldsMap[AssetstoreType.DICOMWEB] = {
         this.$('#g-edit-dwas-url').val(dwInfo.url);
         this.$('#g-edit-dwas-qido-prefix').val(dwInfo.qido_prefix);
         this.$('#g-edit-dwas-wado-prefix').val(dwInfo.wado_prefix);
-        this.$('#g-edit-dwas-auth-type').val(dwInfo.auth_type);
+        // HTML can't accept null, so set it to an empty string
+        this.$('#g-edit-dwas-auth-type').val(dwInfo.auth_type || '');
+        this.$('#g-edit-dwas-auth-token').val(dwInfo.auth_token);
     }
 };

--- a/sources/dicom/large_image_source_dicom/web_client/views/NewAssetstoreWidget.js
+++ b/sources/dicom/large_image_source_dicom/web_client/views/NewAssetstoreWidget.js
@@ -4,13 +4,17 @@ import { wrap } from '@girder/core/utilities/PluginUtils';
 
 import DWASCreateTemplate from '../templates/dicomwebAssetstoreCreate.pug';
 
+import authOptions from './AuthOptions';
+
 /**
  * Add UI for creating new DICOMweb assetstore.
  */
 wrap(NewAssetstoreWidget, 'render', function (render) {
     render.call(this);
 
-    this.$('#g-assetstore-accordion').append(DWASCreateTemplate());
+    this.$('#g-assetstore-accordion').append(DWASCreateTemplate({
+        authOptions
+    }));
     return this;
 });
 
@@ -18,9 +22,10 @@ NewAssetstoreWidget.prototype.events['submit #g-new-dwas-form'] = function (e) {
     this.createAssetstore(e, this.$('#g-new-dwas-error'), {
         type: AssetstoreType.DICOMWEB,
         name: this.$('#g-new-dwas-name').val(),
-        url: this.$('#g-edit-dwas-url').val(),
-        qido_prefix: this.$('#g-edit-dwas-qido-prefix').val(),
-        wado_prefix: this.$('#g-edit-dwas-wado-prefix').val(),
-        auth_type: this.$('#g-edit-dwas-auth-type').val()
+        url: this.$('#g-new-dwas-url').val(),
+        qido_prefix: this.$('#g-new-dwas-qido-prefix').val(),
+        wado_prefix: this.$('#g-new-dwas-wado-prefix').val(),
+        auth_type: this.$('#g-new-dwas-auth-type').val(),
+        auth_token: this.$('#g-new-dwas-auth-token').val()
     });
 };

--- a/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
+++ b/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
@@ -40,7 +40,23 @@ describe('DICOMWeb assetstore', function () {
         runs(function () {
             // Create the DICOMweb assetstore
             $('#g-new-dwas-name').val('DICOMweb');
-            $('#g-edit-dwas-url').val('https://idc-external-006.uc.r.appspot.com/dcm4chee-arc/aets/DCM4CHEE/rs');
+            $('#g-new-dwas-url').val('https://idc-external-006.uc.r.appspot.com/dcm4chee-arc/aets/DCM4CHEE/rs');
+
+            // Test error for setting auth type to "token" with no token
+            $('#g-new-dwas-auth-type').val('token');
+            $('#g-new-dwas-form input.btn-primary').click();
+        });
+
+        waitsFor(function () {
+            const msg = 'A token must be provided if the auth type is "token"';
+            return $('#g-new-dwas-error').html() === msg;
+        }, 'No token provided check');
+
+        runs(function () {
+            // Change the auth type back to None
+            $('#g-new-dwas-auth-type').val(null);
+
+            // This should work now
             $('#g-new-dwas-form input.btn-primary').click();
         });
 


### PR DESCRIPTION
When the user is creating a DICOMweb assetstore, if they select the "token" authentication type, an input box will appear where the user must enter the token.

This token is saved in MongoDB, and is used for making all requests for this DICOMweb assetstore. That includes requests for importing the data (which may only be done by an admin), and requests for viewing the data (which may be done by anyone with access to the folder).

If an admin wishes to restrict users from viewing DICOMweb assets that were imported using this token, the admin must restrict access to the imported items via girder's folder access controls.

Fixes: #1313

Depends on: imi-bigpicture/wsidicom#117