### PR TITLE
Use linkchecker to verify all docs links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,6 +229,9 @@ jobs:
       - run:
           name: Install dependencies
           command: apt-get update -yq && apt-get install -yq pandoc && pandoc --version
+      - run:
+          name: Permissions for link checker
+          command: find /root -type d -exec chmod 755 {} \+
       - tox:
           env: docs,lint,lintclient,notebook
       - store_artifacts:

--- a/docs/girder_config_options.rst
+++ b/docs/girder_config_options.rst
@@ -225,7 +225,7 @@ Image Frame Presets
 
 This is used to specify a list of presets for viewing images in the folder.
 Presets can be customized and saved in the GeoJS Image Viewer.
-To retrieve saved presets, use http://[serverURL]/api/v1/item/[itemID]/internal_metadata/presets.
+To retrieve saved presets, use ``[serverURL]/api/v1/item/[itemID]/internal_metadata/presets``.
 You can convert the response to YAML and paste it into the ``imageFramePresets`` key in your config file.
 
 Each preset can specify a name, a view mode, an image frame, and style options.

--- a/tox.ini
+++ b/tox.ini
@@ -288,6 +288,7 @@ description = Build documentation
 deps =
   -rrequirements-test.txt
   jupyter
+  linkchecker
   nbsphinx
   pypandoc
   sphinx
@@ -299,6 +300,7 @@ allowlist_externals =
   make_docs.sh
 commands =
   ./make_docs.sh
+  linkchecker "{toxinidir}/build/docs/index.html"
 
 [testenv:compare]
 description = Compare inputs with different sources


### PR DESCRIPTION
@annehaley It occurred to me that we should test the links that the documentation generates to ensure that they go to actual destinations.  I added a test as part of building the docs with tox.