### PR TITLE
Simplify check for 401 error message in test

### DIFF
--- a/test/test_source_dicomweb.py
+++ b/test/test_source_dicomweb.py
@@ -30,8 +30,7 @@ def testTilesFromDICOMweb():
     token = os.getenv('DICOMWEB_TEST_TOKEN')
     if token:
         # First, verify that we receive an authorization error without the token
-        match_message = '401 Client Error: Unauthorized for url'
-        with pytest.raises(TileSourceError, match=match_message):
+        with pytest.raises(TileSourceError, match='401'):
             large_image_source_dicom.open(dicomweb_file)
 
         # Create a session, add the token, and try again


### PR DESCRIPTION
It appears that somewhere upstream, the exact text changed when a 401 "Unauthorized" error is printed.

Rather than expecting the text to stay the same, let's just check for "401" in the string instead...