### PR TITLE
Start adding types using monkeytype.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,6 +226,13 @@ jobs:
           path: build/tox/compare.txt
       - store_artifacts:
           path: build/tox/compare.yaml
+  type:
+    executor: toxandnode
+    resource_class: large
+    steps:
+      - checkout
+      - tox:
+          env: type
   wheels:
     executor: toxandnode
     steps:
@@ -333,6 +340,13 @@ workflows:
             branches:
               ignore:
                 - gh-pages
+      - type:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore:
+                - gh-pages
       - compare:
           filters:
             tags:
@@ -355,6 +369,7 @@ workflows:
             - py311
             - py312
             - lint_and_docs
+            - type
             - wheels
           filters:
             tags:
@@ -369,6 +384,7 @@ workflows:
             - py311
             - py312
             - lint_and_docs
+            - type
             - wheels
           filters:
             tags:
@@ -393,5 +409,6 @@ workflows:
       - py311
       - py312
       - lint_and_docs
+      - type
       - compare
       - wheels

--- a/.circleci/dcm4chee/upload_example_data.py
+++ b/.circleci/dcm4chee/upload_example_data.py
@@ -11,9 +11,9 @@ def upload_example_data(server_url):
 
     # This is TCGA-AA-3697
     sha512s = [
-        '48cb562b94d0daf4060abd9eef150c851d3509d9abbff4bea11d00832955720bf1941073a51e6fb68fb5cc23704dec2659fc0c02360a8ac753dc523dca2c8c36', # noqa
-        '36432183380eb7d44417a2210a19d550527abd1181255e19ed5c1d17695d8bb8ca42f5b426a63fa73b84e0e17b770401a377ae0c705d0ed7fdf30d571ef60e2d', # noqa
-        '99bd3da4b8e11ce7b4f7ed8a294ed0c37437320667a06c40c383f4b29be85fe8e6094043e0600bee0ba879f2401de4c57285800a4a23da2caf2eb94e5b847ee0', # noqa
+        '48cb562b94d0daf4060abd9eef150c851d3509d9abbff4bea11d00832955720bf1941073a51e6fb68fb5cc23704dec2659fc0c02360a8ac753dc523dca2c8c36',  # noqa
+        '36432183380eb7d44417a2210a19d550527abd1181255e19ed5c1d17695d8bb8ca42f5b426a63fa73b84e0e17b770401a377ae0c705d0ed7fdf30d571ef60e2d',  # noqa
+        '99bd3da4b8e11ce7b4f7ed8a294ed0c37437320667a06c40c383f4b29be85fe8e6094043e0600bee0ba879f2401de4c57285800a4a23da2caf2eb94e5b847ee0',  # noqa
     ]
     download_urls = [
         f'https://data.kitware.com/api/v1/file/hashsum/sha512/{x}/download' for x in sha512s
@@ -35,6 +35,7 @@ if __name__ == '__main__':
 
     url = os.getenv('DICOMWEB_TEST_URL')
     if url is None:
-        raise Exception('DICOMWEB_TEST_URL must be set')
+        msg = 'DICOMWEB_TEST_URL must be set'
+        raise Exception(msg)
 
     upload_example_data(url)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Optimizing when reading arrays rather than images from tiff files ([#1423](../../pull/1423))
 - Better filter DICOM adjacent files to ensure they share series instance IDs ([#1424](../../pull/1424))
 - Optimizing small getRegion calls and some tiff tile fetches ([#1427](../../pull/1427)
+- Started adding python types to the core library ([#1430](../../pull/1430)
 
 ### Changed
 - Cleanup some places where get was needlessly used ([#1428](../../pull/1428)

--- a/large_image/config.py
+++ b/large_image/config.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 import re
-from typing import cast
+from typing import Any, Optional, Union, cast
 
 from . import exceptions
 
@@ -59,7 +59,8 @@ ConfigValues = {
 }
 
 
-def getConfig(key=None, default=None):
+def getConfig(key: Optional[str] = None,
+              default: Optional[Union[str, bool, int, logging.Logger]] = None) -> Any:
     """
     Get the config dictionary or a value from the cache config settings.
 
@@ -83,7 +84,8 @@ def getConfig(key=None, default=None):
     return ConfigValues.get(key, default)
 
 
-def getLogger(key=None, default=None):
+def getLogger(key: Optional[str] = None,
+              default: Optional[logging.Logger] = None) -> logging.Logger:
     """
     Get a logger from the config.  Ensure that it is a valid logger.
 
@@ -97,7 +99,7 @@ def getLogger(key=None, default=None):
     return logger
 
 
-def setConfig(key, value):
+def setConfig(key: str, value: Optional[Union[str, bool, int, logging.Logger]]) -> None:
     """
     Set a value in the config settings.
 

--- a/large_image/exceptions.py
+++ b/large_image/exceptions.py
@@ -22,7 +22,7 @@ class TileSourceInefficientError(TileSourceError):
 
 
 class TileSourceFileNotFoundError(TileSourceError, FileNotFoundError):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         return super().__init__(errno.ENOENT, *args, **kwargs)
 
 

--- a/large_image/tilesource/__init__.py
+++ b/large_image/tilesource/__init__.py
@@ -2,6 +2,8 @@ import os
 import re
 import uuid
 from importlib.metadata import entry_points
+from pathlib import PosixPath
+from typing import Dict, List, Optional, Tuple, Type, Union
 
 from .. import config
 from ..constants import NEW_IMAGE_PATH_FLAG, SourcePriority
@@ -13,10 +15,10 @@ from .base import (TILE_FORMAT_IMAGE, TILE_FORMAT_NUMPY, TILE_FORMAT_PIL,
                    FileTileSource, TileOutputMimeTypes, TileSource,
                    dictToEtree, etreeToDict, nearPowerOfTwo)
 
-AvailableTileSources = {}
+AvailableTileSources: Dict[str, Type[FileTileSource]] = {}
 
 
-def isGeospatial(path):
+def isGeospatial(path: Union[str, PosixPath]) -> bool:
     """
     Check if a path is likely to be a geospatial file.
 
@@ -38,7 +40,8 @@ def isGeospatial(path):
     return False
 
 
-def loadTileSources(entryPointName='large_image.source', sourceDict=AvailableTileSources):
+def loadTileSources(entryPointName: str = 'large_image.source',
+                    sourceDict: Dict[str, Type[FileTileSource]] = AvailableTileSources) -> None:
     """
     Load all tilesources from entrypoints and add them to the
     AvailableTileSources dictionary.
@@ -61,7 +64,10 @@ def loadTileSources(entryPointName='large_image.source', sourceDict=AvailableTil
                 'Failed to loaded tile source %s' % entryPoint.name)
 
 
-def getSortedSourceList(availableSources, pathOrUri, mimeType=None, *args, **kwargs):
+def getSortedSourceList(
+    availableSources: Dict[str, Type[FileTileSource]], pathOrUri: Union[str, PosixPath],
+    mimeType: Optional[str] = None, *args, **kwargs,
+) -> List[Tuple[bool, bool, SourcePriority, str]]:
     """
     Get an ordered list of sources where earlier sources are more likely to
     work for a specified path or uri.
@@ -108,7 +114,9 @@ def getSortedSourceList(availableSources, pathOrUri, mimeType=None, *args, **kwa
     return sourceList
 
 
-def getSourceNameFromDict(availableSources, pathOrUri, mimeType=None, *args, **kwargs):
+def getSourceNameFromDict(
+        availableSources: Dict[str, Type[FileTileSource]], pathOrUri: Union[str, PosixPath],
+        mimeType: Optional[str] = None, *args, **kwargs) -> Optional[str]:
     """
     Get a tile source based on a ordered dictionary of known sources and a path
     name or URI.  Additional parameters are passed to the tile source and can
@@ -125,9 +133,12 @@ def getSourceNameFromDict(availableSources, pathOrUri, mimeType=None, *args, **k
     for _clash, _fallback, _priority, sourceName in sorted(sourceList):
         if availableSources[sourceName].canRead(pathOrUri, *args, **kwargs):
             return sourceName
+    return None
 
 
-def getTileSourceFromDict(availableSources, pathOrUri, *args, **kwargs):
+def getTileSourceFromDict(
+        availableSources: Dict[str, Type[FileTileSource]], pathOrUri: Union[str, PosixPath],
+        *args, **kwargs) -> FileTileSource:
     """
     Get a tile source based on a ordered dictionary of known sources and a path
     name or URI.  Additional parameters are passed to the tile source and can
@@ -146,7 +157,7 @@ def getTileSourceFromDict(availableSources, pathOrUri, *args, **kwargs):
     raise TileSourceError('No available tilesource for %s' % pathOrUri)
 
 
-def getTileSource(*args, **kwargs):
+def getTileSource(*args, **kwargs) -> FileTileSource:
     """
     Get a tilesource using the known sources.  If tile sources have not yet
     been loaded, load them.
@@ -158,7 +169,7 @@ def getTileSource(*args, **kwargs):
     return getTileSourceFromDict(AvailableTileSources, *args, **kwargs)
 
 
-def open(*args, **kwargs):
+def open(*args, **kwargs) -> FileTileSource:
     """
     Alternate name of getTileSource.
 
@@ -170,7 +181,7 @@ def open(*args, **kwargs):
     return getTileSource(*args, **kwargs)
 
 
-def canRead(*args, **kwargs):
+def canRead(*args, **kwargs) -> bool:
     """
     Check if large_image can read a path or uri.
 
@@ -187,7 +198,9 @@ def canRead(*args, **kwargs):
     return False
 
 
-def canReadList(pathOrUri, mimeType=None, *args, **kwargs):
+def canReadList(
+        pathOrUri: Union[str, PosixPath], mimeType: Optional[str] = None,
+        *args, **kwargs) -> List[Tuple[str, bool]]:
     """
     Check if large_image can read a path or uri via each source.
 
@@ -210,7 +223,7 @@ def canReadList(pathOrUri, mimeType=None, *args, **kwargs):
     return result
 
 
-def new(*args, **kwargs):
+def new(*args, **kwargs) -> TileSource:
     """
     Create a new image.
 

--- a/sources/dicom/large_image_source_dicom/__init__.py
+++ b/sources/dicom/large_image_source_dicom/__init__.py
@@ -265,6 +265,8 @@ class DICOMFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             mm_y = self._dicom.levels[0].pixel_spacing.height or None
         except Exception:
             pass
+        mm_x = float(mm_x) if mm_x else None
+        mm_y = float(mm_y) if mm_y else None
         # Estimate the magnification; we don't have a direct value
         mag = 0.01 / mm_x if mm_x else None
         return {

--- a/sources/dicom/test_dicom/test_web_client.py
+++ b/sources/dicom/test_dicom/test_web_client.py
@@ -22,7 +22,7 @@ def testDICOMWebClient(boundServer, fsAssetstore, db):
     spec = os.path.join(os.path.dirname(__file__), 'web_client_specs', 'dicomWebSpec.js')
 
     # Replace the template variables
-    with open(spec, 'r') as rf:
+    with open(spec) as rf:
         data = rf.read()
 
     dicomweb_test_url = os.environ['DICOMWEB_TEST_URL']

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
   docs
   lint
   lintclient
+  type
   notebook
 skip_missing_interpreters = true
 toxworkdir = {toxinidir}/build/tox
@@ -71,6 +72,41 @@ allowlist_externals = {[testenv:test]allowlist_externals}
 commands = {[testenv:test]commands}
 setenv = {[testenv:test]setenv}
 
+[testenv:monkeytype-py{37,38,39,310,311,312}]
+passenv = {[testenv:test]passenv}
+deps =
+  -rrequirements-dev.txt
+  coverage
+  mock
+  pooch
+  pymongo<4
+  pytest>=3.6
+  pytest-cov>=2.6
+  pytest-custom-exit-code
+  pytest-girder>=3.1.25.dev9
+  pytest-monkeytype
+  pytest-rerunfailures
+  pytest-xdist
+allowlist_externals = {[testenv:test]allowlist_externals}
+commands =
+  rm -rf build/test/coverage/web_temp
+  girder build --dev
+  pytest --numprocesses 0 -m 'not notebook' --no-cov --suppress-no-test-exit-code --monkeytype-output=./monkeytype.sqlite3 {posargs}
+  - npx nyc report --temp-dir build/test/coverage/web_temp --report-dir build/test/coverage --reporter cobertura --reporter text-summary
+# After running tox, you can do
+# build/tox/monkeytype-py311/bin/monkeytype list-modules
+# and apply the results via
+# build/tox/monkeytype-py311/bin/monkeytype apply <module>
+setenv =
+  NPM_CONFIG_FUND=false
+  NPM_CONFIG_AUDIT=false
+  NPM_CONFIG_AUDIT_LEVEL=high
+  NPM_CONFIG_LOGLEVEL=warn
+  NPM_CONFIG_PROGRESS=false
+  NPM_CONFIG_PREFER_OFFLINE=true
+  PIP_FIND_LINKS=https://girder.github.io/large_image_wheels
+  GDAL_PAM_ENABLED=no
+
 [testenv:server]
 description = Run all tests except Girder client
 deps = {[testenv:test]deps}
@@ -137,6 +173,23 @@ deps =
 commands =
   ruff large_image sources utilities girder girder_annotation examples docs test
   flake8
+
+[testenv:type]
+description = Check python types
+skipsdist = true
+deps =
+  -rrequirements-dev.txt
+  mypy
+  types-pillow
+  types-psutil
+commands =
+  mypy --config-file tox.ini {posargs}
+
+[testenv:type-py{38,39,310,311,312}]
+description = {[testenv:type]description}
+skipsdist = true
+deps = {[testenv:type]deps}
+commands = {[testenv:type]commands}
 
 [testenv:flake8]
 description = Lint python code
@@ -347,3 +400,65 @@ title = Large image Coverage Report
 
 [coverage:xml]
 output = build/test/coverage/py_coverage.xml
+
+[mypy]
+python_version = 3.8
+install_types = true
+non_interactive = true
+ignore_missing_imports = true
+
+follow_imports = silent
+
+# Turn these all to true as we can
+strict = True
+
+# Start off with these
+warn_unused_configs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+
+# Getting these passing should be easy
+strict_equality = True
+strict_concatenate = True
+
+# Strongly recommend enabling this one as soon as you can
+check_untyped_defs = True
+
+# These shouldn't be too much additional work, but may be tricky to
+# get passing if you use a lot of untyped libraries
+disallow_subclassing_any = False
+disallow_untyped_decorators = True
+disallow_any_generics = False
+
+# These next few are various gradations of forcing use of type annotations
+disallow_untyped_calls = False
+disallow_incomplete_defs = False
+disallow_untyped_defs = False
+
+# This one isn't too hard to get passing, but return on investment is lower
+no_implicit_reexport = False
+
+# This one can be tricky to get passing if you use a lot of untyped libraries
+warn_return_any = False
+
+# files = .
+files =
+  large_image/config.py,
+  large_image/constants.py,
+  large_image/exceptions.py,
+  large_image/tilesource/__init__.py,
+  large_image/tilesource/base.py
+# large_image/,
+# sources/,
+# girder/,
+# girder_annotation/,
+# utilities/
+exclude = (?x)(
+  (^|/)build/
+  | (^|/)docs/
+  | (^|/)examples/
+  | (^|/).*\.egg-info/
+  | (^|/)setup\.py$
+  | (^|/)test/
+  | (^|/)test_.*/
+  )


### PR DESCRIPTION
We need to drop support for older pythons for this to be useful.

After running `tox -e monkeytype-py311`, you can then list which modules have type data via `build/tox/monkeytype-py311/bin/monkeytype list-modules` and apply the type annotations to a specific modules with `build/tox/monkeytype-py311/bin/monkeytype apply <module>`.

Check types using `tox -e type`.

The next steps are to turn on a few more mypy warnings, then start adding types to more of the source files.