### PR TITLE
Add more type annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Optimizing when reading arrays rather than images from tiff files ([#1423](../../pull/1423))
 - Better filter DICOM adjacent files to ensure they share series instance IDs ([#1424](../../pull/1424), [#1436](../../pull/1436))
 - Optimizing small getRegion calls and some tiff tile fetches ([#1427](../../pull/1427))
-- Started adding python types to the core library ([#1432](../../pull/1432), [#1433](../../pull/1433), [#1437](../../pull/1437), [#1438](../../pull/1438))
+- Started adding python types to the core library ([#1432](../../pull/1432), [#1433](../../pull/1433), [#1437](../../pull/1437), [#1438](../../pull/1438), [#1439](../../pull/1439))
 - Use parallelism in computing tile frames ([#1434](../../pull/1434))
 
 ### Changed

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -56,8 +56,6 @@ class TileSource(IPyLeafletMixin):
     nameMatches: Dict[str, SourcePriority] = {
     }
 
-    geospatial = False
-
     # When getting tiles for otherwise empty levels (missing powers of two), we
     # composite the tile from higher resolution levels.  This can use excessive
     # memory if there are too many missing levels.  For instance, if there are
@@ -202,6 +200,10 @@ class TileSource(IPyLeafletMixin):
 
     def _repr_png_(self):
         return self.getThumbnail(encoding='PNG')[0]
+
+    @property
+    def geospatial(self) -> bool:
+        return False
 
     def _setStyle(self, style: Any) -> None:
         """

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -18,6 +18,7 @@ import importlib.util
 import json
 import os
 import weakref
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from large_image.exceptions import TileSourceXYZRangeError
 from large_image.tilesource.utilities import JSONDict
@@ -25,70 +26,113 @@ from large_image.tilesource.utilities import JSONDict
 ipyleafletPresent = importlib.util.find_spec('ipyleaflet') is not None
 
 
-def launch_tile_server(tile_source, port=0):
-    import tornado.httpserver
-    import tornado.netutil
-    import tornado.web
+class IPyLeafletMixin:
+    """Mixin class to support interactive visualization in JupyterLab.
 
-    class RequestManager:
-        def __init__(self, tile_source):
-            self._tile_source_ = weakref.ref(tile_source)
-            self._ports = ()
+    This class implements ``_ipython_display_`` with ``ipyleaflet``
+    to display an interactive image visualizer for the tile source
+    in JupyterLab.
 
-        @property
-        def tile_source(self):
-            return self._tile_source_()
+    Install `ipyleaflet <https://github.com/jupyter-widgets/ipyleaflet>`_
+    to interactively visualize tile sources in JupyterLab.
 
-        @tile_source.setter
-        def tile_source(self, source):
-            self._tile_source_ = weakref.ref(source)
+    For remote JupyterHub environments, you may need to configure
+    the class variables ``JUPYTER_HOST`` or ``JUPYTER_PROXY``.
 
-        @property
-        def ports(self):
-            return self._ports
+    If ``JUPYTER_PROXY`` is set, it overrides ``JUPYTER_HOST``.
 
-        @property
-        def port(self):
-            return self.ports[0]
+    Use ``JUPYTER_HOST`` to set the host name of the machine such
+    that the tile URL can be accessed at
+    ``'http://{JUPYTER_HOST}:{port}'``.
 
-    manager = RequestManager(tile_source)
-    # NOTE: set `ports` manually after launching server
+    Use ``JUPYTER_PROXY`` to leverage ``jupyter-server-proxy`` to
+    proxy the tile serving port through Jupyter's authenticated web
+    interface. This is useful in Docker and cloud JupyterHub
+    environments. You can set the environment variable
+    ``LARGE_IMAGE_JUPYTER_PROXY`` to control the default value of
+    ``JUPYTER_PROXY``. If ``JUPYTER_PROXY`` is set to ``True``, the
+    default will be ``'/proxy/`` which will work for most Docker
+    Jupyter configurations. If in a cloud JupyterHub environment,
+    this will get a bit more nuanced as the
+    ``JUPYTERHUB_SERVICE_PREFIX`` may need to prefix the
+    ``'/proxy/'``.
 
-    class TileSourceMetadataHandler(tornado.web.RequestHandler):
-        """REST endpoint to get image metadata."""
+    To programmatically set these values:
 
-        def get(self):
-            self.write(json.dumps(manager.tile_source.getMetadata()))
-            self.set_header('Content-Type', 'application/json')
+    .. code::
 
-    class TileSourceTileHandler(tornado.web.RequestHandler):
-        """REST endpoint to serve tiles from image in slippy maps standard."""
+        from large_image.tilesource.jupyter import IPyLeafletMixin
 
-        def get(self):
-            x = int(self.get_argument('x'))
-            y = int(self.get_argument('y'))
-            z = int(self.get_argument('z'))
-            encoding = self.get_argument('encoding', 'PNG')
-            try:
-                tile_binary = manager.tile_source.getTile(x, y, z, encoding=encoding)
-            except TileSourceXYZRangeError as e:
-                self.clear()
-                self.set_status(404)
-                self.finish(f'<html><body>{e}</body></html>')
+        # Only set one of these values
+
+        # Use a custom domain (avoids port proxying)
+        IPyLeafletMixin.JUPYTER_HOST = 'mydomain'
+
+        # Proxy in a standard JupyterLab environment
+        IPyLeafletMixin.JUPYTER_PROXY = True  # defaults to `/proxy/`
+
+        # Proxy in a cloud JupyterHub environment
+        IPyLeafletMixin.JUPYTER_PROXY = '/jupyter/user/username/proxy/'
+        # See if ``JUPYTERHUB_SERVICE_PREFIX`` is in the environment
+        # variables to improve this
+
+    """
+
+    JUPYTER_HOST = '127.0.0.1'
+    JUPYTER_PROXY = os.environ.get('LARGE_IMAGE_JUPYTER_PROXY', False)
+
+    _jupyter_server_manager: Any
+
+    def __init__(self, *args, **kwargs) -> None:
+        self._jupyter_server_manager = None
+        self._map = Map()
+        if ipyleafletPresent:
+            self.to_map = self._map.to_map
+            self.from_map = self._map.from_map
+
+    def as_leaflet_layer(self, **kwargs) -> Any:
+        # NOTE: `as_leaflet_layer` is supported by ipyleaflet.Map.add
+
+        if self._jupyter_server_manager is None:
+            # Must relaunch to ensure style updates work
+            self._jupyter_server_manager = launch_tile_server(self)
+        else:
+            # Must update the source on the manager in case the previous reference is bad
+            self._jupyter_server_manager.tile_source = self
+
+        port = self._jupyter_server_manager.port
+
+        if self.JUPYTER_PROXY:
+            if isinstance(self.JUPYTER_PROXY, str):
+                base_url = f'{self.JUPYTER_PROXY.rstrip("/")}/{port}'
             else:
-                self.write(tile_binary)
-                self.set_header('Content-Type', 'image/png')
+                base_url = f'/proxy/{port}'
+        else:
+            base_url = f'http://{self.JUPYTER_HOST}:{port}'
 
-    app = tornado.web.Application([
-        (r'/metadata', TileSourceMetadataHandler),
-        (r'/tile', TileSourceTileHandler),
-    ])
-    sockets = tornado.netutil.bind_sockets(port, '')
-    server = tornado.httpserver.HTTPServer(app)
-    server.add_sockets(sockets)
+        # Use repr in URL params to prevent caching across sources/styles
+        endpoint = f'tile?z={{z}}&x={{x}}&y={{y}}&encoding=png&repr={self.__repr__()}'
+        return self._map.make_layer(
+            self.metadata,  # type: ignore[attr-defined]
+            f'{base_url}/{endpoint}')
 
-    manager._ports = tuple(s.getsockname()[1] for s in sockets)
-    return manager
+    # Only make _ipython_display_ available if ipyleaflet is installed
+    if ipyleafletPresent:
+
+        def _ipython_display_(self) -> Any:
+            from IPython.display import display
+
+            t = self.as_leaflet_layer()
+
+            return display(self._map.make_map(
+                self.metadata, t, self.getCenter(srs='EPSG:4326')))  # type: ignore[attr-defined]
+
+        @property
+        def iplmap(self) -> Any:
+            """
+            If using ipyleaflets, get access to the map object.
+            """
+            return self._map.map
 
 
 class Map:
@@ -96,7 +140,11 @@ class Map:
     An IPyLeafletMap representation of a large image.
     """
 
-    def __init__(self, *, ts=None, metadata=None, url=None, gc=None, id=None, resource=None):
+    def __init__(
+            self, *, ts: Optional[IPyLeafletMixin] = None,
+            metadata: Optional[Dict] = None, url: Optional[str] = None,
+            gc: Optional[Any] = None, id: Optional[str] = None,
+            resource: Optional[str] = None) -> None:
         """
         Specify the large image to be used with the IPyLeaflet Map.  One of (a)
         a tile source, (b) metadata dictionary and tile url, (c) girder client
@@ -133,11 +181,12 @@ class Map:
                     if metadata.get('geospatial'):
                         suffix = '?projection=EPSG:3857&encoding=PNG'
                         metadata = gc.get(f'item/{id}/tiles' + suffix)
-                        if metadata.get('geospatial') and metadata.get('projection'):
-                            url += suffix
+                        if (cast(Dict, metadata).get('geospatial') and
+                                cast(Dict, metadata).get('projection')):
+                            url += suffix  # type: ignore[operator]
                     self._id = id
                 else:
-                    self._ts = self._get_temp_source(gc, fileId or id)
+                    self._ts = self._get_temp_source(gc, cast(str, fileId or id))
         if url and metadata:
             self._metadata = metadata
             self._url = url
@@ -145,7 +194,7 @@ class Map:
             self._map = self.make_map(metadata)
 
     if ipyleafletPresent:
-        def _ipython_display_(self):
+        def _ipython_display_(self) -> Any:
             from IPython.display import display
 
             if self._map:
@@ -153,9 +202,11 @@ class Map:
             if self._ts:
                 t = self._ts.as_leaflet_layer()
                 return display(self._ts._map.make_map(
-                    self._ts.metadata, t, self._ts.getCenter(srs='EPSG:4326')))
+                    self._ts.metadata,  # type: ignore[attr-defined]
+                    t,
+                    self._ts.getCenter(srs='EPSG:4326')))  # type: ignore[attr-defined]
 
-    def _get_temp_source(self, gc, id):
+    def _get_temp_source(self, gc: Any, id: str) -> IPyLeafletMixin:
         """
         If the server isn't large_image enabled, download the file to view it.
         """
@@ -175,7 +226,7 @@ class Map:
         gc.downloadFile(file['_id'], self._tempfile)
         return large_image.open(self._tempfile.name)
 
-    def make_layer(self, metadata, url, **kwargs):
+    def make_layer(self, metadata: Dict, url: str, **kwargs) -> Any:
         """
         Create an ipyleaflet tile layer given large_image metadata and a tile
         url.
@@ -200,7 +251,9 @@ class Map:
             self._metadata = metadata
         return layer
 
-    def make_map(self, metadata, layer=None, center=None):
+    def make_map(
+            self, metadata: Dict, layer: Optional[Any] = None,
+            center: Optional[Tuple[float, float]] = None) -> Any:
         """
         Create an ipyleaflet map given large_image metadata, an optional
         ipyleaflet layer, and the center of the tile source.
@@ -271,22 +324,22 @@ class Map:
         return m
 
     @property
-    def layer(self):
+    def layer(self) -> Any:
         return self._layer
 
     @property
-    def map(self):
+    def map(self) -> Any:
         return self._map
 
     @property
-    def metadata(self):
+    def metadata(self) -> JSONDict:
         return JSONDict(self._metadata)
 
     @property
-    def id(self):
+    def id(self) -> Optional[str]:
         return getattr(self, '_id', None)
 
-    def to_map(self, coordinate):
+    def to_map(self, coordinate: Union[List[float], Tuple[float, float]]) -> Tuple[float, float]:
         """
         Convert a coordinate from the image or projected image space to the map
         space.
@@ -296,131 +349,96 @@ class Map:
         :returns: a two-tuple that is in the map space coordinates.
         """
         x, y = coordinate[:2]
+        if not self._metadata:
+            return y, x
         if self._geospatial:
             import pyproj
 
             transf = pyproj.Transformer.from_crs(
                 self._metadata['projection'], 'EPSG:4326', always_xy=True)
             return tuple(transf.transform(x, y)[::-1])
-        else:
-            return self._metadata['sizeY'] - y, x
+        return self._metadata['sizeY'] - y, x
 
-    def from_map(self, coordinate):
+    def from_map(self, coordinate: Union[List[float], Tuple[float, float]]) -> Tuple[float, float]:
         """
         :param coordinate: a two-tuple that is in the map space coordinates.
         :returns: a two-tuple that is x, y in pixel space or x, y in image
             projection space.
         """
         y, x = coordinate[:2]
+        if not self._metadata:
+            return x, y
         if self._geospatial:
             import pyproj
 
             transf = pyproj.Transformer.from_crs(
                 'EPSG:4326', self._metadata['projection'], always_xy=True)
             return transf.transform(x, y)
-        else:
-            return x, self._metadata['sizeY'] - y
+        return x, self._metadata['sizeY'] - y
 
 
-class IPyLeafletMixin:
-    """Mixin class to support interactive visualization in JupyterLab.
+def launch_tile_server(tile_source: IPyLeafletMixin, port: int = 0) -> Any:
+    import tornado.httpserver
+    import tornado.netutil
+    import tornado.web
 
-    This class implements ``_ipython_display_`` with ``ipyleaflet``
-    to display an interactive image visualizer for the tile source
-    in JupyterLab.
-
-    Install `ipyleaflet <https://github.com/jupyter-widgets/ipyleaflet>`_
-    to interactively visualize tile sources in JupyterLab.
-
-    For remote JupyterHub environments, you may need to configure
-    the class variables ``JUPYTER_HOST`` or ``JUPYTER_PROXY``.
-
-    If ``JUPYTER_PROXY`` is set, it overrides ``JUPYTER_HOST``.
-
-    Use ``JUPYTER_HOST`` to set the host name of the machine such
-    that the tile URL can be accessed at
-    ``'http://{JUPYTER_HOST}:{port}'``.
-
-    Use ``JUPYTER_PROXY`` to leverage ``jupyter-server-proxy`` to
-    proxy the tile serving port through Jupyter's authenticated web
-    interface. This is useful in Docker and cloud JupyterHub
-    environments. You can set the environment variable
-    ``LARGE_IMAGE_JUPYTER_PROXY`` to control the default value of
-    ``JUPYTER_PROXY``. If ``JUPYTER_PROXY`` is set to ``True``, the
-    default will be ``'/proxy/`` which will work for most Docker
-    Jupyter configurations. If in a cloud JupyterHub environment,
-    this will get a bit more nuanced as the
-    ``JUPYTERHUB_SERVICE_PREFIX`` may need to prefix the
-    ``'/proxy/'``.
-
-    To programmatically set these values:
-
-    .. code::
-
-        from large_image.tilesource.jupyter import IPyLeafletMixin
-
-        # Only set one of these values
-
-        # Use a custom domain (avoids port proxying)
-        IPyLeafletMixin.JUPYTER_HOST = 'mydomain'
-
-        # Proxy in a standard JupyterLab environment
-        IPyLeafletMixin.JUPYTER_PROXY = True  # defaults to `/proxy/`
-
-        # Proxy in a cloud JupyterHub environment
-        IPyLeafletMixin.JUPYTER_PROXY = '/jupyter/user/username/proxy/'
-        # See if ``JUPYTERHUB_SERVICE_PREFIX`` is in the environment
-        # variables to improve this
-
-    """
-
-    JUPYTER_HOST = '127.0.0.1'
-    JUPYTER_PROXY = os.environ.get('LARGE_IMAGE_JUPYTER_PROXY', False)
-
-    def __init__(self, *args, **kwargs):
-        self._jupyter_server_manager = None
-        self._map = Map()
-        if ipyleafletPresent:
-            self.to_map = self._map.to_map
-            self.from_map = self._map.from_map
-
-    def as_leaflet_layer(self, **kwargs):
-        # NOTE: `as_leaflet_layer` is supported by ipyleaflet.Map.add
-
-        if self._jupyter_server_manager is None:
-            # Must relaunch to ensure style updates work
-            self._jupyter_server_manager = launch_tile_server(self)
-        else:
-            # Must update the source on the manager in case the previous reference is bad
-            self._jupyter_server_manager.tile_source = self
-
-        port = self._jupyter_server_manager.port
-
-        if self.JUPYTER_PROXY:
-            if isinstance(self.JUPYTER_PROXY, str):
-                base_url = f'{self.JUPYTER_PROXY.rstrip("/")}/{port}'
-            else:
-                base_url = f'/proxy/{port}'
-        else:
-            base_url = f'http://{self.JUPYTER_HOST}:{port}'
-
-        # Use repr in URL params to prevent caching across sources/styles
-        endpoint = f'tile?z={{z}}&x={{x}}&y={{y}}&encoding=png&repr={self.__repr__()}'
-        return self._map.make_layer(self.metadata, f'{base_url}/{endpoint}')
-
-    # Only make _ipython_display_ available if ipyleaflet is installed
-    if ipyleafletPresent:
-
-        def _ipython_display_(self):
-            from IPython.display import display
-
-            t = self.as_leaflet_layer()
-
-            return display(self._map.make_map(self.metadata, t, self.getCenter(srs='EPSG:4326')))
+    class RequestManager:
+        def __init__(self, tile_source: IPyLeafletMixin) -> None:
+            self._tile_source_ = weakref.ref(tile_source)
+            self._ports = ()
 
         @property
-        def iplmap(self):
-            """
-            If using ipyleaflets, get access to the map object.
-            """
-            return self._map.map
+        def tile_source(self) -> IPyLeafletMixin:
+            return cast(IPyLeafletMixin, self._tile_source_())
+
+        @tile_source.setter
+        def tile_source(self, source: IPyLeafletMixin) -> None:
+            self._tile_source_ = weakref.ref(source)
+
+        @property
+        def ports(self) -> Tuple[int, ...]:
+            return self._ports
+
+        @property
+        def port(self) -> int:
+            return self.ports[0]
+
+    manager = RequestManager(tile_source)
+    # NOTE: set `ports` manually after launching server
+
+    class TileSourceMetadataHandler(tornado.web.RequestHandler):
+        """REST endpoint to get image metadata."""
+
+        def get(self) -> None:
+            self.write(json.dumps(manager.tile_source.metadata))  # type: ignore[attr-defined]
+            self.set_header('Content-Type', 'application/json')
+
+    class TileSourceTileHandler(tornado.web.RequestHandler):
+        """REST endpoint to serve tiles from image in slippy maps standard."""
+
+        def get(self) -> None:
+            x = int(self.get_argument('x'))
+            y = int(self.get_argument('y'))
+            z = int(self.get_argument('z'))
+            encoding = self.get_argument('encoding', 'PNG')
+            try:
+                tile_binary = manager.tile_source.getTile(  # type: ignore[attr-defined]
+                    x, y, z, encoding=encoding)
+            except TileSourceXYZRangeError as e:
+                self.clear()
+                self.set_status(404)
+                self.finish(f'<html><body>{e}</body></html>')
+            else:
+                self.write(tile_binary)
+                self.set_header('Content-Type', 'image/png')
+
+    app = tornado.web.Application([
+        (r'/metadata', TileSourceMetadataHandler),
+        (r'/tile', TileSourceTileHandler),
+    ])
+    sockets = tornado.netutil.bind_sockets(port, '')
+    server = tornado.httpserver.HTTPServer(app)
+    server.add_sockets(sockets)
+
+    manager._ports = tuple(s.getsockname()[1] for s in sockets)
+    return manager

--- a/tox.ini
+++ b/tox.ini
@@ -443,18 +443,8 @@ no_implicit_reexport = False
 # This one can be tricky to get passing if you use a lot of untyped libraries
 warn_return_any = False
 
-# files = .
 files =
-  large_image/__init__.py,
-  large_image/cache_util/,
-  large_image/config.py,
-  large_image/constants.py,
-  large_image/exceptions.py,
-  large_image/tilesource/__init__.py,
-  large_image/tilesource/base.py,
-  large_image/tilesource/stylefuncs.py,
-  large_image/tilesource/utilities.py
-# large_image/,
+  large_image/
 # sources/,
 # girder/,
 # girder_annotation/,


### PR DESCRIPTION
This finishes adding type annotations to the core.  Obviously they could be improved to have less `Any`s and more precision.  It'd be nice to also add type annotations to the utilities and the sources, but that will be done in a separate wave of work.