### PR TITLE
Use flat mount paths where possible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Improve plottable data endpoint to better fetch adjacent items and annotations ([#1573](../../pull/1573), [#1574](../../pull/1574))), [#1575](../../pull/1575)))
+- Support Girder flat-mount paths ([#1576](../../pull/1576))
 
 ## 1.29.2
 

--- a/girder/girder_large_image/girder_tilesource.py
+++ b/girder/girder_large_image/girder_tilesource.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import re
 
@@ -99,7 +100,10 @@ class GirderTileSource(tilesource.FileTileSource):
                     pass
                 if not largeImagePath:
                     try:
-                        largeImagePath = File().getGirderMountFilePath(largeImageFile)
+                        largeImagePath = File().getGirderMountFilePath(
+                            largeImageFile,
+                            **({'preferFlat': True} if 'preferFlat' in inspect.signature(
+                                File.getGirderMountFilePath).parameters else {}))
                     except FilePathException:
                         pass
             if not largeImagePath:

--- a/utilities/tasks/large_image_tasks/tasks.py
+++ b/utilities/tasks/large_image_tasks/tasks.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import os
 import shutil
@@ -128,7 +129,10 @@ def convert_image_job(job):
         inputPath = None
         if not fileObj.get('imported'):
             try:
-                inputPath = File().getGirderMountFilePath(fileObj)
+                inputPath = File().getGirderMountFilePath(
+                    fileObj,
+                    **({'preferFlat': True} if 'preferFlat' in inspect.signature(
+                        File.getGirderMountFilePath).parameters else {}))
             except Exception:
                 pass
         inputPath = inputPath or File().getLocalFilePath(fileObj)


### PR DESCRIPTION
This improves the ability to read multi-image file formats where the reader doesn't know about girder's item-as-folder resource paths. Specifically, formats like vsi that are imported from S3 mounts will now be properly accessible with this change.