### PR TITLE
Add support for Imaging Data Commons

### DIFF
--- a/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
@@ -438,7 +438,6 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
         if progress:
             progress.update(message='Searching for series...')
 
-        # FIXME: might need to search in chunks for larger web servers
         series_results = client.search_for_series(
             fields=fields, limit=limit, search_filters=search_filters)
         items = []

--- a/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
@@ -420,8 +420,6 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
             msg = f'Invalid parent type: {parentType}'
             raise RuntimeError(msg)
 
-        from wsidicom.uid import WSI_SOP_CLASS_UID
-
         limit = params.get('limit')
         search_filters = params.get('search_filters', {})
 
@@ -433,14 +431,6 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
         series_uid_key = dicom_key_to_tag('SeriesInstanceUID')
         instance_uid_key = dicom_key_to_tag('SOPInstanceUID')
 
-        # We are only searching for WSI datasets. Ignore all others.
-        # FIXME: is this actually working? For the SLIM server at
-        # https://imagingdatacommons.github.io/slim/, none of the series
-        # report a SOPClassUID, but we still get all results anyways.
-        search_filters = {
-            'SOPClassUID': WSI_SOP_CLASS_UID,
-            **search_filters,
-        }
         fields = [
             study_uid_key,
             series_uid_key,

--- a/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
@@ -431,6 +431,20 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
         series_uid_key = dicom_key_to_tag('SeriesInstanceUID')
         instance_uid_key = dicom_key_to_tag('SOPInstanceUID')
 
+        # Search for studies. Apply the limit and search filters.
+        fields = [
+            study_uid_key,
+        ]
+        if progress:
+            progress.update(message='Searching for studies...')
+
+        studies_results = client.search_for_studies(
+            limit=limit,
+            fields=fields,
+            search_filters=search_filters,
+        )
+
+        # Search for all series in the returned studies.
         fields = [
             study_uid_key,
             series_uid_key,
@@ -438,8 +452,12 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
         if progress:
             progress.update(message='Searching for series...')
 
-        series_results = client.search_for_series(
-            fields=fields, limit=limit, search_filters=search_filters)
+        series_results = []
+        for study in studies_results:
+            study_uid = study[study_uid_key]['Value'][0]
+            series_results += client.search_for_series(study_uid, fields=fields)
+
+        # Create folders for each study, items for each series, and files for each instance.
         items = []
         for i, result in enumerate(series_results):
             if progress:

--- a/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/dicomweb_assetstore_adapter.py
@@ -503,8 +503,9 @@ class DICOMwebAssetstoreAdapter(AbstractAssetstoreAdapter):
                 }
                 file['imported'] = True
 
-                # Try to infer the file size without streaming, if possible.
-                file['size'] = self._infer_file_size(file)
+                # Inferring the file size can take a long time, so don't
+                # do it right away, unless we figure out a way to make it faster.
+                # file['size'] = self._infer_file_size(file)
                 file = File().save(file)
 
             items.append(item)

--- a/sources/dicom/large_image_source_dicom/assetstore/rest.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/rest.py
@@ -64,7 +64,7 @@ class DICOMwebAssetstoreResource(Resource):
         )
 
         if not items:
-            msg = 'No DICOM objects matching the search filters were found'
+            msg = 'No studies matching the search filters were found'
             raise RestException(msg)
 
     @access.admin(scope=TokenScope.DATA_WRITE)

--- a/sources/dicom/large_image_source_dicom/assetstore/rest.py
+++ b/sources/dicom/large_image_source_dicom/assetstore/rest.py
@@ -77,9 +77,9 @@ class DICOMwebAssetstoreResource(Resource):
         .param('destinationType', 'The type of the parent object to import into.',
                enum=('folder', 'user', 'collection'),
                required=False, default='folder')
-        .param('limit', 'The maximum number of results to import.',
+        .param('limit', 'The maximum number of studies to import.',
                required=False, default=None)
-        .param('filters', 'Any search parameters to filter DICOM objects.',
+        .param('filters', 'Any search parameters to filter the studies query.',
                required=False, default='{}')
         .param('progress', 'Whether to record progress on this operation.',
                required=False, default=False, dataType='boolean')

--- a/sources/dicom/large_image_source_dicom/web_client/templates/assetstoreImport.pug
+++ b/sources/dicom/large_image_source_dicom/web_client/templates/assetstoreImport.pug
@@ -26,9 +26,9 @@ form.g-dwas-import-form
         type="number", step="1", min="1", value="10")
     label(for="g-dwas-import-filters") Filters (Studies)
     textarea#g-dwas-import-filters.form-control(rows="10")
-        | {
-        |     "ModalitiesInStudy": "SM"
-        | }
+      | {
+      |     "ModalitiesInStudy": "SM"
+      | }
   .g-validation-failed-message
   button.g-submit-assetstore-import.btn.btn-success(type="submit")
     i.icon-link-ext

--- a/sources/dicom/large_image_source_dicom/web_client/templates/assetstoreImport.pug
+++ b/sources/dicom/large_image_source_dicom/web_client/templates/assetstoreImport.pug
@@ -23,10 +23,12 @@ form.g-dwas-import-form
           i.icon-folder-open
     label(for="g-dwas-import-limit") Limit (Series)
     input#g-dwas-import-limit.form-control(
-        type="number", step="1", min="1", value="")
-    label(for="g-dwas-import-filters") Filters
-    textarea#g-dwas-import-filters.form-control(rows="10",
-        placeholder="Valid JSON. e.g.:\n\n{\n    \"PatientID\": \"ABC123\"\n}")
+        type="number", step="1", min="1", value="20")
+    label(for="g-dwas-import-filters") Filters (Series)
+    textarea#g-dwas-import-filters.form-control(rows="10")
+        | {
+        |     "Modality": "SM"
+        | }
   .g-validation-failed-message
   button.g-submit-assetstore-import.btn.btn-success(type="submit")
     i.icon-link-ext

--- a/sources/dicom/large_image_source_dicom/web_client/templates/assetstoreImport.pug
+++ b/sources/dicom/large_image_source_dicom/web_client/templates/assetstoreImport.pug
@@ -21,13 +21,13 @@ form.g-dwas-import-form
       .input-group-btn
         button.g-open-browser.btn.btn-default(type="button")
           i.icon-folder-open
-    label(for="g-dwas-import-limit") Limit (Series)
+    label(for="g-dwas-import-limit") Limit (Studies)
     input#g-dwas-import-limit.form-control(
-        type="number", step="1", min="1", value="20")
-    label(for="g-dwas-import-filters") Filters (Series)
+        type="number", step="1", min="1", value="10")
+    label(for="g-dwas-import-filters") Filters (Studies)
     textarea#g-dwas-import-filters.form-control(rows="10")
         | {
-        |     "Modality": "SM"
+        |     "ModalitiesInStudy": "SM"
         | }
   .g-validation-failed-message
   button.g-submit-assetstore-import.btn.btn-success(type="submit")

--- a/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
+++ b/sources/dicom/test_dicom/web_client_specs/dicomWebSpec.js
@@ -23,7 +23,9 @@ describe('DICOMWeb assetstore', function () {
         var dicomFileContent;
 
         // After importing, we will verify that this item exists
-        const verifyItemName = '1.3.6.1.4.1.5962.99.1.3205815762.381594633.1639588388306.2.0';
+        const studyUID = '2.25.25644321580420796312527343668921514374';
+        const seriesUID = '1.3.6.1.4.1.5962.99.1.3205815762.381594633.1639588388306.2.0';
+        const verifyItemName = seriesUID;
 
         runs(function () {
             $('a.g-nav-link[g-target="admin"]').trigger('click');
@@ -173,20 +175,20 @@ describe('DICOMWeb assetstore', function () {
 
         runs(function () {
             // Perform a search where no results are returned
-            const filters = '{"SeriesInstanceUID": "DOES_NOT_EXIST"}';
+            const filters = '{"StudyInstanceUID": "DOES_NOT_EXIST"}';
             $('#g-dwas-import-filters').val(filters);
             $('.g-submit-assetstore-import').trigger('click');
         });
 
         waitsFor(function () {
-            const msg = 'No DICOM objects matching the search filters were found';
+            const msg = 'No studies matching the search filters were found';
             return $('.g-validation-failed-message').html() === msg;
         }, 'No results check');
 
         runs(function () {
             // Fix the filters
-            // We will only import this specific SeriesInstanceUID
-            const filters = '{"SeriesInstanceUID": "' + verifyItemName + '"}';
+            // We will only import this specific StudyInstanceUID
+            const filters = '{"StudyInstanceUID": "' + studyUID + '"}';
             $('#g-dwas-import-filters').val(filters);
 
             // This one should work fine


### PR DESCRIPTION
The NCI's [Imaging Data Commons](https://datacommons.cancer.gov/repository/imaging-data-commons) is a big repository (>38k studies) for cancer research. For the DICOMweb server, it uses Google's Cloud Healthcare API behind a proxy. This DICOMweb server sometimes behaves differently than the dcm4chee server we have been testing with.

This PR fixes a couple of issues we encountered. One of which is that we cannot use the `SOPClassUID` as a search filter (even though the [DICOMweb standard](https://dicom.nema.org/medical/dicom/current/output/chtml/part18/sect_10.6.html) indicates that it should be supported when searching for instances). We can perform manual filtering instead, however.

This PR also adds a default limit to the import page (which is required for importing from IDC), and a default search filter that specifies `SM`. Without the search filter, we end up importing a lot of non-WSI datasets. With the `SM` search filter, most of the imported datasets look correct, and all are viewable.

Also needed to support the IDC: imi-bigpicture/wsidicom#149