### PR TITLE
Add an extras require to the zarr source for conversion

### DIFF
--- a/sources/zarr/setup.py
+++ b/sources/zarr/setup.py
@@ -59,6 +59,9 @@ setup(
     ],
     extras_require={
         'girder': f'girder-large-image{limit_version}',
+        'all': [
+            'large-image-converter',
+        ],
     },
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),


### PR DESCRIPTION
The large-image-converter is needed when writing zarr sinks to tiff.