### PR TITLE
Read and set several metadata items, if available

### DIFF
--- a/sources/dicom/large_image_source_dicom/__init__.py
+++ b/sources/dicom/large_image_source_dicom/__init__.py
@@ -121,7 +121,6 @@ class DICOMFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         """
         super().__init__(path, **kwargs)
 
-        self.logger = config.getConfig('logger')
         self._dicomWebClient = None
 
         # We want to make a list of paths of files in this item, if multiple,

--- a/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
@@ -192,7 +192,7 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
 
             # Set the DICOMweb metadata
             item['dicomweb_meta'] = get_dicomweb_metadata(client, study_uid, series_uid)
-            Item().save(item)
+            item = Item().save(item)
 
             # Create a placeholder file with the same name
             file = File().createFile(

--- a/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
@@ -190,13 +190,9 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
             item = Item().createItem(name=series_uid, creator=user, folder=folder,
                                      reuseExisting=True)
 
-            # Set the DICOMweb metadata, if available
-            metadata = get_dicomweb_metadata(client, study_uid, series_uid)
-            if metadata:
-                Item().setMetadata(item, metadata)
-                # Also save a copy that the user cannot modify, for _getDicomMetadata()
-                item['dicomweb_meta'] = metadata
-                Item().save(item)
+            # Set the DICOMweb metadata
+            item['dicomweb_meta'] = get_dicomweb_metadata(client, study_uid, series_uid)
+            Item().save(item)
 
             # Create a placeholder file with the same name
             file = File().createFile(

--- a/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
@@ -1,6 +1,6 @@
 import requests
-from large_image_source_dicom.dicom_metadata import extract_dicom_metadata
 from large_image_source_dicom.dicom_tags import dicom_key_to_tag
+from large_image_source_dicom.dicomweb_utils import get_dicomweb_metadata
 from requests.exceptions import HTTPError
 
 from girder.exceptions import ValidationException
@@ -144,7 +144,6 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
             msg = f'Invalid parent type: {parentType}'
             raise RuntimeError(msg)
 
-        from pydicom import Dataset
         from wsidicom.uid import WSI_SOP_CLASS_UID
 
         limit = params.get('limit')
@@ -191,22 +190,13 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
             item = Item().createItem(name=series_uid, creator=user, folder=folder,
                                      reuseExisting=True)
 
-            # Many series-level metadata items are available if we explicitly
-            # request for them in the earlier `search_for_series()` call.
-            # However, some things are not available in the series-level
-            # metadata - in particular, the specimen information is only
-            # on the instance-level metadata.
-            # It seems that, for the most part, all WSI DICOM instances in a
-            # series have virtually identical metadata (except one or two things,
-            # such as the suffix on the serial number, and sometimes one of the
-            # items in the specimen metadata).
-            # We will do as the SLIM viewer does: grab a single volume instance
-            # and use that for the metadata.
-            volume_metadata = _get_first_wsi_volume_metadata(client, study_uid, series_uid)
-            if volume_metadata:
-                dataset = Dataset.from_json(volume_metadata)
-                metadata = extract_dicom_metadata(dataset)
+            # Set the DICOMweb metadata, if available
+            metadata = get_dicomweb_metadata(client, study_uid, series_uid)
+            if metadata:
                 Item().setMetadata(item, metadata)
+                # Also save a copy that the user cannot modify, for _getDicomMetadata()
+                item['dicomweb_meta'] = metadata
+                Item().save(item)
 
             # Create a placeholder file with the same name
             file = File().createFile(
@@ -233,40 +223,6 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
     @property
     def auth_session(self):
         return _create_auth_session(self.assetstore_meta)
-
-
-def _get_first_wsi_volume_metadata(client, study_uid, series_uid):
-    from wsidicom.uid import WSI_SOP_CLASS_UID
-
-    image_type_tag = dicom_key_to_tag('ImageType')
-    instance_uid_tag = dicom_key_to_tag('SOPInstanceUID')
-
-    search_filters = {
-        'SOPClassUID': WSI_SOP_CLASS_UID,
-    }
-    fields = [
-        image_type_tag,
-        instance_uid_tag,
-    ]
-    wsi_instances = client.search_for_instances(
-        study_uid, series_uid, search_filters=search_filters, fields=fields)
-
-    volume_instance = None
-    for instance in wsi_instances:
-        image_type = instance.get(image_type_tag, {}).get('Value')
-        # It would be nice if we could have a search filter for this, but
-        # I didn't see one...
-        if image_type and len(image_type) > 2 and image_type[2] == 'VOLUME':
-            volume_instance = instance
-            break
-
-    if not volume_instance:
-        # No volumes were found...
-        return None
-
-    instance_uid = volume_instance[instance_uid_tag]['Value'][0]
-
-    return client.retrieve_instance_metadata(study_uid, series_uid, instance_uid)
 
 
 def _create_auth_session(meta):

--- a/sources/dicom/large_image_source_dicom/dicom_metadata.py
+++ b/sources/dicom/large_image_source_dicom/dicom_metadata.py
@@ -1,0 +1,104 @@
+def extract_dicom_metadata(dataset):
+    # Extract any metadata we want to display from the dataset
+
+    metadata = {}
+    for field in TOP_LEVEL_METADATA_FIELDS:
+        if field not in dataset:
+            # This field is missing
+            continue
+
+        element = dataset[field]
+        value = element.value
+
+        if not value:
+            # This field is blank
+            continue
+
+        if isinstance(value, list):
+            value = ', '.join(value)
+
+        metadata[element.name] = str(value)
+
+    # The specimens are complex and many layers deep
+    specimens = extract_specimen_metadata(dataset)
+    if specimens:
+        metadata['Specimens'] = specimens
+
+    return metadata
+
+
+# These are the top-level metadata fields we will look for
+# (if available on the DICOM object)
+TOP_LEVEL_METADATA_FIELDS = [
+    'PatientID',
+    'PatientName',
+    'PatientSex',
+    'PatientBirthDate',
+
+    'AccessionNumber',
+    'StudyID',
+    'StudyDate',
+    'StudyTime',
+
+    'ClinicalTrialSponsorName',
+    'ClinicalTrialProtocolID',
+    'ClinicalTrialProtocolName',
+    'ClinicalTrialSiteName',
+
+    'Manufacturer',
+    'ManufacturerModelName',
+    'DeviceSerialNumber',
+    'SoftwareVersions',
+
+    'ReferringPhysicianName',
+    'ModalitiesInStudy',
+]
+
+
+def extract_specimen_metadata(dataset):
+    # Specimens are complex and many layers deep.
+    # This function tries to extract what we need from the specimens.
+
+    output = []
+    for specimen in getattr(dataset, 'SpecimenDescriptionSequence', []):
+        metadata = {}
+        if 'SpecimenIdentifier' in specimen:
+            metadata['Identifier'] = specimen.SpecimenIdentifier
+
+        if 'SpecimenShortDescription' in specimen:
+            metadata['Description'] = specimen.SpecimenShortDescription
+
+        structures = ', '.join(
+            x.CodeMeaning for x in getattr(specimen, 'PrimaryAnatomicStructureSequence', [])
+        )
+        if structures:
+            metadata['Anatomical Structure'] = structures
+
+        preps = []
+        for prep in getattr(specimen, 'SpecimenPreparationSequence', []):
+            steps = {}
+            for step in getattr(prep, 'SpecimenPreparationStepContentItemSequence', []):
+                # Only extract entires that have both a name and a value
+                if (len(getattr(step, 'ConceptCodeSequence', [])) > 0 and
+                        len(getattr(step, 'ConceptNameCodeSequence', [])) > 0):
+                    name = step.ConceptNameCodeSequence[0].CodeMeaning
+                    value = step.ConceptCodeSequence[0].CodeMeaning
+                    if name in steps:
+                        # There must be several values for this name.
+                        # Turn it into a list instead.
+                        if not isinstance(steps[name], list):
+                            steps[name] = [steps[name]]
+                        steps[name].append(value)
+                    else:
+                        steps[name] = value
+
+            if steps:
+                preps.append(steps)
+
+        if preps:
+            metadata['Specimen Preparation'] = preps
+
+        if metadata:
+            output.append(metadata)
+
+    return output

--- a/sources/dicom/large_image_source_dicom/dicomweb_utils.py
+++ b/sources/dicom/large_image_source_dicom/dicomweb_utils.py
@@ -1,0 +1,59 @@
+from large_image_source_dicom.dicom_metadata import extract_dicom_metadata
+from large_image_source_dicom.dicom_tags import dicom_key_to_tag
+
+
+def get_dicomweb_metadata(client, study_uid, series_uid):
+    # Many series-level metadata items are available if we explicitly
+    # request for them in the `search_for_series()` calls.
+    # However, some things are not available in the series-level
+    # metadata - in particular, the specimen information is only
+    # on the instance-level metadata.
+    # It seems that, for the most part, all WSI DICOM instances in a
+    # series have virtually identical metadata (except one or two things,
+    # such as the suffix on the serial number, and sometimes one of the
+    # items in the specimen metadata).
+    # We will do as the SLIM viewer does: grab a single volume instance
+    # and use that for the metadata.
+    volume_metadata = get_first_wsi_volume_metadata(client, study_uid, series_uid)
+    if not volume_metadata:
+        # No metadata
+        return None
+
+    from pydicom import Dataset
+    dataset = Dataset.from_json(volume_metadata)
+    return extract_dicom_metadata(dataset)
+
+
+def get_first_wsi_volume_metadata(client, study_uid, series_uid):
+    # Find the first WSI Volume and return the DICOMweb metadata
+    from wsidicom.uid import WSI_SOP_CLASS_UID
+
+    image_type_tag = dicom_key_to_tag('ImageType')
+    instance_uid_tag = dicom_key_to_tag('SOPInstanceUID')
+
+    search_filters = {
+        'SOPClassUID': WSI_SOP_CLASS_UID,
+    }
+    fields = [
+        image_type_tag,
+        instance_uid_tag,
+    ]
+    wsi_instances = client.search_for_instances(
+        study_uid, series_uid, search_filters=search_filters, fields=fields)
+
+    volume_instance = None
+    for instance in wsi_instances:
+        image_type = instance.get(image_type_tag, {}).get('Value')
+        # It would be nice if we could have a search filter for this, but
+        # I didn't see one...
+        if image_type and len(image_type) > 2 and image_type[2] == 'VOLUME':
+            volume_instance = instance
+            break
+
+    if not volume_instance:
+        # No volumes were found...
+        return None
+
+    instance_uid = volume_instance[instance_uid_tag]['Value'][0]
+
+    return client.retrieve_instance_metadata(study_uid, series_uid, instance_uid)

--- a/sources/dicom/large_image_source_dicom/girder_source.py
+++ b/sources/dicom/large_image_source_dicom/girder_source.py
@@ -75,9 +75,9 @@ class DICOMGirderTileSource(DICOMFileTileSource, GirderTileSource):
         }
 
     def _getDicomMetadata(self):
-        if 'dicomweb_meta' not in self.item:
-            # Cache this in the database
-            self.item['dicomweb_meta'] = super()._getDicomMetadata()
-            Item().save(self.item)
+        if self._isDicomWeb:
+            # This should have already been saved in the item
+            return self.item['dicomweb_meta']
 
-        return self.item['dicomweb_meta']
+        # Return the parent result. This is a cached method.
+        return super()._getDicomMetadata()

--- a/sources/dicom/large_image_source_dicom/girder_source.py
+++ b/sources/dicom/large_image_source_dicom/girder_source.py
@@ -73,3 +73,11 @@ class DICOMGirderTileSource(DICOMFileTileSource, GirderTileSource):
             'wado_prefix': meta.get('wado_prefix'),
             'session': adapter.auth_session,
         }
+
+    def _getDicomMetadata(self):
+        if 'dicomweb_meta' not in self.item:
+            # Cache this in the database
+            self.item['dicomweb_meta'] = super()._getDicomMetadata()
+            Item().save(self.item)
+
+        return self.item['dicomweb_meta']

--- a/test/test_source_dicomweb.py
+++ b/test/test_source_dicomweb.py
@@ -25,3 +25,7 @@ def testTilesFromDICOMweb():
     assert tileMetadata['levels'] == 9
 
     utilities.checkTilesZXY(source, tileMetadata)
+
+    # Verify that the internal metadata is working too
+    internalMetadata = source.getInternalMetadata()
+    assert internalMetadata['dicom_meta']['Specimens'][0]['Anatomical Structure'] == 'Lung'


### PR DESCRIPTION
When DICOMweb series are imported, several metadata entries from each series are now extracted and set on the item metadata.

We are extracting most of the metadata that is displayed in the SLIM viewer: https://imagingdatacommons.github.io/slim/

Most of the metadata entries are available as series-level metadata items. However, some of the metadata entries are only available on the instances themselves (in particular, the "Specimen" information, which is nested several dataset layers deep).

The SLIM viewer sets most of its metadata by locating the first WSI Volume dataset, and using that (it appears that the metadata for WSI volume datasets in a series are almost completely identical to other WSI volume datasets in the series). We are also using that approach here.

We are using a slightly different approach for displaying the Specimen metadata, but that is something we can always improve upon.

Additionally, the SLIM viewer is finding the first WSI Volume dataset in a whole study, and using that for the metadata for the whole study. We are currently doing it on a series-level, though (we find the first WSI Volume dataset for a series, and use that to set the metadata on the girder item that represents that series).

Here are some examples:

![TCGA-05-4244](https://github.com/girder/large_image/assets/9558430/66b586e3-8586-4b38-af0e-0d5c002ec9dc)

![C3N-01016](https://github.com/girder/large_image/assets/9558430/3047dee5-0814-4931-8766-c7b43ab1da47)

![HTA9_1](https://github.com/girder/large_image/assets/9558430/b6d6c0cb-39b4-4684-a8a9-5f34141c406a)


Fixes: #1314