### PR TITLE
Harden marking S3 uploads as large images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Create or check large images for each item in a folder ([#1572](../../pull/1572))
 - Support multiprocessing and pickling with a zarr sink ([#1551](../../pull/1551))
 
+### Bug Fixes
+- Harden marking S3 uploads as large images ([#1579](../../pull/1579))
+
 ## 1.29.2
 
 ### Improvements


### PR DESCRIPTION
The S3 assetstore upload process saves the uploaded file potentially before the upload is finalized in S3.  Reading the file immediately can report that the S3 key does not exist.  When detecting uploaded files for S3, check if the S3 reported size is the same as the uploaded size. If not, poll and wait before checking.