### PR TITLE
Remove logic for determining transfer syntax

### DIFF
--- a/sources/dicom/large_image_source_dicom/__init__.py
+++ b/sources/dicom/large_image_source_dicom/__init__.py
@@ -189,7 +189,6 @@ class DICOMFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
 
         wsidicom_client = wsidicom.WsiDicomWebClient(client)
 
-
         # Save this for future use
         self._dicomWebClient = client
 

--- a/sources/dicom/large_image_source_dicom/__init__.py
+++ b/sources/dicom/large_image_source_dicom/__init__.py
@@ -15,8 +15,6 @@ from large_image.exceptions import TileSourceError, TileSourceFileNotFoundError
 from large_image.tilesource import FileTileSource
 from large_image.tilesource.utilities import _imageToNumpy, _imageToPIL
 
-from .dicom_tags import dicom_key_to_tag
-
 dicomweb_client = None
 pydicom = None
 wsidicom = None
@@ -191,62 +189,12 @@ class DICOMFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
 
         wsidicom_client = wsidicom.WsiDicomWebClient(client)
 
-        # Identify the transfer syntax
-        transfer_syntax = self._identify_dicomweb_transfer_syntax(client,
-                                                                  study_uid,
-                                                                  series_uid)
 
         # Save this for future use
         self._dicomWebClient = client
 
         # Open the WSI DICOMweb file
-        return wsidicom.WsiDicom.open_web(wsidicom_client, study_uid, series_uid,
-                                          requested_transfer_syntax=transfer_syntax)
-
-    def _identify_dicomweb_transfer_syntax(self, client, study_uid, series_uid):
-        # "client" is a dicomweb_client.DICOMwebClient
-
-        # This is how we select the JPEG type to return
-        # The available transfer syntaxes used by wsidicom may be found here:
-        # https://github.com/imi-bigpicture/wsidicom/blob/a2716cd6a443f4102e66e35bbce32b0e2ae72dab/wsidicom/web/wsidicom_web_client.py#L97-L109
-        # (we may need to update this if they add more options)
-        # FIXME: maybe this function better belongs upstream in `wsidicom`?
-        from pydicom.uid import JPEG2000, JPEG2000Lossless, JPEGBaseline8Bit, JPEGExtended12Bit
-
-        # Prefer the transfer syntaxes in this order.
-        transfer_syntax_preferred_order = [
-            JPEGBaseline8Bit,
-            JPEGExtended12Bit,
-            JPEG2000,
-            JPEG2000Lossless,
-        ]
-        available_transfer_syntax_tag = dicom_key_to_tag('AvailableTransferSyntaxUID')
-
-        # Access the dicom web client, and search for one instance for the given
-        # study and series. Check the available transfer syntaxes.
-        result, = client.search_for_instances(
-            study_uid, series_uid,
-            fields=[available_transfer_syntax_tag], limit=1)
-
-        if available_transfer_syntax_tag in result:
-            available_transfer_syntaxes = result[available_transfer_syntax_tag]['Value']
-            for syntax in transfer_syntax_preferred_order:
-                if syntax in available_transfer_syntaxes:
-                    return syntax
-        else:
-            # The server is not telling us which transfer syntaxes are available.
-            # Print a warning, default to JPEG2000, and hope for the best.
-            self.logger.warning(
-                'DICOMweb server is not communicating the available '
-                'transfer syntaxes. Assuming JPEG2000...',
-            )
-            return JPEG2000
-
-        msg = (
-            'Could not find an appropriate transfer syntax. '
-            f'Available transfer syntaxes are: {available_transfer_syntaxes}'
-        )
-        raise TileSourceError(msg)
+        return wsidicom.WsiDicom.open_web(wsidicom_client, study_uid, series_uid)
 
     def __del__(self):
         # If we have an _unstyledInstance attribute, this is not the owner of

--- a/sources/dicom/setup.py
+++ b/sources/dicom/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from setuptools import find_packages, setup
 
@@ -31,6 +32,21 @@ try:
 except (ImportError, LookupError):
     limit_version = ''
 
+entry_points = {
+    'large_image.source': [
+        'dicom = large_image_source_dicom:DICOMFileTileSource',
+    ],
+    'girder_large_image.source': [
+        'dicom = large_image_source_dicom.girder_source:DICOMGirderTileSource',
+    ],
+}
+
+if sys.version_info >= (3, 9):
+    # For Python >= 3.9, include the DICOMweb plugin
+    entry_points['girder.plugin'] = [
+        'dicomweb = large_image_source_dicom.girder_plugin:DICOMwebPlugin',
+    ]
+
 setup(
     name='large-image-source-dicom',
     use_scm_version={'root': '../..', 'local_scheme': prerelease_local_scheme,
@@ -62,15 +78,5 @@ setup(
     packages=find_packages(exclude=['test', 'test.*', 'test_dicom', 'test_dicom.*']),
     url='https://github.com/girder/large_image',
     python_requires='>=3.8',
-    entry_points={
-        'large_image.source': [
-            'dicom = large_image_source_dicom:DICOMFileTileSource',
-        ],
-        'girder_large_image.source': [
-            'dicom = large_image_source_dicom.girder_source:DICOMGirderTileSource',
-        ],
-        'girder.plugin': [
-            'dicomweb = large_image_source_dicom.girder_plugin:DICOMwebPlugin',
-        ],
-    },
+    entry_points=entry_points,
 )

--- a/sources/dicom/test_dicom/test_web_client.py
+++ b/sources/dicom/test_dicom/test_web_client.py
@@ -1,6 +1,12 @@
 import os
+import sys
 
 import pytest
+
+# We support Python 3.9 and greater for DICOMweb
+pytestmark = [
+    pytest.mark.skipif(sys.version_info < (3, 9), reason='requires python3.9 or higher'),
+]
 
 
 @pytest.mark.girder()

--- a/test/test_source_dicomweb.py
+++ b/test/test_source_dicomweb.py
@@ -1,6 +1,13 @@
+import sys
+
 import pytest
 
 from . import utilities
+
+# We support Python 3.9 and greater for DICOMweb
+pytestmark = [
+    pytest.mark.skipif(sys.version_info < (3, 9), reason='requires python3.9 or higher'),
+]
 
 
 @pytest.mark.plugin('large_image_source_dicom')


### PR DESCRIPTION
wsidicom now determines the transfer syntax automatically, as of version 0.14.0, so we don't need to do this anymore.

wsidicom also supports more transfer syntaxes as well, so the list of transfer syntaxes we had are not complete now either. Just remove this logic and let wsidicom take care of it.

wsidicom now has optional dependencies: imagecodecs and pylibjpeg-rle. If we install those optional dependencies, it adds support for several more transfer syntaxes. Those are found [here](https://github.com/imi-bigpicture/wsidicom#limitations).

Fixes: #1308