### PR TITLE
Zarr Sink Multiprocessing

### DIFF
--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -1,9 +1,9 @@
 import math
+import multiprocessing
 import os
 import shutil
 import tempfile
 import threading
-import multiprocessing
 import uuid
 import warnings
 from importlib.metadata import PackageNotFoundError

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -3,6 +3,7 @@ import pickle
 import pytest
 
 import large_image
+import large_image_source_vips
 
 from .datastore import datastore
 
@@ -61,6 +62,9 @@ def testPickleTile():
 
 
 def testPickleNew():
-    ts = large_image.new()
+    ts_zarr = large_image.new()
+    pickle.dumps(ts_zarr)
+
+    ts_vips = large_image_source_vips.new()
     with pytest.raises(pickle.PicklingError):
-        pickle.dumps(ts)
+        pickle.dumps(ts_vips)

--- a/test/test_pickle.py
+++ b/test/test_pickle.py
@@ -1,9 +1,9 @@
 import pickle
 
+import large_image_source_vips
 import pytest
 
 import large_image
-import large_image_source_vips
 
 from .datastore import datastore
 

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -486,6 +486,7 @@ def _add_tile_from_seed_data(sink, seed_data, position):
     )
 
 
+@pytest.mark.singular()
 def testConcurrency(tmp_path):
     output_file = tmp_path / 'test.db'
     max_workers = 5

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -1,11 +1,11 @@
 import math
+from multiprocessing.pool import Pool, ThreadPool
 
 import large_image_source_test
 import large_image_source_zarr
 import numpy as np
 import pytest
 from PIL import Image
-from multiprocessing.pool import Pool, ThreadPool
 
 import large_image
 from large_image.constants import NEW_IMAGE_PATH_FLAG
@@ -501,7 +501,7 @@ def testConcurrency(tmp_path):
                     'z': z,
                     'y': slice(y * tile_size[0], (y + 1) * tile_size[0]),
                     'x': slice(x * tile_size[1], (x + 1) * tile_size[1]),
-                    's': slice(0, target_shape[3])
+                    's': slice(0, target_shape[3]),
                 })
 
     for pool_class in [Pool, ThreadPool]:


### PR DESCRIPTION
In addition to the zarr sink being compatible with multithreading, this PR makes the zarr sink compatible with multiprocessing. This is accomplished by the following:

-  splitting the `addLock` into `threadLock` and `processLock` (each a different class)
-  changing how a zarr sink is initialized from a path; now made more predictable by using `os.tempdir` as the root rather than a generated `tempdir.TemporaryDirectory()` and opened with "append" mode via zarr
- removing the clause to set `self.unpickleable = True`
- adding a pytest to check the behavior of both multithreading and multiprocessing cases

With this addition, there continues to be the caveat that the size of the whole image must be known before any multiprocessing or multithreading can work. The image size cannot be changed within a thread or process. The test reflects this; the last tile in the tileset (at the maximum extents) is added first, then all other tiles are added within a thread or process. 