### PR TITLE
Use math.prod in preference to np.prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.29.6
+
+### Bug Fixes
+
+- Use math.prod in preference to np.prod ([#1606](../../pull/1606))
+
 ## 1.29.5
 
 ### Improvements

--- a/sources/tifffile/large_image_source_tifffile/__init__.py
+++ b/sources/tifffile/large_image_source_tifffile/__init__.py
@@ -183,7 +183,7 @@ class TifffileFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         ex = 'no maximum series'
         try:
             for idx, s in enumerate(self._tf.series):
-                samples = np.prod(s.shape)
+                samples = math.prod(s.shape)
                 if samples > maxsamples and 'X' in s.axes and 'Y' in s.axes:
                     maxseries = idx
                     maxsamples = samples
@@ -232,7 +232,7 @@ class TifffileFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 'sizeX': s.shape[s.axes.index('X')], 'sizeY': s.shape[s.axes.index('Y')]})
             self.sizeX = max(self.sizeX, s.shape[s.axes.index('X')])
             self.sizeY = max(self.sizeY, s.shape[s.axes.index('Y')])
-        self._framecount = len(self._series) * np.prod(tuple(
+        self._framecount = len(self._series) * math.prod(tuple(
             1 if base.axes[sidx] in 'YXS' else v for sidx, v in enumerate(base.shape)))
         self._basis = {}
         basis = 1

--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -659,7 +659,7 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 self._bandCount = new_dims.get(axes[-1])  # last axis is assumed to be bands
                 self.sizeX = new_dims.get('x')
                 self.sizeY = new_dims.get('y')
-                self._framecount = np.prod([
+                self._framecount = math.prod([
                     length
                     for axis, length in new_dims.items()
                     if axis in axes[:-3]


### PR DESCRIPTION
Fixes #1606.

On some systems, numpy defaults to 32 bit integers.  When np.prod produces should produce a value greater than `2^31 - 1`, it overflows and produces a value that isn't accurate.  Since `math.prod` was added in Python 3.8, we can just switch to `math.prod` and let python take care of arbitrary sized integers regardless of its environment.