### PR TITLE
Fix histogram request bug in band compositing mode

### DIFF
--- a/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
+++ b/girder/girder_large_image/web_client/vue/components/CompositeLayers.vue
@@ -455,6 +455,7 @@ export default {
                 :auto-range="autoRange"
                 :current-min="min"
                 :current-max="max"
+                :active="active"
                 @updateMin="(v, d) => updateLayerMin(layerName, v, d)"
                 @updateMax="(v, d) => updateLayerMax(layerName, v, d)"
                 @updateAutoRange="(v) => updateLayerAutoRange(layerName, v)"

--- a/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
+++ b/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
@@ -213,6 +213,8 @@ export default Vue.extend({
                     case 4:
                         this.metadata.bands = ['red', 'green', 'blue', 'alpha'];
                         break;
+                    default:
+                        this.metadata.bands = [...Array(this.metadata.bandCount).keys()].map((i) => `Band ${i+1}`)
                 }
             } else {
                 this.metadata.bands = Object.values(this.metadata.bands).map(

--- a/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
+++ b/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
@@ -214,7 +214,7 @@ export default Vue.extend({
                         this.metadata.bands = ['red', 'green', 'blue', 'alpha'];
                         break;
                     default:
-                        this.metadata.bands = [...Array(this.metadata.bandCount).keys()].map((i) => `Band ${i+1}`)
+                        this.metadata.bands = [...Array(this.metadata.bandCount).keys()].map((i) => `Band ${i + 1}`);
                 }
             } else {
                 this.metadata.bands = Object.values(this.metadata.bands).map(

--- a/girder/girder_large_image/web_client/vue/components/HistogramEditor.vue
+++ b/girder/girder_large_image/web_client/vue/components/HistogramEditor.vue
@@ -15,7 +15,7 @@ export default {
         'currentMin',
         'currentMax',
         'autoRange',
-        'active',
+        'active'
     ],
     emits: ['updateMin', 'updateMax', 'updateAutoRange'],
     data() {
@@ -65,7 +65,7 @@ export default {
     },
     methods: {
         fetchHistogram() {
-            if (!this.active) return
+            if (!this.active) return undefined;
             if (this.framedelta !== undefined) {
                 restRequest({
                     type: 'GET',

--- a/girder/girder_large_image/web_client/vue/components/HistogramEditor.vue
+++ b/girder/girder_large_image/web_client/vue/components/HistogramEditor.vue
@@ -14,7 +14,8 @@ export default {
         'framedelta',
         'currentMin',
         'currentMax',
-        'autoRange'
+        'autoRange',
+        'active',
     ],
     emits: ['updateMin', 'updateMax', 'updateAutoRange'],
     data() {
@@ -64,6 +65,7 @@ export default {
     },
     methods: {
         fetchHistogram() {
+            if (!this.active) return
             if (this.framedelta !== undefined) {
                 restRequest({
                     type: 'GET',


### PR DESCRIPTION
Resolves #1458. 

After viewing the histograms in channel compositing mode, those histogram components still exist after switching to band compositing mode. The instances for the channel compositing table are invisible, but still send requests with a `framedelta` every time the `currentFrame` changes. 

This PR prevents sending histogram requests while the parent compositing table of the histogram component is not active.

One additional change enables band compositing on images with greater than 4 bands without assigned names; default names are assigned.