### PR TITLE
Don't redirect tile frame images via 303

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Speed up checks for old annotations ([#1591](../../pull/1591))
 - Improve plottable data endpoint to better fetch folder data ([#1594](../../pull/1594))
 
+### Bug Fixes
+
+- Don't redirect tile frame images via 303; they aren't rendered correctly ([#1596](../../pull/1596))
+
 ## 1.29.4
 
 ### Improvements

--- a/girder/girder_large_image/models/image_item.py
+++ b/girder/girder_large_image/models/image_item.py
@@ -410,7 +410,8 @@ class ImageItem(Item):
             if pickleCache:
                 data = File().open(existing).read()
                 return pickle.loads(data), 'application/octet-stream'
-            return File().download(existing, contentDisposition=contentDisposition)
+            return File().download(existing, contentDisposition=contentDisposition,
+                                   headers=kwargs.get('headers', True))
         if checkAndCreate == 'check':
             return False
         return self.getAndCacheImageOrDataRun(
@@ -563,7 +564,7 @@ class ImageItem(Item):
         imageKey = 'tileFrames'
         return self._getAndCacheImageOrData(
             item, 'tileFrames', checkAndCreate,
-            dict(kwargs, imageKey=imageKey), **kwargs)
+            dict(kwargs, imageKey=imageKey), headers=False, **kwargs)
 
     def getPixel(self, item, **kwargs):
         """


### PR DESCRIPTION
They aren't rendered correctly.  Apparently pulling in a 303 redirect on a texture image doesn't work as expected.