### PR TITLE
Add a guard when reading incorrect associated images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.27.4
+
+### Improvements
+- Add a guard when reading incorrect associated images ([#1472](../../pull/1472))
+
 ## 1.27.3
 
 ### Improvements

--- a/sources/openslide/large_image_source_openslide/__init__.py
+++ b/sources/openslide/large_image_source_openslide/__init__.py
@@ -395,7 +395,15 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 self._openslide = openslide.OpenSlide(self._largeImagePath)
                 return None
         tiff_buffer = io.BytesIO()
-        tifftools.write_tiff(self._tiffinfo['ifds'][images[imageKey]], tiff_buffer)
+        ifd = self._tiffinfo['ifds'][images[imageKey]]
+        if (tifftools.Tag.Photometric.value in ifd['tags'] and
+                ifd['tags'][tifftools.Tag.Photometric.value]['data'][0] ==
+                tifftools.constants.Photometric.RGB and
+                tifftools.Tag.SamplesPerPixel.value in ifd['tags'] and
+                ifd['tags'][tifftools.Tag.SamplesPerPixel.value]['data'][0] == 1):
+            ifd['tags'][tifftools.Tag.Photometric.value]['data'][
+                0] = tifftools.constants.Photometric.MinIsBlack
+        tifftools.write_tiff(ifd, tiff_buffer)
         return PIL.Image.open(tiff_buffer)
 
 


### PR DESCRIPTION
These occur in ndpi files