### PR TITLE
Add DCM4CHEE server for DICOMweb tests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,11 @@ commands:
             # docker run --rm -d -p 127.0.0.1:27017:27017 mongo:5.0 bash -c "mkdir /dev/shm/mongo && mongod --nojournal --dbpath=/dev/shm/mongo --noauth --bind_ip_all"
             docker run --rm -d -p 127.0.0.1:27017:27017 mongo:latest bash -c "mongod --noauth --bind_ip_all"
       - run:
-          name: start dcm4chee (for DICOMweb tests)
+          name: start dcm4chee and upload example data (for DICOMweb tests)
           command: |
             docker-compose -f ./.circleci/dcm4chee/docker-compose.yml up -d
+            pip install dicomweb_client
+            python ./.circleci/dcm4chee/upload_example_data.py
       - run:
           name: start rabbitmq
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,8 @@ commands:
           command: |
             docker-compose -f ./.circleci/dcm4chee/docker-compose.yml up -d
             pip install dicomweb_client
+            # Wait up to 30 seconds for the server if it isn't ready
+            curl --retry 30 -f --retry-all-errors --retry-delay 1 -s -o /dev/null http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs/studies
             python ./.circleci/dcm4chee/upload_example_data.py
       - run:
           name: start rabbitmq

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,11 @@ commands:
           name: start dcm4chee and upload example data (for DICOMweb tests)
           command: |
             docker-compose -f ./.circleci/dcm4chee/docker-compose.yml up -d
+            export DICOMWEB_TEST_URL=http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs
+            echo "export DICOMWEB_TEST_URL=$DICOMWEB_TEST_URL" >> $BASH_ENV
             pip install dicomweb_client
             # Wait up to 30 seconds for the server if it isn't ready
-            curl --retry 30 -f --retry-all-errors --retry-delay 1 -s -o /dev/null http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs/studies
+            curl --retry 30 -f --retry-all-errors --retry-delay 1 -s -o /dev/null $DICOMWEB_TEST_URL/studies
             python ./.circleci/dcm4chee/upload_example_data.py
       - run:
           name: start rabbitmq

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,10 @@ commands:
             # docker run --rm -d -p 127.0.0.1:27017:27017 mongo:5.0 bash -c "mkdir /dev/shm/mongo && mongod --nojournal --dbpath=/dev/shm/mongo --noauth --bind_ip_all"
             docker run --rm -d -p 127.0.0.1:27017:27017 mongo:latest bash -c "mongod --noauth --bind_ip_all"
       - run:
+          name: start dcm4chee (for DICOMweb tests)
+          command: |
+            docker-compose -f ./.circleci/dcm4chee/docker-compose.yml up -d
+      - run:
           name: start rabbitmq
           command: |
             docker run --rm -d -p 5672:5672 rabbitmq

--- a/.circleci/dcm4chee/docker-compose.env
+++ b/.circleci/dcm4chee/docker-compose.env
@@ -1,0 +1,4 @@
+STORAGE_DIR=/storage/fs1
+POSTGRES_DB=pacsdb
+POSTGRES_USER=pacs
+POSTGRES_PASSWORD=pacs

--- a/.circleci/dcm4chee/docker-compose.yml
+++ b/.circleci/dcm4chee/docker-compose.yml
@@ -1,0 +1,51 @@
+version: "3"
+
+volumes:
+  db_data: {}
+  arc_data: {}
+  ldap_data: {}
+  ldap_config: {}
+
+services:
+  ldap:
+    image: dcm4che/slapd-dcm4chee:2.6.0-26.0
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+    expose:
+      - 389
+    env_file: docker-compose.env
+    volumes:
+      - ldap_data:/var/lib/openldap/openldap-data
+      - ldap_config:/etc/openldap/slapd.d
+
+  db:
+    image: dcm4che/postgres-dcm4chee:14.2-26
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+    expose:
+      - 5432
+    env_file: docker-compose.env
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  arc:
+    image: dcm4che/dcm4chee-arc-psql:5.26.0
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+    ports:
+      - "8008:8080"
+    env_file: docker-compose.env
+    environment:
+      WILDFLY_CHOWN: /opt/wildfly/standalone /storage
+      WILDFLY_WAIT_FOR: ldap:389 db:5432
+    depends_on:
+      - ldap
+      - db
+    volumes:
+      - arc_data:/storage

--- a/.circleci/dcm4chee/upload_example_data.py
+++ b/.circleci/dcm4chee/upload_example_data.py
@@ -27,5 +27,10 @@ def upload_example_data(server_url):
 
 
 if __name__ == '__main__':
-    url = 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs'
+    import os
+
+    url = os.getenv('DICOMWEB_TEST_URL')
+    if url is None:
+        raise Exception('DICOMWEB_TEST_URL must be set')
+
     upload_example_data(url)

--- a/.circleci/dcm4chee/upload_example_data.py
+++ b/.circleci/dcm4chee/upload_example_data.py
@@ -10,11 +10,15 @@ from pydicom import dcmread
 def upload_example_data(server_url):
 
     # This is TCGA-AA-3697
-    download_urls = [
-        'https://data.kitware.com/api/v1/file/6594790e9c30d6f4e17c9d0d/download',
-        'https://data.kitware.com/api/v1/file/6594790f9c30d6f4e17c9d10/download',
-        'https://data.kitware.com/api/v1/file/6594790d9c30d6f4e17c9d0a/download',
+    sha512s = [
+        '48cb562b94d0daf4060abd9eef150c851d3509d9abbff4bea11d00832955720bf1941073a51e6fb68fb5cc23704dec2659fc0c02360a8ac753dc523dca2c8c36', # noqa
+        '36432183380eb7d44417a2210a19d550527abd1181255e19ed5c1d17695d8bb8ca42f5b426a63fa73b84e0e17b770401a377ae0c705d0ed7fdf30d571ef60e2d', # noqa
+        '99bd3da4b8e11ce7b4f7ed8a294ed0c37437320667a06c40c383f4b29be85fe8e6094043e0600bee0ba879f2401de4c57285800a4a23da2caf2eb94e5b847ee0', # noqa
     ]
+    download_urls = [
+        f'https://data.kitware.com/api/v1/file/hashsum/sha512/{x}/download' for x in sha512s
+    ]
+
     datasets = []
     for url in download_urls:
         resp = urllib.request.urlopen(url)

--- a/.circleci/dcm4chee/upload_example_data.py
+++ b/.circleci/dcm4chee/upload_example_data.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+import urllib.request
+from io import BytesIO
+
+from dicomweb_client import DICOMwebClient
+from pydicom import dcmread
+
+
+def upload_example_data(server_url):
+
+    download_urls = [
+        # 'https://data.kitware.com/api/v1/file/65933ddb9c30d6f4e17c9ca1/download',
+        # 'https://data.kitware.com/api/v1/file/65933dd09c30d6f4e17c9c9e/download',
+
+        # This is the lowest resolution
+        'https://data.kitware.com/api/v1/file/65933ddd9c30d6f4e17c9ca4/download',
+    ]
+    datasets = []
+    for url in download_urls:
+        resp = urllib.request.urlopen(url)
+        data = resp.read()
+        dataset = dcmread(BytesIO(data))
+        datasets.append(dataset)
+
+    client = DICOMwebClient(server_url)
+    client.store_instances(datasets)
+
+
+if __name__ == '__main__':
+    url = 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs'
+    upload_example_data(url)

--- a/.circleci/dcm4chee/upload_example_data.py
+++ b/.circleci/dcm4chee/upload_example_data.py
@@ -9,12 +9,11 @@ from pydicom import dcmread
 
 def upload_example_data(server_url):
 
+    # This is TCGA-AA-3697
     download_urls = [
-        # 'https://data.kitware.com/api/v1/file/65933ddb9c30d6f4e17c9ca1/download',
-        # 'https://data.kitware.com/api/v1/file/65933dd09c30d6f4e17c9c9e/download',
-
-        # This is the lowest resolution
-        'https://data.kitware.com/api/v1/file/65933ddd9c30d6f4e17c9ca4/download',
+        'https://data.kitware.com/api/v1/file/6594790e9c30d6f4e17c9d0d/download',
+        'https://data.kitware.com/api/v1/file/6594790f9c30d6f4e17c9d10/download',
+        'https://data.kitware.com/api/v1/file/6594790d9c30d6f4e17c9d0a/download',
     ]
     datasets = []
     for url in download_urls:

--- a/sources/dicom/test_dicom/test_web_client.py
+++ b/sources/dicom/test_dicom/test_web_client.py
@@ -9,7 +9,6 @@ pytestmark = [
 ]
 
 
-@pytest.mark.skip(reason='the remote server we test with is down as of 2023-12-17')
 @pytest.mark.girder()
 @pytest.mark.girder_client()
 @pytest.mark.plugin('large_image')

--- a/sources/dicom/test_dicom/test_web_client.py
+++ b/sources/dicom/test_dicom/test_web_client.py
@@ -6,6 +6,8 @@ import pytest
 # We support Python 3.9 and greater for DICOMweb
 pytestmark = [
     pytest.mark.skipif(sys.version_info < (3, 9), reason='requires python3.9 or higher'),
+    pytest.mark.skipif(os.getenv('DICOMWEB_TEST_URL') is None,
+                       reason='DICOMWEB_TEST_URL is not set'),
 ]
 
 

--- a/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
+++ b/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
@@ -1,3 +1,6 @@
+// These will be replaced by templating
+const url = DICOMWEB_TEST_URL;
+
 girderTest.importPlugin('jobs', 'large_image', 'dicomweb');
 
 girderTest.startApp();
@@ -40,7 +43,7 @@ describe('DICOMWeb assetstore', function () {
         runs(function () {
             // Create the DICOMweb assetstore
             $('#g-new-dwas-name').val('DICOMweb');
-            $('#g-new-dwas-url').val(process.env.DICOMWEB_TEST_URL);
+            $('#g-new-dwas-url').val(url);
 
             // Test error for setting auth type to "token" with no token
             $('#g-new-dwas-auth-type').val('token');

--- a/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
+++ b/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
@@ -15,7 +15,7 @@ describe('DICOMWeb assetstore', function () {
         var destinationType;
 
         // After importing, we will verify that this item exists
-        const verifyItemName = '1.3.6.1.4.1.5962.99.1.3510881361.982628633.1635598486609.2.0';
+        const verifyItemName = '1.3.6.1.4.1.5962.99.1.3205815762.381594633.1639588388306.2.0';
 
         runs(function () {
             $('a.g-nav-link[g-target="admin"]').trigger('click');

--- a/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
+++ b/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
@@ -40,7 +40,7 @@ describe('DICOMWeb assetstore', function () {
         runs(function () {
             // Create the DICOMweb assetstore
             $('#g-new-dwas-name').val('DICOMweb');
-            $('#g-new-dwas-url').val('https://idc-external-006.uc.r.appspot.com/dcm4chee-arc/aets/DCM4CHEE/rs');
+            $('#g-new-dwas-url').val('http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs');
 
             // Test error for setting auth type to "token" with no token
             $('#g-new-dwas-auth-type').val('token');

--- a/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
+++ b/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
@@ -40,7 +40,7 @@ describe('DICOMWeb assetstore', function () {
         runs(function () {
             // Create the DICOMweb assetstore
             $('#g-new-dwas-name').val('DICOMweb');
-            $('#g-new-dwas-url').val('http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs');
+            $('#g-new-dwas-url').val(process.env.DICOMWEB_TEST_URL);
 
             // Test error for setting auth type to "token" with no token
             $('#g-new-dwas-auth-type').val('token');

--- a/test/test_source_dicomweb.py
+++ b/test/test_source_dicomweb.py
@@ -16,8 +16,8 @@ def testTilesFromDICOMweb():
 
     dicomweb_file = {
         'url': 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs',
-        'study_uid': '2.25.18199272949575141157802058345697568861',
-        'series_uid': '1.3.6.1.4.1.5962.99.1.3510881361.982628633.1635598486609.2.0',
+        'study_uid': '2.25.25644321580420796312527343668921514374',
+        'series_uid': '1.3.6.1.4.1.5962.99.1.3205815762.381594633.1639588388306.2.0',
     }
 
     source = large_image_source_dicom.open(dicomweb_file)
@@ -25,12 +25,12 @@ def testTilesFromDICOMweb():
 
     assert tileMetadata['tileWidth'] == 256
     assert tileMetadata['tileHeight'] == 256
-    assert tileMetadata['sizeX'] == 2896
-    assert tileMetadata['sizeY'] == 2768
-    assert tileMetadata['levels'] == 5
+    assert tileMetadata['sizeX'] == 7081
+    assert tileMetadata['sizeY'] == 10000
+    assert tileMetadata['levels'] == 7
 
     utilities.checkTilesZXY(source, tileMetadata)
 
     # Verify that the internal metadata is working too
     internalMetadata = source.getInternalMetadata()
-    assert internalMetadata['dicom_meta']['Specimens'][0]['Anatomical Structure'] == 'Lung'
+    assert internalMetadata['dicom_meta']['Specimens'][0]['Anatomical Structure'] == 'Colon'

--- a/test/test_source_dicomweb.py
+++ b/test/test_source_dicomweb.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 import pytest
@@ -7,6 +8,8 @@ from . import utilities
 # We support Python 3.9 and greater for DICOMweb
 pytestmark = [
     pytest.mark.skipif(sys.version_info < (3, 9), reason='requires python3.9 or higher'),
+    pytest.mark.skipif(os.getenv('DICOMWEB_TEST_URL') is None,
+                       reason='DICOMWEB_TEST_URL is not set'),
 ]
 
 
@@ -15,12 +18,13 @@ def testTilesFromDICOMweb():
     import large_image_source_dicom
 
     dicomweb_file = {
-        'url': 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs',
+        'url': os.environ['DICOMWEB_TEST_URL'],
         'study_uid': '2.25.25644321580420796312527343668921514374',
         'series_uid': '1.3.6.1.4.1.5962.99.1.3205815762.381594633.1639588388306.2.0',
     }
 
     source = large_image_source_dicom.open(dicomweb_file)
+
     tileMetadata = source.getMetadata()
 
     assert tileMetadata['tileWidth'] == 256

--- a/test/test_source_dicomweb.py
+++ b/test/test_source_dicomweb.py
@@ -10,17 +10,46 @@ pytestmark = [
 ]
 
 
-@pytest.mark.skip(reason='the remote server we test with is down as of 2023-12-17')
+def upload_test_files(server_url):
+    import urllib.request
+    from io import BytesIO
+
+    from dicomweb_client import DICOMwebClient
+    from pydicom import dcmread
+
+    urls = [
+        # 'https://data.kitware.com/api/v1/file/65933ddb9c30d6f4e17c9ca1/download',
+        # 'https://data.kitware.com/api/v1/file/65933dd09c30d6f4e17c9c9e/download',
+
+        # This is the lowest resolution
+        'https://data.kitware.com/api/v1/file/65933ddd9c30d6f4e17c9ca4/download',
+    ]
+    datasets = []
+    for url in urls:
+        resp = urllib.request.urlopen(url)
+        data = resp.read()
+        dataset = dcmread(BytesIO(data))
+        datasets.append(dataset)
+
+    client = DICOMwebClient(server_url)
+    client.store_instances(datasets)
+
+
 @pytest.mark.plugin('large_image_source_dicom')
 def testTilesFromDICOMweb():
     import large_image_source_dicom
 
-    # Hopefully this URL and file will work for a long time. But we might need
-    # to update it at some point.
+    url = 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs'
+    study_uid = '2.25.18199272949575141157802058345697568861'
+    series_uid = '1.3.6.1.4.1.5962.99.1.3510881361.982628633.1635598486609.2.0'
+
+    # Make sure our test files are uploaded
+    upload_test_files(url)
+
     dicomweb_file = {
-        'url': 'https://idc-external-006.uc.r.appspot.com/dcm4chee-arc/aets/DCM4CHEE/rs',
-        'study_uid': '2.25.18199272949575141157802058345697568861',
-        'series_uid': '1.3.6.1.4.1.5962.99.1.3510881361.982628633.1635598486609.2.0',
+        'url': url,
+        'study_uid': study_uid,
+        'series_uid': series_uid,
     }
 
     source = large_image_source_dicom.open(dicomweb_file)
@@ -28,9 +57,9 @@ def testTilesFromDICOMweb():
 
     assert tileMetadata['tileWidth'] == 256
     assert tileMetadata['tileHeight'] == 256
-    assert tileMetadata['sizeX'] == 46336
-    assert tileMetadata['sizeY'] == 44288
-    assert tileMetadata['levels'] == 9
+    assert tileMetadata['sizeX'] == 2896
+    assert tileMetadata['sizeY'] == 2768
+    assert tileMetadata['levels'] == 5
 
     utilities.checkTilesZXY(source, tileMetadata)
 

--- a/test/test_source_dicomweb.py
+++ b/test/test_source_dicomweb.py
@@ -10,46 +10,14 @@ pytestmark = [
 ]
 
 
-def upload_test_files(server_url):
-    import urllib.request
-    from io import BytesIO
-
-    from dicomweb_client import DICOMwebClient
-    from pydicom import dcmread
-
-    urls = [
-        # 'https://data.kitware.com/api/v1/file/65933ddb9c30d6f4e17c9ca1/download',
-        # 'https://data.kitware.com/api/v1/file/65933dd09c30d6f4e17c9c9e/download',
-
-        # This is the lowest resolution
-        'https://data.kitware.com/api/v1/file/65933ddd9c30d6f4e17c9ca4/download',
-    ]
-    datasets = []
-    for url in urls:
-        resp = urllib.request.urlopen(url)
-        data = resp.read()
-        dataset = dcmread(BytesIO(data))
-        datasets.append(dataset)
-
-    client = DICOMwebClient(server_url)
-    client.store_instances(datasets)
-
-
 @pytest.mark.plugin('large_image_source_dicom')
 def testTilesFromDICOMweb():
     import large_image_source_dicom
 
-    url = 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs'
-    study_uid = '2.25.18199272949575141157802058345697568861'
-    series_uid = '1.3.6.1.4.1.5962.99.1.3510881361.982628633.1635598486609.2.0'
-
-    # Make sure our test files are uploaded
-    upload_test_files(url)
-
     dicomweb_file = {
-        'url': url,
-        'study_uid': study_uid,
-        'series_uid': series_uid,
+        'url': 'http://localhost:8008/dcm4chee-arc/aets/DCM4CHEE/rs',
+        'study_uid': '2.25.18199272949575141157802058345697568861',
+        'series_uid': '1.3.6.1.4.1.5962.99.1.3510881361.982628633.1635598486609.2.0',
     }
 
     source = large_image_source_dicom.open(dicomweb_file)

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ skip_missing_interpreters = true
 toxworkdir = {toxinidir}/build/tox
 
 [testenv]
-passenv = PYTEST_*
+passenv = PYTEST_*,DICOMWEB_TEST_URL
 extras =
   memcached
   performance


### PR DESCRIPTION
In CircleCI, this PR spins up a local DCM4CHEE server and uploads example DICOM files to it. This server is then used for the DICOMweb tests.

~~This is almost working. The DICOMweb tests are still skipped, and I need to get the `DICOMWEB_TEST_URL` environment variable to propagate to the pytests...~~

~~The `DICOMWEB_TEST_URL` is now being passed via tox's `passenv`. However, I still need to access the environment variable in the JavaScript test. I tried to do so via `process.env`, but it is apparently not there...~~

We made the JavaScript spec file into a simple template and inserted the `DICOMWEB_TEST_URL` into it before running it.

This is ready!