### PR TITLE
Add the ability to specify the dtype of a multi-source file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Better detect available memory in containers ([#1532](../../pull/1532))
 - Reject the promise from a canceled annotation ([#1535](../../pull/1535))
 - Disallow certain names from being read by any but specific sources ([#1537](../../pull/1537))
+- Add the ability to specify the dtype of a multi-source file ([#1542](../../pull/1542))
 
 ### Changes
 - Log more when saving annotations ([#1525](../../pull/1525))

--- a/test/test_files/multi_test_source_style.yml
+++ b/test/test_files/multi_test_source_style.yml
@@ -1,0 +1,20 @@
+---
+dtype: uint8
+sources:
+  - sourceName: test
+    path: __none__
+    params:
+      tileWidth: 256
+      tileHeight: 256
+      sizeX: 1000
+      sizeY: 750
+      fractal: True
+      monochrome: False
+      bands: "red=0-4000"
+    style:
+      bands:
+      -
+        min: 0
+        max: 4000
+        color: #ffffff
+        band: 1

--- a/test/test_source_multi.py
+++ b/test/test_source_multi.py
@@ -298,3 +298,21 @@ def testMultiAffineTransform():
         assert abs(np.average(thumbs[2048] - thumbs[256])) < 7
         assert abs(np.average(thumbs[1024] - thumbs[256])) < 7
         assert abs(np.average(thumbs[512] - thumbs[256])) < 7
+
+
+def testTilesWithStyleAndDtype():
+    testDir = os.path.dirname(os.path.realpath(__file__))
+    imagePath = os.path.join(testDir, 'test_files', 'multi_test_source_style.yml')
+    source = large_image_source_multi.open(imagePath)
+    tileMetadata = source.getMetadata()
+    assert tileMetadata['tileWidth'] == 256
+    assert tileMetadata['tileHeight'] == 256
+    assert tileMetadata['sizeX'] == 1000
+    assert tileMetadata['sizeY'] == 750
+    assert tileMetadata['levels'] == 3
+    utilities.checkTilesZXY(source, tileMetadata)
+    region1, _ = source.getRegion(
+        output=dict(maxWidth=100),
+        format=large_image.constants.TILE_FORMAT_NUMPY)
+    assert region1.shape == (75, 100, 1)
+    assert region1.dtype == np.uint8

--- a/tox.ini
+++ b/tox.ini
@@ -327,7 +327,7 @@ exclude =
   */web_client/*
   */*egg*/*
 # Ignore missing docstring errors.
-ignore = D100,D101,D102,D103,D104,D105,D106,D107,D200,D205,D400,D401,E741,W504,B017
+ignore = D100,D101,D102,D103,D104,D105,D106,D107,D200,D205,D400,D401,E741,W504,B017,C408
 
 [pytest]
 addopts = --verbose --strict-markers --showlocals --cov-report="term" --cov-report="xml" --cov-report="html" --cov --ignore test/utils


### PR DESCRIPTION
This allows better control over how files with styled sources are rendered.