### PR TITLE
Allow alternate name axes in the multi source schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 - Fix an issue with single band on multi source with non uniform sources ([#1474](../../pull/1474))
+- Allow alternate name axes in the multi source schema ([#1475](../../pull/1475))
 
 ## 1.27.4
 

--- a/sources/multi/large_image_source_multi/__init__.py
+++ b/sources/multi/large_image_source_multi/__init__.py
@@ -30,7 +30,7 @@ except PackageNotFoundError:
 
 SourceEntrySchema = {
     'type': 'object',
-    'additionalProperties': False,
+    'additionalProperties': True,
     'properties': {
         'name': {'type': 'string'},
         'description': {'type': 'string'},

--- a/test/test_source_multi.py
+++ b/test/test_source_multi.py
@@ -127,10 +127,12 @@ def testTilesFromMultiString():
 
 
 def testTilesFromNonschemaMultiString():
-    sourceString = json.dumps({'sources': [{
-        'sourceName': 'test', 'path': '__none__',
+    sourceString = json.dumps({
+        'sources': [{
+            'sourceName': 'test', 'path': '__none__',
+            'params': {'sizeX': 10000, 'sizeY': 10000}}],
         'notAKnownKey': 'X',
-        'params': {'sizeX': 10000, 'sizeY': 10000}}]})
+    })
     with pytest.raises(large_image.exceptions.TileSourceError):
         large_image_source_multi.open(sourceString)
 


### PR DESCRIPTION
This relaxes the schema requirements to allow specifying values for alternate named axes (e.g., 'v: 5').