### PR TITLE
Handle setup_requires deprecation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Use vips resize rather than reduce to increase speed ([#1384](../../pull/1384))
 - Added annotation to geojson endpoint and utility ([#1385](../../pull/1385))
 
+### Changes
+- Handle setup_requires deprecation ([#1390](../../pull/1390))
+
 ### Bug Fixes
 - Fix an issue applying ICC profile adjustments to multiple image modes ([#1382](../../pull/1382))
 - Guard against bad tifffile magnification values ([#1383](../../pull/1383))

--- a/girder/pyproject.toml
+++ b/girder/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/girder/setup.py
+++ b/girder/setup.py
@@ -35,7 +35,6 @@ setup(
     name='girder-large-image',
     use_scm_version={'root': '..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm', 'setuptools-git'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/girder_annotation/pyproject.toml
+++ b/girder_annotation/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/girder_annotation/setup.py
+++ b/girder_annotation/setup.py
@@ -35,7 +35,6 @@ setup(
     name='girder-large-image-annotation',
     use_scm_version={'root': '..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm', 'setuptools-git'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[tool.ruff]
 include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
 exclude = [
     "build",
@@ -56,14 +61,14 @@ select = [
     "RSE",
 ]
 
-[per-file-ignores]
+[tool.ruff.per-file-ignores]
 # allow "useless expressions" as it shows output
 # allow non-top level imports
 # allow long lines
 "docs/large_image_examples.ipynb" = ["B018", "E402", "E501"]
 
-[flake8-quotes]
+[tool.ruff.flake8-quotes]
 inline-quotes = "single"
 
-[mccabe]
+[tool.ruff.mccabe]
 max-complexity = 14

--- a/setup.py
+++ b/setup.py
@@ -84,9 +84,6 @@ setup(
     name='large-image',
     use_scm_version={'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=[
-        'setuptools-scm',
-    ],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/bioformats/pyproject.toml
+++ b/sources/bioformats/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/bioformats/setup.py
+++ b/sources/bioformats/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-bioformats',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/deepzoom/pyproject.toml
+++ b/sources/deepzoom/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/deepzoom/setup.py
+++ b/sources/deepzoom/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-deepzoom',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/dicom/pyproject.toml
+++ b/sources/dicom/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/dicom/setup.py
+++ b/sources/dicom/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-dicom',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/dummy/pyproject.toml
+++ b/sources/dummy/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/dummy/setup.py
+++ b/sources/dummy/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-dummy',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/gdal/pyproject.toml
+++ b/sources/gdal/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/gdal/setup.py
+++ b/sources/gdal/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-gdal',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/mapnik/pyproject.toml
+++ b/sources/mapnik/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/mapnik/setup.py
+++ b/sources/mapnik/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-mapnik',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/multi/pyproject.toml
+++ b/sources/multi/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/multi/setup.py
+++ b/sources/multi/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-multi',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/nd2/pyproject.toml
+++ b/sources/nd2/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/nd2/setup.py
+++ b/sources/nd2/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-nd2',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/ometiff/pyproject.toml
+++ b/sources/ometiff/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/ometiff/setup.py
+++ b/sources/ometiff/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-ometiff',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/openjpeg/pyproject.toml
+++ b/sources/openjpeg/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/openjpeg/setup.py
+++ b/sources/openjpeg/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-openjpeg',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/openslide/pyproject.toml
+++ b/sources/openslide/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/openslide/setup.py
+++ b/sources/openslide/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-openslide',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/pil/pyproject.toml
+++ b/sources/pil/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/pil/setup.py
+++ b/sources/pil/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-pil',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/rasterio/pyproject.toml
+++ b/sources/rasterio/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/rasterio/setup.py
+++ b/sources/rasterio/setup.py
@@ -38,7 +38,6 @@ setup(
         'local_scheme': prerelease_local_scheme,
         'fallback_version': 'development',
     },
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/test/pyproject.toml
+++ b/sources/test/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/test/setup.py
+++ b/sources/test/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-test',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/tiff/pyproject.toml
+++ b/sources/tiff/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/tiff/setup.py
+++ b/sources/tiff/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-tiff',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/tifffile/pyproject.toml
+++ b/sources/tifffile/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/tifffile/setup.py
+++ b/sources/tifffile/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-tifffile',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/vips/pyproject.toml
+++ b/sources/vips/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/vips/setup.py
+++ b/sources/vips/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-vips',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/sources/zarr/pyproject.toml
+++ b/sources/zarr/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/sources/zarr/setup.py
+++ b/sources/zarr/setup.py
@@ -35,7 +35,6 @@ setup(
     name='large-image-source-zarr',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/utilities/converter/pyproject.toml
+++ b/utilities/converter/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/utilities/converter/setup.py
+++ b/utilities/converter/setup.py
@@ -38,7 +38,6 @@ setup(
     name='large-image-converter',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',

--- a/utilities/tasks/pyproject.toml
+++ b/utilities/tasks/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"

--- a/utilities/tasks/setup.py
+++ b/utilities/tasks/setup.py
@@ -38,7 +38,6 @@ setup(
     name='large-image-tasks',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
                      'fallback_version': '0.0.0'},
-    setup_requires=['setuptools-scm'],
     description=description,
     long_description=long_description,
     license='Apache Software License 2.0',


### PR DESCRIPTION
As a future task, we can move all but the main setup.py to just use pyproject.toml.  The main setup.py's attempt to ensure harmonious versions might prevent it being converted.