### PR TITLE
Thumbnail generation jobs are less blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 - Log more when saving annotations ([#1525](../../pull/1525))
+- Thumbnail generation jobs are less blocking ([#1528](../../pull/1528))
 
 ## 1.28.2
 

--- a/girder/girder_large_image/rest/large_image_resource.py
+++ b/girder/girder_large_image/rest/large_image_resource.py
@@ -22,6 +22,7 @@ import os
 import pprint
 import re
 import shutil
+import threading
 import time
 
 import cherrypy
@@ -117,6 +118,11 @@ def cursorNextOrNone(cursor):
 
 
 def createThumbnailsJob(job):
+    thread = threading.Thread(target=createThumbnailsJobThread, args=(job, ), daemon=True)
+    thread.start()
+
+
+def createThumbnailsJobThread(job):
     """
     Create thumbnails for all of the large image items.
 


### PR DESCRIPTION
When running a job via the PUT large_image/thumbnails endpoint, run it as an independent thread so other local asynchronous jobs are not delayed.