### PR TITLE
Yamlfix doesn't work with a recent package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,3 +106,5 @@ repos:
         args:
           - -c
           - pyproject.toml
+        additional_dependencies:
+          - 'maison<2.0.0'

--- a/tox.ini
+++ b/tox.ini
@@ -173,6 +173,7 @@ deps =
   flake8-quotes
   ruff
   yamlfix
+  maison<2.0.0
 allowlist_externals =
   find
 commands =
@@ -230,6 +231,7 @@ deps =
   unify
   ruff
   yamlfix
+  maison<2.0.0
 allowlist_externals =
   find
 commands =


### PR DESCRIPTION
Pin maison so yamlfix will still work.  See
https://github.com/lyz-code/yamlfix/issues/286 for details.  The pinned packages should be unpinned when that issues is addressed.