### PR TITLE
Default to "None" for the limit

### DIFF
--- a/sources/dicom/large_image_source_dicom/assetstore/rest.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/rest.py
@@ -79,7 +79,7 @@ class DICOMwebAssetstoreResource(Resource):
                enum=('folder', 'user', 'collection'),
                required=True)
         .param('limit', 'The maximum number of results to import.',
-               required=False, dataType='int')
+               required=False, default=None)
         .param('filters', 'Any search parameters to filter DICOM objects.',
                required=False, default='{}')
         .param('progress', 'Whether to record progress on this operation.',

--- a/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
+++ b/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
@@ -112,7 +112,7 @@ describe('DICOMWeb assetstore', function () {
         });
 
         waitsFor(function () {
-            return $('.g-validation-failed-message').html().includes('Invalid value');
+            return $('.g-validation-failed-message').html() === 'Invalid limit';
         }, 'Invalid limit check (float)');
 
         runs(function () {


### PR DESCRIPTION
On the master branch, if I try to import with no limit set, I get the following error:

```
Invalid value for integer parameter limit: .
```

We should remove the datatype restriction and set the default to `None`. That way, it will work properly.