### PR TITLE
General handling of skipped levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,12 @@
 - Configurable item list grid view ([#1363](../../pull/1363))
 - Allow labels in item list view ([#1366](../../pull/1366))
 - Improve cache key guard ([#1368](../../pull/1368))
-- Improve handling dicom files in the working directory ([#1370](../../pull/137068))
+- Improve handling dicom files in the working directory ([#1370](../../pull/1370))
+- General handling of skipped levels ([#1373](../../pull/1373))
+
+### Changes
+- Update WsiDicomWebClient init call ([#1371](../../pull/1371))
+- Rename DICOMweb AssetstoreImportView ([#1372](../../pull/1372))
 
 ### Bug Fixes
 - Default to "None" for the DICOM assetstore limit ([#1359](../../pull/1359))

--- a/sources/dicom/large_image_source_dicom/__init__.py
+++ b/sources/dicom/large_image_source_dicom/__init__.py
@@ -157,6 +157,8 @@ class DICOMFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         self.levels = int(max(1, math.ceil(math.log(
             max(self.sizeX / self.tileWidth, self.sizeY / self.tileHeight)) / math.log(2)) + 1))
         self._populatedLevels = len(self._dicom.levels)
+        # We need to detect which levels are functionally present if we want to
+        # return a sensible _nonemptyLevelsList
 
     def _open_wsi_dicom(self, path):
         if isinstance(path, dict):

--- a/test/datastore.py
+++ b/test/datastore.py
@@ -104,6 +104,8 @@ registry = {
     'synthetic_multiaxis.zarr.db': 'sha512:2ca118b67ca73bbc6fe9542c5b71ee6cb5f45f5049575a4682290cec4cfb4deef29aee5e19fb5d4005167322668a94191a86f98f1125c94f5eef3e14c6ec6e26',  # noqa
     # The same as above, but as a multi directory zip
     'synthetic_multiaxis.zarr.zip': 'sha512:95da53061bd09deaf4357e745404780d78a0949935f82c10ee75237e775345caace18fad3f05c3452ba36efca6b3ed58d815d041f33197497ab53d2c80b9e2ac',  # noqa
+    # Single flat array zarr
+    'flat2.zarr.zip': 'sha512:c49ff5fbfa73615da4c2a7c8602723297d604892b848860a068ab200245eec6c4f638f35d0b40cde0233c55faa6dc4e46351a841b481211f36dc5fb43765d818',  # noqa
 }
 
 


### PR DESCRIPTION
When a tile source is missing many levels of tiles, it can use too much memory to read the next available resolution and scale from that directly.  This does that scaling in stages, if necessary.