### PR TITLE
Speed up tile output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Add a utility function for getting loggers ([#1403](../../pull/1403))
 - Get bioformats jar version if bioformats was started ([#1405](../../pull/1405))
 - Improve thread safety of concurrent first reads using bioformats ([#1406](../../pull/1406))
+- Read more metadata from DICOMweb ([#1378](../../pull/1378))
+- Remove logic for determining DICOMweb transfer syntax ([#1393](../../pull/1393))
+- Speed up tile output ([#1407](../../pull/1407))
 
 ### Changes
 - Use an enum for priority constants ([#1400](../../pull/1400))

--- a/large_image/tilesource/tiledict.py
+++ b/large_image/tilesource/tiledict.py
@@ -173,10 +173,11 @@ class LazyTileDict(dict):
             else:
                 tileData = self._retileTile()
 
-            pilData = _imageToPIL(tileData)
-
+            pilData = None
             # resample if needed
             if self.resample not in (False, None) and self.requestedScale:
+                pilData = _imageToPIL(tileData)
+
                 self['width'] = max(1, int(
                     pilData.size[0] / self.requestedScale))
                 self['height'] = max(1, int(
@@ -206,7 +207,7 @@ class LazyTileDict(dict):
                     tileData, _ = _imageToNumpy(tileData)
                     tileFormat = TILE_FORMAT_NUMPY
                 elif TILE_FORMAT_PIL in self.format:
-                    tileData = pilData
+                    tileData = pilData if pilData is not None else _imageToPIL(tileData)
                     tileFormat = TILE_FORMAT_PIL
                 elif TILE_FORMAT_IMAGE in self.format:
                     tileData, mimeType = _encodeImage(
@@ -217,7 +218,7 @@ class LazyTileDict(dict):
                         'Cannot yield tiles in desired format %r' % (
                             self.format, ))
             else:
-                tileData = pilData
+                tileData = pilData if pilData is not None else _imageToPIL(tileData)
                 tileFormat = TILE_FORMAT_PIL
 
             self['tile'] = tileData

--- a/sources/dicom/large_image_source_dicom/dicom_metadata.py
+++ b/sources/dicom/large_image_source_dicom/dicom_metadata.py
@@ -78,7 +78,7 @@ def extract_specimen_metadata(dataset):
         for prep in getattr(specimen, 'SpecimenPreparationSequence', []):
             steps = {}
             for step in getattr(prep, 'SpecimenPreparationStepContentItemSequence', []):
-                # Only extract entires that have both a name and a value
+                # Only extract entries that have both a name and a value
                 if (len(getattr(step, 'ConceptCodeSequence', [])) > 0 and
                         len(getattr(step, 'ConceptNameCodeSequence', [])) > 0):
                     name = step.ConceptNameCodeSequence[0].CodeMeaning

--- a/sources/multi/large_image_source_multi/__init__.py
+++ b/sources/multi/large_image_source_multi/__init__.py
@@ -970,6 +970,7 @@ class MultiFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         x = y = 0
         # If there is no transform or the diagonals are positive and there is
         #   no sheer, use getRegion with an appropriate size (be wary of edges)
+        # TODO: when affine is generalized, only use this if scale is 1
         if (transform is None or
                 transform[0][0] > 0 and transform[0][1] == 0 and
                 transform[1][0] == 0 and transform[1][1] > 0):


### PR DESCRIPTION
Skip a decode step if possible; use simplejpeg for decoding when available and appropriate.