### PR TITLE
Add a utility function to minimize caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Speed up getting plottable data from adjacent items; plot more data ([#1613](../../pull/1613), [#1614](../../pull/1614))
 - Better handle mixed dtype sources in the multi source ([#1616](../../pull/1616))
+- Add a utility function to minimize caching ([#1617](../../pull/1617))
 
 ### Bug Fixes
 

--- a/large_image/config.py
+++ b/large_image/config.py
@@ -185,3 +185,17 @@ def total_memory() -> int:
     if mem:
         return mem
     return 8 * 1024 ** 3
+
+
+def minimizeCaching(mode=None):
+    """
+    Set python cache sizes to very low values.
+
+    :param mode: None for all caching, 'tile' for the tile cache, 'source' for
+        the source cache.
+    """
+    if not mode or str(mode).lower().startswith('source'):
+        setConfig('cache_tilesource_maximum', 1)
+    if not mode or str(mode).lower().startswith('tile'):
+        setConfig('cache_backend', 'python')
+        setConfig('cache_python_memory_portion', 256)


### PR DESCRIPTION
When a workflow opens a lot of tile sources and uses each one once, caching is often wasteful.  This adds a utility function `large_image.config.minimizeCaching()` for these cases.