### PR TITLE
Add a lock to avoid mongo excessively computing random numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Speed up checks for old annotations ([#1591](../../pull/1591))
 - Improve plottable data endpoint to better fetch folder data ([#1594](../../pull/1594))
 - Show a frame slider when appropriate in jupyter widgets ([#1595](../../pull/1595))
+- Improve options for creating or check large images for each item in a folder ([#1586](../../pull/1586))
+- Add a lock to avoid mongo excessively computing random numbers ([#1601](../../pull/1601))
 
 ### Bug Fixes
 

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -651,7 +651,7 @@ def getPaletteColors(value: Union[str, List[Union[str, float, Tuple[float, ...]]
             else:
                 cmap = (mpl.colormaps.get_cmap(str(value)) if hasattr(getattr(
                     mpl, 'colormaps', None), 'get_cmap') else
-                    mpl.cm.get_cmap(str(value)))  # type: ignore
+                    mpl.cm.get_cmap(str(value)))
                 palette = [mpl.colors.to_hex(cmap(i)) for i in range(cmap.N)]
         except (ImportError, ValueError, AttributeError):
             pass


### PR DESCRIPTION
When ingesting annotation elements, we use insert_many in batches split across a thread pool.  There is some work (such as computing bounding boxes) that parallelizes decently.  The actual mongo insert_many call _does_ parallelize, but is slower than using a lock to prevent concurrency.

The specific problem is that mongo assigns new ids to the new element documents using the bson package's ObjectID class.  This class generates a new random number as part of the id whenever it is called from a different thread pid.  The bulk of the insert time ends up being generating random numbers rather than anything else.  By having a lock, this will only trigger the pid-change code once per batch.

One test showed a large annotation insert time dropping from 395 seconds to 140 seconds, and the cpu utilization dropping from 100% across all cores to around 4 cores in use.  A longer run of a mixed set of annotations (some large, some small) dropped the time from 10:36 to 4:57.