### PR TITLE
Speed up some tifffile and multi source access cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 - Improve uint16 image scaling ([#1511](../../pull/1511))
 - Read some untiled tiffs using the tiff source ([#1512](../../pull/1512))
 - Speed up multi source compositing in tiled cases ([#1513](../../pull/1513))
+- Speed up some tifffile and multi source access cases ([#1515](../../pull/1515))
 
 ### Changes
 - Limit internal metadata on multi-source files with huge numbers of sources ([#1514](../../pull/1514))
+- Make DICOMweb assetstore imports compatible with Girder generics ([#1504](../../pull/1504))
 
 ## 1.28.1
 

--- a/sources/multi/large_image_source_multi/__init__.py
+++ b/sources/multi/large_image_source_multi/__init__.py
@@ -828,7 +828,8 @@ class MultiFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         with self._lastOpenSourceLock:
             if (hasattr(self, '_lastOpenSource') and
                     self._lastOpenSource['source'] == source and
-                    self._lastOpenSource['params'] == params):
+                    (self._lastOpenSource['params'] == params or (
+                        params == {} and self._lastOpenSource['params'] is None))):
                 return self._lastOpenSource['ts']
         if not len(large_image.tilesource.AvailableTileSources):
             large_image.tilesource.loadTileSources()
@@ -841,6 +842,7 @@ class MultiFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         if params is None:
             params = source.get('params', {})
         ts = openFunc(source['path'], **params)
+        source['sourceName'] = ts.name
         with self._lastOpenSourceLock:
             self._lastOpenSource = {
                 'source': source,


### PR DESCRIPTION
For small tifffile arrays, use them directly rather than with zarr access.

Note which source was used to open a file in the multisource source so if it needs to be reopened, we can do so more efficiently.