### PR TITLE
Fix compositing multi source with alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Infer DICOM file size, when possible ([#1448](../../pull/1448))
 - Swap styles faster in the frame viewer ([#1452](../../pull/1452))
 
+### Bug Fixes
+- Fix an issue with compositing sources in the multi source caused by alpha range ([#1453](../../pull/1453))
+
 ## 1.27.1
 
 ### Improvements

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -8,6 +8,7 @@ from operator import attrgetter
 from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 import numpy as np
+import numpy.typing as npt
 import PIL
 import PIL.Image
 import PIL.ImageColor
@@ -729,7 +730,7 @@ def getAvailableNamedPalettes(includeColors: bool = True, reduced: bool = False)
     return sorted(palettes)
 
 
-def fullAlphaValue(arr: np.ndarray) -> int:
+def fullAlphaValue(arr: Union[np.ndarray, npt.DTypeLike]) -> int:
     """
     Given a numpy array, return the value that should be used for a fully
     opaque alpha channel.  For uint variants, this is the max value.
@@ -737,8 +738,9 @@ def fullAlphaValue(arr: np.ndarray) -> int:
     :param arr: a numpy array.
     :returns: the value for the alpha channel.
     """
-    if arr.dtype.kind == 'u':
-        return np.iinfo(arr.dtype).max
+    dtype = arr.dtype if isinstance(arr, np.ndarray) else arr
+    if dtype.kind == 'u':
+        return np.iinfo(dtype).max
     return 1
 
 


### PR DESCRIPTION
Fix an issue with compositing sources in the multi source caused by alpha range.  We composite tiles using pre-multiplied alpha values. When we have 8 bit images and apply an affine transform, we do this in float precision so that compositing does not lose precision prematurely. The function fullAlphaValue is used to determine the range of the alpha values we expect; for uint8 this is 255, for float it is 1.  Since the values have been cast to float but NOT scaled, this ends up with the wrong values.  Functionally, this was multiplying incomplete tiles by 255 and then taking the low 8 bits of the resultant integer cast, which looked like nonsense.