### PR TITLE
Fix the README.rst so we can deploy.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ Large Image consists of several Python modules designed to work together.  These
 
   - ``large-image-source-openslide``: A tile source using the OpenSlide library.  This works with svs, ndpi, Mirax, tiff, vms, and other file formats.
 
-  - ``large-image-source-pil``: A tile source for small images via the Python Imaging Library (Pillow). By default, the maximum size is 4096, but the maximum size can be configured (see :ref:`Configuration Options<config_max_small_image_size>`).
+  - ``large-image-source-pil``: A tile source for small images via the Python Imaging Library (Pillow). By default, the maximum size is 4096, but the maximum size can be configured.
 
   - ``large-image-source-tiff``: A tile source for reading pyramidal tiff files in common compression formats.
 
@@ -159,7 +159,7 @@ Most tile sources can be used with Girder Large Image.  You can specify an extra
   - ``girder-large-image``: Large Image as a Girder 3.x plugin.
     You can install ``large-image[tasks]`` to install a Girder Worker task that can convert otherwise unreadable images to pyramidal tiff files.
 
-  - ``girder-large-image-annotation``: Adds models to the Girder database for supporting annotating large images.  These annotations can be rendered on images. Annotations can include polygons, points, image overlays, and other types (see :doc:`annotations`). Each annotation can have a label and metadata.
+  - ``girder-large-image-annotation``: Adds models to the Girder database for supporting annotating large images.  These annotations can be rendered on images. Annotations can include polygons, points, image overlays, and other types. Each annotation can have a label and metadata.
 
   - ``large-image-tasks``: A utility for running the converter via Girder Worker.
     You can specify an extras_require of ``girder`` to include modules needed to work with the Girder remote worker or ``worker`` to include modules needed on the remote side of the Girder remote worker.  If neither is specified, some conversion tasks can be run using Girder local jobs.


### PR DESCRIPTION
Because we use the README as part of the built docs, we added references into it.  These won't deploy, as the description uploaded to pypi.org can't use them directly.