### PR TITLE
Frame Selector component: Auto-Range format for saving presets

### DIFF
--- a/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
+++ b/girder/girder_large_image/web_client/vue/components/PresetsMenu.vue
@@ -125,7 +125,7 @@ export default {
                 name: this.newPresetName || this.generatedPresetName,
                 mode: this.currentMode,
                 frame: this.currentFrame,
-                style: this.currentStyle
+                style: {bands: this.currentStyle.bands.map((b) => this.styleToAutoRange(b))}
             };
             newPreset.name = newPreset.name.trim();
             if (!overwrite && this.availablePresets.find((p) => p.name === newPreset.name)) {
@@ -152,6 +152,15 @@ export default {
                 data: JSON.stringify(this.itemPresets),
                 contentType: 'application/json'
             });
+        },
+        styleToAutoRange(band) {
+            band = Object.assign({}, band); // new reference
+            if (band.min && band.min.includes('min:')) {
+                band.autoRange = parseFloat(band.min.replace('min:', '')) * 100;
+                delete band.min;
+                delete band.max;
+            }
+            return band;
         },
         styleFromAutoRange(band) {
             band = Object.assign({}, band); // new reference


### PR DESCRIPTION
Resolves #1394.

There are two ways a band object can express autoRanging:
1. {min: 'min:0.002', max: 'max:0.002'}
2. {autoRange: 0.2}

After #1306, the `currentStyle` passed to `PresetsMenu` will always be in the first format. This PR converts those bands to the second format before saving the preset, since we document the preset specification with `autoRange`.