### PR TITLE
Retry read_region if openslide reports an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Infer DICOM file size, when possible ([#1448](../../pull/1448))
 - Swap styles faster in the frame viewer ([#1452](../../pull/1452))
 - Reduce color fringing in multi source compositing ([#1456](../../pull/1456))
+- Retry read_region if openslide reports an error ([#1457](../../pull/1457))
 
 ### Bug Fixes
 - Fix an issue with compositing sources in the multi source caused by alpha range ([#1453](../../pull/1453))

--- a/sources/openslide/large_image_source_openslide/__init__.py
+++ b/sources/openslide/large_image_source_openslide/__init__.py
@@ -297,14 +297,21 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         if svslevel['scale'] > 2 ** self._maxSkippedLevels:
             tile = self._getTileFromEmptyLevel(x, y, z, **kwargs)
         else:
-            try:
-                tile = self._openslide.read_region(
-                    (offsetx, offsety), svslevel['svslevel'],
-                    (self.tileWidth * svslevel['scale'],
-                     self.tileHeight * svslevel['scale']))
-            except openslide.lowlevel.OpenSlideError as exc:
-                raise TileSourceError(
-                    'Failed to get OpenSlide region (%r).' % exc)
+            retries = 3
+            while retries > 0:
+                try:
+                    tile = self._openslide.read_region(
+                        (offsetx, offsety), svslevel['svslevel'],
+                        (self.tileWidth * svslevel['scale'],
+                         self.tileHeight * svslevel['scale']))
+                    break
+                except openslide.lowlevel.OpenSlideError as exc:
+                    # Reopen handle after a lowlevel error
+                    self._openslide = openslide.OpenSlide(self._largeImagePath)
+                    retries -= 1
+                    if retries <= 0:
+                        raise TileSourceError(
+                            'Failed to get OpenSlide region (%r).' % exc)
             # Always scale to the svs level 0 tile size.
             if svslevel['scale'] != 1:
                 tile = tile.resize((self.tileWidth, self.tileHeight),


### PR DESCRIPTION
Occasionally the openslide library fails to read from a tiff directory.  This adds a reconnect and retry loop to make it more robust.