### PR TITLE
Skip dicom web tests for now.

### DIFF
--- a/sources/dicom/test_dicom/test_web_client.py
+++ b/sources/dicom/test_dicom/test_web_client.py
@@ -9,6 +9,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.skip(reason='the remote server we test with is down as of 2023-12-17')
 @pytest.mark.girder()
 @pytest.mark.girder_client()
 @pytest.mark.plugin('large_image')

--- a/test/test_source_dicomweb.py
+++ b/test/test_source_dicomweb.py
@@ -10,6 +10,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.skip(reason='the remote server we test with is down as of 2023-12-17')
 @pytest.mark.plugin('large_image_source_dicom')
 def testTilesFromDICOMweb():
     import large_image_source_dicom


### PR DESCRIPTION
The server we were using for testing is down.

@psavery I'm disabling these for now so I can merge some other PRs.  We can reenable it when it is back or we change the tests.