### PR TITLE
Prioritize tile sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## 1.27.5
 
+### Features
+- Zarr tile sink ([#1446](../../pull/1446))
+
 ### Improvements
+- Prioritize tile sinks ([#1478](../../pull/1478))
 - Add a dependency to the zarr source to read more compression types ([#1480](../../pull/1480))
 
 ### Bug Fixes

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -57,6 +57,10 @@ class TileSource(IPyLeafletMixin):
     nameMatches: Dict[str, SourcePriority] = {
     }
 
+    # If a source supports creating new tiled images, specify its basic
+    # priority based on expected feature set
+    newPriority: Optional[SourcePriority] = None
+
     # When getting tiles for otherwise empty levels (missing powers of two), we
     # composite the tile from higher resolution levels.  This can use excessive
     # memory if there are too many missing levels.  For instance, if there are

--- a/sources/vips/large_image_source_vips/__init__.py
+++ b/sources/vips/large_image_source_vips/__init__.py
@@ -50,6 +50,7 @@ class VipsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
     mimeTypes = {
         None: SourcePriority.FALLBACK,
     }
+    newPriority = SourcePriority.MEDIUM
 
     _tileSize = 256
 

--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -41,6 +41,7 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         'zarray': SourcePriority.PREFERRED,
         'db': SourcePriority.MEDIUM,
     }
+    newPriority = SourcePriority.HIGH
 
     _tileSize = 512
     _minTileSize = 128

--- a/test/test_source_vips.py
+++ b/test/test_source_vips.py
@@ -151,8 +151,7 @@ def testNewAndWriteMinSize(tmp_path):
 def testNewAndWriteJPEG(tmp_path):
     imagePath = datastore.fetch('sample_image.ptif')
     source = large_image.open(imagePath)
-    # Update this if it doesn't direct to vips source
-    out = large_image.new()
+    out = large_image_source_vips.new()
     for tile in source.tileIterator(
         format=large_image.constants.TILE_FORMAT_NUMPY,
         region=dict(right=4000, bottom=2000),


### PR DESCRIPTION
This makes it so `large_image.new()` will pick our preferred sink (zarr over vips, since it is more capable).