### PR TITLE
Remove NaN values from band information for JSON serializability

### DIFF
--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -561,7 +561,7 @@ class GDALFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass):
                     if band.GetMaskBand():
                         info['maskband'] = band.GetMaskBand().GetBand() or None
                     # Only keep values that aren't None or the empty string
-                    infoSet[i] = {
+                    infoSet[i + 1] = {
                         k: v for k, v in info.items()
                         if v not in (None, '') and not (
                             isinstance(v, float) and

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -561,7 +561,13 @@ class GDALFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass):
                     if band.GetMaskBand():
                         info['maskband'] = band.GetMaskBand().GetBand() or None
                     # Only keep values that aren't None or the empty string
-                    infoSet[i + 1] = {k: v for k, v in info.items() if v not in (None, '')}
+                    infoSet[i] = {
+                        k: v for k, v in info.items() 
+                        if v not in (None, '') and not (
+                            isinstance(v, float) and
+                            math.isnan(v)
+                        )
+                    }            
             if not cache:
                 return infoSet
             self._bandInfo = infoSet

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -562,12 +562,12 @@ class GDALFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass):
                         info['maskband'] = band.GetMaskBand().GetBand() or None
                     # Only keep values that aren't None or the empty string
                     infoSet[i] = {
-                        k: v for k, v in info.items() 
+                        k: v for k, v in info.items()
                         if v not in (None, '') and not (
                             isinstance(v, float) and
                             math.isnan(v)
                         )
-                    }            
+                    }
             if not cache:
                 return infoSet
             self._bandInfo = infoSet

--- a/sources/rasterio/large_image_source_rasterio/__init__.py
+++ b/sources/rasterio/large_image_source_rasterio/__init__.py
@@ -482,7 +482,7 @@ class RasterioFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass
 
                 # Only keep values that aren't None or the empty string
                 infoSet[i] = {
-                    k: v for k, v in info.items() 
+                    k: v for k, v in info.items()
                     if v not in (None, '') and not (
                         isinstance(v, float) and
                         math.isnan(v)

--- a/sources/rasterio/large_image_source_rasterio/__init__.py
+++ b/sources/rasterio/large_image_source_rasterio/__init__.py
@@ -481,7 +481,13 @@ class RasterioFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass
                 #     info["maskband"] = dataset.mask_flag_enums[i - 1][1].value
 
                 # Only keep values that aren't None or the empty string
-                infoSet[i] = {k: v for k, v in info.items() if v not in (None, '')}
+                infoSet[i] = {
+                    k: v for k, v in info.items() 
+                    if v not in (None, '') and not (
+                        isinstance(v, float) and
+                        math.isnan(v)
+                    )
+                }
 
         # set the value to cache if needed
         if cache:


### PR DESCRIPTION
This PR prevents the occurrence of `ValueError: Out of range float values are not JSON compliant` when using GDAL or rasterio sources.