### PR TITLE
Turn off a linting rule that changes code

### DIFF
--- a/girder/girder_large_image/web_client/package.json
+++ b/girder/girder_large_image/web_client/package.json
@@ -66,7 +66,8 @@
             "promise/no-native": "error",
             "promise/no-return-in-finally": "error",
             "promise/no-return-wrap": "error",
-            "vue/require-prop-types": "off"
+            "vue/require-prop-types": "off",
+            "vue/multiline-html-element-content-newline": "off"
         },
         "root": true
     },


### PR DESCRIPTION
Adding extra white space into html can change the meaning; don't required that in vue components.