### PR TITLE
Speed up checks for old annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Make the plottable data class threadsafe ([#1588](../../pull/1588))
 - Speed up getting plottable data from items ([#1589](../../pull/1589))
 - Add an index to speed up getting plottable data from annotation elements ([#1590](../../pull/1590))
+- Speed up checks for old annotations ([#1591](../../pull/1591))
 
 ## 1.29.4
 


### PR DESCRIPTION
Use aggregation pipelines rather than plain queries.