### PR TITLE
Disable client tests with openseadragon.

### DIFF
--- a/girder_annotation/test_annotation/web_client_specs/annotationListSpec.js
+++ b/girder_annotation/test_annotation/web_client_specs/annotationListSpec.js
@@ -167,13 +167,13 @@ describe('AnnotationListWidget', function () {
     });
 
     describe('Test annotation list widget as admin', function () {
-        it('select the openseadragon viewer', function () {
+        xit('select the openseadragon viewer', function () {
             runs(function () {
                 $('.g-item-image-viewer-select select').val('openseadragon').trigger('change');
             });
             waitForLargeImageViewer('openseadragon');
         });
-        it('select the geojs viewer', function () {
+        xit('select the geojs viewer', function () {
             runs(function () {
                 $('.g-item-image-viewer-select select').val('geojs').trigger('change');
             });


### PR DESCRIPTION
It is no longer compatible with the phantomjs test runner.  We can reenable this test once girder upgrades to a modern test harness.