### PR TITLE
Improve cache key guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Use minified geojs ([#1362](../../pull/1362))
 - Configurable item list grid view ([#1363](../../pull/1363))
 - Allow labels in item list view ([#1366](../../pull/1366))
+- Improve cache key guard ([#1368](../../pull/1368))
 
 ### Bug Fixes
 - Default to "None" for the DICOM assetstore limit ([#1359](../../pull/1359))

--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -210,27 +210,27 @@ class LruCacheMetaclass(type):
                         return result
                 except KeyError:
                     pass
-            # This conditionally copies a non-styled class and adds a style.
-            if (kwargs.get('style') and hasattr(cls, '_setStyle') and
-                    kwargs.get('style') != getattr(cls, '_unstyledStyle', None)):
-                subkwargs = kwargs.copy()
-                subkwargs['style'] = getattr(cls, '_unstyledStyle', None)
-                subresult = cls(*args, **subkwargs)
-                result = subresult.__class__.__new__(subresult.__class__)
-                with subresult._sourceLock:
-                    result.__dict__ = subresult.__dict__.copy()
-                    result._sourceLock = threading.RLock()
-                result._classkey = key
-                # for pickling
-                result._initValues = (args, kwargs.copy())
-                result._unstyledInstance = subresult
-                result._derivedSource = True
-                # Has to be after setting the _unstyledInstance
-                result._setStyle(kwargs['style'])
-                with cacheLock:
-                    cache[key] = result
-                    return result
             try:
+                # This conditionally copies a non-styled class and adds a style.
+                if (kwargs.get('style') and hasattr(cls, '_setStyle') and
+                        kwargs.get('style') != getattr(cls, '_unstyledStyle', None)):
+                    subkwargs = kwargs.copy()
+                    subkwargs['style'] = getattr(cls, '_unstyledStyle', None)
+                    subresult = cls(*args, **subkwargs)
+                    result = subresult.__class__.__new__(subresult.__class__)
+                    with subresult._sourceLock:
+                        result.__dict__ = subresult.__dict__.copy()
+                        result._sourceLock = threading.RLock()
+                    result._classkey = key
+                    # for pickling
+                    result._initValues = (args, kwargs.copy())
+                    result._unstyledInstance = subresult
+                    result._derivedSource = True
+                    # Has to be after setting the _unstyledInstance
+                    result._setStyle(kwargs['style'])
+                    with cacheLock:
+                        cache[key] = result
+                        return result
                 instance = super().__call__(*args, **kwargs)
                 # for pickling
                 instance._initValues = (args, kwargs.copy())


### PR DESCRIPTION
Broaden where a try/except decides to remove an invalid item from the cache.  Before, when a bad style was passed, the cache could end up with entries for that bad style, cycling the cache more than necessary.