### PR TITLE
Use minified geojs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 - Have zarr use read-only mode ([#1360](../../pull/1360))
+- Use minified geojs ([#1362](../../pull/1362))
 
 ### Bug Fixes
 - Default to "None" for the DICOM assetstore limit ([#1359](../../pull/1359))

--- a/girder/girder_large_image/web_client/webpack.helper.js
+++ b/girder/girder_large_image/web_client/webpack.helper.js
@@ -8,7 +8,7 @@ const {VueLoaderPlugin} = require('vue-loader');
 module.exports = function (config) {
     config.plugins.push(
         new CopyWebpackPlugin([{
-            from: require.resolve('geojs'),
+            from: require.resolve('geojs/geo.lean.min.js'),
             to: path.join(config.output.path, 'extra', 'geojs.js'),
             toType: 'file'
         }, {


### PR DESCRIPTION
This reduces data transfer when showing large images in girder.