### PR TITLE
Tifffile _biggestSeries() bug for large images

### DIFF
--- a/sources/tifffile/large_image_source_tifffile/__init__.py
+++ b/sources/tifffile/large_image_source_tifffile/__init__.py
@@ -180,7 +180,7 @@ class TifffileFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         ex = 'no maximum series'
         try:
             for idx, s in enumerate(self._tf.series):
-                samples = np.prod(s.shape)
+                samples = np.prod(np.sqrt(s.shape))
                 if samples > maxsamples and 'X' in s.axes and 'Y' in s.axes:
                     maxseries = idx
                     maxsamples = samples


### PR DESCRIPTION
The _biggestSeries() method used to read tifffile sources rely on np.prod(shape) to find the biggest series in the file (macro image > image). This leads to an overflow for big images and the macro image is wrongly selected as the main content of the file. Simple fix is done with np.sqrt(), though a better solution could be found.