### PR TITLE
Add support for downloading DICOMweb files

### DIFF
--- a/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
@@ -356,7 +356,7 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
                     reuseExisting=True,
                     assetstore=self.assetstore,
                     mimeType='application/dicom',
-                    size=0,
+                    size=None,
                     saveFile=False,
                 )
                 file['dicom_uids'] = {

--- a/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
@@ -218,8 +218,8 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
             for chunk in iterator:
                 if b'\r\n\r\n' in chunk:
                     idx = chunk.index(b'\r\n\r\n')
-                    # Yield the first section of data
-                    yield chunk[idx + 4:]
+                    # Save the first section of data. We will yield it later.
+                    prev_chunk = chunk[idx + 4:]
                     header_found = True
                     break
 
@@ -229,7 +229,7 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
 
             # Now the header has been finished. Stream the data until
             # we encounter the ending boundary or finish the data.
-            prev_chunk = b''
+            # The "prev_chunk" will start out set to the section right after the header.
             for chunk in iterator:
                 # Ensure the chunk is large enough to contain the whole ending, so
                 # we can be sure the ending won't be split across 3 or more chunks.

--- a/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
@@ -132,6 +132,12 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
                 'Accept': '; '.join(accept_parts),
             }
 
+            if offset != 0 or endByte is not None:
+                # Attempt to make a range request (although all DICOMweb
+                # servers we have seen do not honor it)
+                end_str = '' if endByte is None else endByte
+                headers['Range'] = f'bytes={offset}-{end_str}'
+
             response = client._http_get(url, headers=headers)
             for part in client._decode_multipart_message(response, False):
                 yield part

--- a/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
@@ -120,7 +120,7 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
                 _Transaction.RETRIEVE,
                 study_uid,
                 series_uid,
-                instance_uid
+                instance_uid,
             )
 
             # Build the headers

--- a/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
@@ -105,10 +105,10 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
     def downloadFile(self, file, offset=0, headers=True, endByte=None,
                      contentDisposition=None, extraParameters=None, **kwargs):
 
-        dicomweb_meta = file['dicomweb_meta']
-        study_uid = dicomweb_meta['study_uid']
-        series_uid = dicomweb_meta['series_uid']
-        instance_uid = dicomweb_meta['instance_uid']
+        dicom_uids = file['dicom_uids']
+        study_uid = dicom_uids['study_uid']
+        series_uid = dicom_uids['series_uid']
+        instance_uid = dicom_uids['instance_uid']
 
         client = _create_dicomweb_client(self.assetstore_meta)
 
@@ -219,6 +219,10 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
 
             # Set the DICOMweb metadata
             item['dicomweb_meta'] = get_dicomweb_metadata(client, study_uid, series_uid)
+            item['dicom_uids'] = {
+                'study_uid': study_uid,
+                'series_uid': series_uid,
+            }
             item = Item().save(item)
 
             instance_results = client.search_for_instances(study_uid, series_uid)
@@ -235,7 +239,7 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
                     size=0,
                     saveFile=False,
                 )
-                file['dicomweb_meta'] = {
+                file['dicom_uids'] = {
                     'study_uid': study_uid,
                     'series_uid': series_uid,
                     'instance_uid': instance_uid,

--- a/sources/dicom/large_image_source_dicom/girder_source.py
+++ b/sources/dicom/large_image_source_dicom/girder_source.py
@@ -59,15 +59,14 @@ class DICOMGirderTileSource(DICOMFileTileSource, GirderTileSource):
 
     def _getDICOMwebLargeImagePath(self, assetstore):
         meta = assetstore[DICOMWEB_META_KEY]
-        file = Item().childFiles(self.item, limit=1)[0]
-        file_meta = file['dicomweb_meta']
+        item_uids = self.item['dicom_uids']
 
         adapter = assetstore_utilities.getAssetstoreAdapter(assetstore)
 
         return {
             'url': meta['url'],
-            'study_uid': file_meta['study_uid'],
-            'series_uid': file_meta['series_uid'],
+            'study_uid': item_uids['study_uid'],
+            'series_uid': item_uids['series_uid'],
             # The following are optional
             'qido_prefix': meta.get('qido_prefix'),
             'wado_prefix': meta.get('wado_prefix'),

--- a/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
+++ b/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
@@ -16,6 +16,7 @@ describe('DICOMWeb assetstore', function () {
     it('Create an assetstore and import data', function () {
         var destinationId;
         var destinationType;
+        var itemId;
 
         // After importing, we will verify that this item exists
         const verifyItemName = '1.3.6.1.4.1.5962.99.1.3205815762.381594633.1639588388306.2.0';
@@ -195,7 +196,23 @@ describe('DICOMWeb assetstore', function () {
                 }
             }).responseJSON.item;
 
-            return items.length > 0 && items[0].largeImage !== undefined;
+            if (items.length === 0 || items[0].largeImage === undefined) {
+                return false;
+            }
+
+            // Save the itemId
+            itemId = items[0]['_id'];
+            return true
         }, 'Wait for large images to be present');
+
+        // Verify that we can download the item
+        waitsFor(function () {
+            const resp = girder.rest.restRequest({
+                url: 'item/' + itemId + '/download',
+                type: 'GET',
+                async: false,
+            });
+            return resp.status === 200;
+        }, 'Wait to download the DICOM files');
     });
 });

--- a/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
+++ b/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
@@ -13,10 +13,12 @@ describe('DICOMWeb assetstore', function () {
             'Admin',
             'Admin',
             'adminpassword!'));
+
     it('Create an assetstore and import data', function () {
         var destinationId;
         var destinationType;
         var itemId;
+        var fileId;
 
         // After importing, we will verify that this item exists
         const verifyItemName = '1.3.6.1.4.1.5962.99.1.3205815762.381594633.1639588388306.2.0';
@@ -200,8 +202,9 @@ describe('DICOMWeb assetstore', function () {
                 return false;
             }
 
-            // Save the itemId
+            // Save the itemId, and the file id
             itemId = items[0]['_id'];
+            fileId = items[0].largeImage.fileId;
             return true
         }, 'Wait for large images to be present');
 
@@ -212,7 +215,21 @@ describe('DICOMWeb assetstore', function () {
                 type: 'GET',
                 async: false,
             });
-            return resp.status === 200;
-        }, 'Wait to download the DICOM files');
+
+            // Should be larger than 10 million bytes
+            return resp.status === 200 && resp.responseText.length > 10000000;
+        }, 'Wait to download all DICOM files in the item');
+
+        // Verify that we can download a single file
+        waitsFor(function () {
+            const resp = girder.rest.restRequest({
+                url: 'file/' + fileId + '/download',
+                type: 'GET',
+                async: false,
+            });
+
+            // Should be larger than 500k bytes
+            return resp.status === 200 && resp.responseText.length > 500000;
+        }, 'Wait to download a single DICOM file');
     });
 });


### PR DESCRIPTION
Each girder item represents a series. Previously, each item would contain a single file with the same name.

Now, each instance (DICOM file) within a series is represented by separate girder files within the item.

This PR includes download support, so individual DICOM files can be downloaded, or all DICOM files in a series can be downloaded together by downloading the girder item.

Range requests for the DICOM files are attempted if requested. However, the DICOMweb standard doesn't guarantee that they will be supported, and none of the DICOMweb servers we have tried have supported range requests for DICOM files.

To do:

- [x] Figure out why downloading the file has the wrong mimetype (which results in the web browser displaying the contents rather than downloading)

Fixes: #1309