### PR TITLE
Create new large images for each item in a folder

### DIFF
--- a/girder/girder_large_image/rest/large_image_resource.py
+++ b/girder/girder_large_image/rest/large_image_resource.py
@@ -454,7 +454,7 @@ class LargeImageResource(Resource):
                'existing or unfinished large images.')
         .modelParam('id', 'The ID of the folder.', model=Folder, level=AccessType.WRITE,
                     required=True)
-        .param('createJobs', 'Whether job(s) should be created for each large image.',
+        .param('force', 'Whether creation job(s) should be forced for each large image.',
                required=False, default=False, dataType='boolean')
         .param('localJobs', 'Whether the job(s) created should be local.', required=False,
                default=False, dataType='boolean')
@@ -465,9 +465,7 @@ class LargeImageResource(Resource):
     )
     def createLargeImages(self, folder, params):
         user = self.getCurrentUser()
-        createJobs = params.get('createJobs')
-        if createJobs:
-            createJobs = 'always' or True
+        createJobs = 'always' if self.boolParam('force', params, default=False) else True
         return self.createImagesRecurseOption(folder=folder, createJobs=createJobs, user=user,
                                               recurse=params.get('recurse'),
                                               localJobs=params.get('localJobs'))
@@ -496,7 +494,7 @@ class LargeImageResource(Resource):
                         ImageItem().getMetadata(item)
                         result['itemsSkipped'] += 1
                         continue
-                    except TileSourceError:
+                    except (TileSourceError, KeyError):
                         previousFileId = item['largeImage'].get('originalId',
                                                                 item['largeImage']['fileId'])
                         ImageItem().delete(item)

--- a/girder/girder_large_image/rest/large_image_resource.py
+++ b/girder/girder_large_image/rest/large_image_resource.py
@@ -502,12 +502,10 @@ class LargeImageResource(Resource):
                                                     createJob=createJobs, localJob=localJobs)
                         result['largeImagesRemovedAndRecreated'] += 1
             else:
-                largeImageFileId = None
-                files = list(Item().childFiles(item=item))
+                files = list(Item().childFiles(item=item, limit=2))
                 if len(files) == 1:
-                    largeImageFileId = str(files[0]['_id'])
-                    ImageItem().createImageItem(item, File().load(user=user, id=largeImageFileId),
-                                                createJob=createJobs, localJob=localJobs)
+                    ImageItem().createImageItem(item, files[0], createJob=createJobs,
+                                                localJob=localJobs)
                     result['largeImagesCreated'] += 1
         return result
 

--- a/girder/test_girder/test_large_image.py
+++ b/girder/test_girder/test_large_image.py
@@ -237,6 +237,25 @@ def testThumbnailFileJob(server, admin, user, fsAssetstore):
     Setting().set(constants.PluginSettings.LARGE_IMAGE_MAX_THUMBNAIL_FILES, 0)
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
+@pytest.mark.plugin('large_image')
+def testFolderCreateImages(server, admin, user, fsAssetstore):
+    file = utilities.uploadExternalFile('sample_image.ptif', admin, fsAssetstore)
+    itemId = file['itemId']
+    item = Item().load(itemId, user=admin)
+    folderId = str(item['folderId'])
+    # Remove the large image from this item
+    ImageItem().delete(item)
+    # Ask to make all items in this folder large images
+    resp = server.request(
+        method='PUT', path=f'/large_image/folder/{folderId}/tiles', user=admin)
+    assert utilities.respStatus(resp) == 200
+    assert resp.json['largeImagesCreated'] == 1
+    item = Item().load(itemId, user=admin)
+    # Check that this item became a large image again
+    assert 'largeImage' in item
+
+
 @pytest.mark.singular()
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')

--- a/girder/test_girder/test_large_image.py
+++ b/girder/test_girder/test_large_image.py
@@ -254,6 +254,18 @@ def testFolderCreateImages(server, admin, user, fsAssetstore):
     item = Item().load(itemId, user=admin)
     # Check that this item became a large image again
     assert 'largeImage' in item
+    # Hitting the endpoint again should skip the item
+    resp = server.request(
+        method='PUT', path=f'/large_image/folder/{folderId}/tiles', user=admin)
+    assert utilities.respStatus(resp) == 200
+    assert resp.json['itemsSkipped'] == 1
+    # If the item's source isn't working, it should be recreated.
+    item['largeImage']['sourceName'] = 'unknown'
+    Item().updateItem(item)
+    resp = server.request(
+        method='PUT', path=f'/large_image/folder/{folderId}/tiles', user=admin)
+    assert utilities.respStatus(resp) == 200
+    assert resp.json['largeImagesRemovedAndRecreated'] == 1
 
 
 @pytest.mark.singular()


### PR DESCRIPTION
This adds an endpoint that creates large images for an entire folder, as mentioned [here](https://github.com/girder/large_image/issues/1139). It iterates through the folder's items, skips over items with a large image already and creates a large image for the items without one. It has several options, one that recurses child folders, a second that creates a job for each large image item, and another that makes the jobs local.

This does not yet retry creating large images for items with an unfinished large image, but seemed to be a good start.