### PR TITLE
Silence a type warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add an index to speed up getting plottable data from annotation elements ([#1590](../../pull/1590))
 - Speed up checks for old annotations ([#1591](../../pull/1591))
 - Improve plottable data endpoint to better fetch folder data ([#1594](../../pull/1594))
+- Show a frame slider when appropriate in jupyter widgets ([#1595](../../pull/1595))
 
 ### Bug Fixes
 

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -649,9 +649,9 @@ def getPaletteColors(value: Union[str, List[Union[str, float, Tuple[float, ...]]
             if value in mpl.colors.get_named_colors_mapping():
                 palette = ['#0000', mpl.colors.to_hex(str(value))]
             else:
-                cmap = mpl.colormaps.get_cmap(str(value)) if hasattr(getattr(
-                    mpl, 'colormaps', None), 'get_cmap') else mpl.cm.get_cmap(
-                        str(value))
+                cmap = (mpl.colormaps.get_cmap(str(value)) if hasattr(getattr(
+                    mpl, 'colormaps', None), 'get_cmap') else
+                    mpl.cm.get_cmap(str(value)))  # type: ignore
                 palette = [mpl.colors.to_hex(cmap(i)) for i in range(cmap.N)]
         except (ImportError, ValueError, AttributeError):
             pass


### PR DESCRIPTION
The type checker started throwing a warning where we have some code to fallback to previous versions of external libraries.  Silence this warning.