### PR TITLE
Speed up some retiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 - Log and recover from occasional openslide failures ([#1461](../../pull/1461))
 - Add support for Imaging Data Commons ([#1450](../../pull/1450))
+- Speed up some retiling ([#1471](../../pull/1471))
 
 ### Changes
 - Make GDAL an optional dependency for the converter ([#1464](../../pull/1464))

--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -65,7 +65,7 @@ def strhash(*args, **kwargs) -> str:
     """
     if kwargs:
         return '%r,%r' % (args, sorted(kwargs.items()))
-    return '%r' % (args, )
+    return repr(args)
 
 
 def methodcache(key: Optional[Callable] = None) -> Callable:  # noqa

--- a/large_image/config.py
+++ b/large_image/config.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import logging
 import os
@@ -60,6 +61,8 @@ ConfigValues = {
 }
 
 
+# Fix when we drop Python 3.8 to just be @functools.cache
+@functools.lru_cache(maxsize=None)
 def getConfig(key: Optional[str] = None,
               default: Optional[Union[str, bool, int, logging.Logger]] = None) -> Any:
     """
@@ -110,6 +113,7 @@ def setConfig(key: str, value: Optional[Union[str, bool, int, logging.Logger]]) 
     curConfig = getConfig()
     if curConfig.get(key) is not value:
         curConfig[key] = value
+        getConfig.cache_clear()
 
 
 def _ignoreSourceNames(

--- a/sources/tiff/large_image_source_tiff/tiff_reader.py
+++ b/sources/tiff/large_image_source_tiff/tiff_reader.py
@@ -596,13 +596,27 @@ class TiledTiffDirectory:
                     self._tiffFile).value
             stripsCount = min(self._stripsPerTile, self._stripCount - tileNum)
             tileSize = stripSize * self._stripsPerTile
-        imageBuffer = ctypes.create_string_buffer(tileSize)
+        tw, th = self._tileWidth, self._tileHeight
+        if self._tiffInfo.get('orientation') in {
+                libtiff_ctypes.ORIENTATION_LEFTTOP,
+                libtiff_ctypes.ORIENTATION_RIGHTTOP,
+                libtiff_ctypes.ORIENTATION_RIGHTBOT,
+                libtiff_ctypes.ORIENTATION_LEFTBOT}:
+            tw, th = th, tw
+        format = (
+            self._tiffInfo.get('bitspersample'),
+            self._tiffInfo.get('sampleformat') if self._tiffInfo.get(
+                'sampleformat') is not None else libtiff_ctypes.SAMPLEFORMAT_UINT)
+        image = np.empty((th, tw, self._tiffInfo['samplesperpixel']),
+                         dtype=_ctypesFormattbl[format])
+        imageBuffer = image.ctypes.data_as(ctypes.POINTER(ctypes.c_char))
         if self._tiffInfo.get('istiled'):
             with self._tileLock:
                 readSize = libtiff_ctypes.libtiff.TIFFReadEncodedTile(
                     self._tiffFile, tileNum, imageBuffer, tileSize)
         else:
             readSize = 0
+            imageBuffer = ctypes.cast(imageBuffer, ctypes.POINTER(ctypes.c_char * 2)).contents
             for stripNum in range(stripsCount):
                 with self._tileLock:
                     chunkSize = libtiff_ctypes.libtiff.TIFFReadEncodedStrip(
@@ -621,21 +635,6 @@ class TiledTiffDirectory:
             raise IOTiffError(
                 'Read an unexpected number of bytes from an encoded tile' if readSize >= 0 else
                 'Failed to read from an encoded tile')
-        tw, th = self._tileWidth, self._tileHeight
-        if self._tiffInfo.get('orientation') in {
-                libtiff_ctypes.ORIENTATION_LEFTTOP,
-                libtiff_ctypes.ORIENTATION_RIGHTTOP,
-                libtiff_ctypes.ORIENTATION_RIGHTBOT,
-                libtiff_ctypes.ORIENTATION_LEFTBOT}:
-            tw, th = th, tw
-        format = (
-            self._tiffInfo.get('bitspersample'),
-            self._tiffInfo.get('sampleformat') if self._tiffInfo.get(
-                'sampleformat') is not None else libtiff_ctypes.SAMPLEFORMAT_UINT)
-        image = np.ctypeslib.as_array(ctypes.cast(
-            imageBuffer, ctypes.POINTER(ctypes.c_uint8)), (tileSize, )).view(
-                _ctypesFormattbl[format]).reshape(
-                    (th, tw, self._tiffInfo['samplesperpixel']))
         if (self._tiffInfo.get('samplesperpixel') == 3 and
                 self._tiffInfo.get('photometric') == libtiff_ctypes.PHOTOMETRIC_YCBCR):
             if self._tiffInfo.get('bitspersample') == 16:


### PR DESCRIPTION
In one test, this reduces tiling time by about 8% when running a tile iterator on a tile that is slightly smaller than the native size (224 square rather than 240 square).  Of the time reduction, some of the speed is based on non-format specific gains and some specifically on the tiff tile source; roughly 3% is the non-format specific, and 5% is tiff specific.

Note that these gains become less significant as tile size goes up.