### PR TITLE
Better handle images that are composed of a folder and an item.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 - Show a loading spinner on the image display in geojs in girder ([#1559](../../pull/1559))
+-
 
 ### Bug Fixes
 - Fix a compositing error in transformed multi source images ([#1560](../../pull/1560))

--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -183,6 +183,7 @@ class BioformatsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
     extensions = {
         None: SourcePriority.FALLBACK,
         'czi': SourcePriority.PREFERRED,
+        'ets': SourcePriority.LOW,  # part of vsi
         'lif': SourcePriority.MEDIUM,
         'vsi': SourcePriority.PREFERRED,
     }

--- a/sources/openslide/large_image_source_openslide/__init__.py
+++ b/sources/openslide/large_image_source_openslide/__init__.py
@@ -48,6 +48,7 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         None: SourcePriority.MEDIUM,
         'bif': SourcePriority.LOW,  # Ventana
         'dcm': SourcePriority.LOW,  # DICOM
+        'ini': SourcePriority.LOW,  # Part of mrxs
         'mrxs': SourcePriority.PREFERRED,  # MIRAX
         'ndpi': SourcePriority.PREFERRED,  # Hamamatsu
         'scn': SourcePriority.LOW,  # Leica


### PR DESCRIPTION
Some file formats (mrxs, vsi) include folders of files and a root file. These need to be processed after all files are present, not when just the root file is present.  This change checks for a named file within the folder and, if present and not a large image, checks if the parent item exists and is not a large image.