### PR TITLE
Switch to using COVERAGE_CORE=sysmon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ commands:
           # consume the exit code
           # command: PYTEST_ADDOPTS=--forked tox -e << parameters.env >> | cat; test ${PIPESTATUS[0]} -eq 0
           # command: PYTEST_ADDOPTS="--reruns=3 --numprocesses=0" tox -e << parameters.env >> | cat; test ${PIPESTATUS[0]} -eq 0
-          command: PYTEST_NUMPROCESSES=3 PYTEST_ADDOPTS="--reruns=3" tox -e << parameters.env >> | cat; test ${PIPESTATUS[0]} -eq 0
+          command: COVERAGE_CORE=sysmon PYTEST_NUMPROCESSES=3 PYTEST_ADDOPTS="--reruns=3" tox -e << parameters.env >> | cat; test ${PIPESTATUS[0]} -eq 0
   switchpython:
     description: "Upgrade python"
     parameters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 - Improved zarr sink metadata handling ([#1508](../../pull/1508))
-- Speed up decoding jp2k tiff with an optional library ([#1553](../../pull/1553))
+- Speed up decoding jp2k tiff with an optional library ([#1555](../../pull/1555))
 
 ### Changes
 - Work with newer python-mapnik ([#1550](../../pull/1550))

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skip_missing_interpreters = true
 toxworkdir = {toxinidir}/build/tox
 
 [testenv]
-passenv = PYTEST_*,DICOMWEB_TEST_URL,DICOMWEB_TEST_TOKEN
+passenv = PYTEST_*,COVERAGE_*,DICOMWEB_TEST_URL,DICOMWEB_TEST_TOKEN
 extras =
   memcached
   redis
@@ -395,6 +395,7 @@ include =
   utilities/converter/*
   utilities/tasks*
 parallel = True
+core = sysmon
 
 [coverage:html]
 directory = build/test/artifacts/python_coverage


### PR DESCRIPTION
This should speed up python 3.12 tests with coverage.  See https://github.com/nedbat/coveragepy/pull/1747