### PR TITLE
Generate a docs table for file format examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ node_modules/
 test/externaldata
 
 docs/source/*
+docs/format_examples
+docs/format_table.rst
 !docs/source/*.py
 !docs/source/*.rst
 docs/_build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build/**.ipynb', '**.ipynb_checkpoints']
+exclude_patterns = ['_build/**.ipynb', '**.ipynb_checkpoints', 'format_table.rst']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/format_examples_datastore.py
+++ b/docs/format_examples_datastore.py
@@ -5,7 +5,8 @@ EXAMPLES_FOLDER = Path('format_examples')
 
 format_examples = [
     dict(
-        name='TIFF (Tagged Image File Format)',
+        name='TIFF',
+        long_name='Tagged Image File Format',
         reference='https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf',
         examples=[
             dict(
@@ -21,7 +22,8 @@ format_examples = [
         ],
     ),
     dict(
-        name='SVS (Aperio ScanScope Virtual Slide)',
+        name='SVS',
+        long_name='Aperio ScanScope Virtual Slide',
         reference='https://paulbourke.net/dataformats/svs/',
         examples=[
             dict(
@@ -32,7 +34,8 @@ format_examples = [
         ],
     ),
     dict(
-        name='OME-TIFF (Open Microscopy Environment Tagged Image File Format)',
+        name='OME-TIFF',
+        long_name='Open Microscopy Environment Tagged Image File Format',
         reference='https://docs.openmicroscopy.org/ome-model/5.6.3/ome-tiff/',
         examples=[
             dict(
@@ -43,7 +46,8 @@ format_examples = [
         ],
     ),
     dict(
-        name='NDPI (Hamamatsu NanoZoomer Digital Pathology Image)',
+        name='NDPI',
+        long_name='Hamamatsu NanoZoomer Digital Pathology Image',
         reference='https://openslide.org/formats/hamamatsu/',
         examples=[
             dict(
@@ -88,7 +92,8 @@ format_examples = [
         ],
     ),
     dict(
-        name='ND2 (Nikon NIS Elements)',
+        name='ND2',
+        long_name='Nikon NIS Elements',
         reference='https://docs.openmicroscopy.org/bio-formats/5.9.2/formats/nikon-nis-elements-nd2.html',
         examples=[
             dict(
@@ -99,7 +104,8 @@ format_examples = [
         ],
     ),
     dict(
-        name='CZI (Carl Zeiss Image)',
+        name='CZI',
+        long_name='Carl Zeiss Image',
         reference='https://www.zeiss.com/microscopy/en/products/software/zeiss-zen/czi-image-file-format.html',
         examples=[
             dict(
@@ -110,7 +116,8 @@ format_examples = [
         ],
     ),
     dict(
-        name='DICOM (Digital Imaging and Communications in Medicine)',
+        name='DICOM',
+        long_name='Digital Imaging and Communications in Medicine',
         reference='https://www.dicomstandard.org/about',
         examples=[
             dict(
@@ -121,7 +128,8 @@ format_examples = [
         ],
     ),
     dict(
-        name='LIF (Leica Image Format)',
+        name='LIF',
+        long_name='Leica Image Format',
         reference='https://svi.nl/LeicaLif',
         examples=[
             dict(
@@ -132,7 +140,8 @@ format_examples = [
         ],
     ),
     dict(
-        name='PNG (Portable Network Graphics)',
+        name='PNG',
+        long_name='Portable Network Graphics',
         reference='http://www.libpng.org/pub/png/spec/1.2/PNG-Structure.html',
         examples=[
             dict(
@@ -143,7 +152,8 @@ format_examples = [
         ],
     ),
     dict(
-        name='JPEG (Joint Photographic Experts Group)',
+        name='JPEG',
+        long_name='Joint Photographic Experts Group',
         reference='https://jpeg.org/jpeg/',
         examples=[
             dict(
@@ -158,7 +168,8 @@ format_examples = [
         ],
     ),
     dict(
-        name='JPEG (Joint Photographic Experts Group) 2000',
+        name='JPEG 2000',
+        long_name='Joint Photographic Experts Group 2000',
         reference='https://jpeg.org/jpeg2000/index.html',
         examples=[
             dict(
@@ -169,7 +180,8 @@ format_examples = [
         ],
     ),
     dict(
-        name='GIF (Graphics Interchange Format)',
+        name='GIF',
+        long_name='Graphics Interchange Format',
         reference='https://www.adobe.com/creativecloud/file-types/image/raster/gif-file.html',
         examples=[
             dict(

--- a/docs/format_examples_datastore.py
+++ b/docs/format_examples_datastore.py
@@ -10,7 +10,7 @@ format_examples = [
         examples=[
             dict(
                 filename='A5.pattern3.tif',
-                url='http://parakon.khq:8088/api/v1/item/650203a2cb6c25723b2b5361/download',
+                url='https://data.kitware.com/api/v1/item/66e1af78560e61279679128a/download',
                 hash='c6d198c3e0a1c46bd44f2a1c2c594db9c91a013e98a127d7eed727cd1b0d8d1e',
             ),
             dict(
@@ -112,7 +112,7 @@ format_examples = [
         examples=[
             dict(
                 filename='Plate1-Blue-A-02-Scene-1-P2-E1-01.czi',
-                url='http://parakon.khq:8088/api/v1/item/650203d4cb6c25723b2b5511/download',
+                url='https://data.kitware.com/api/v1/item/66e1af4d560e61279679127b/download',
                 hash='494936fa5a8c2e53b73672980986e2c44f3779e9b709ebfd406ffda723336376',
             ),
         ],
@@ -134,24 +134,24 @@ format_examples = [
         examples=[
             dict(
                 filename='test3.ndpis',
-                url='http://parakon.khq:8088/api/v1/item/6501efdee53b012280515c00/download',
+                url='https://data.kitware.com/api/v1/item/66e1af68560e612796791287/download',
                 hash='35542dff44d7844f1fac04c1703bdb1476f90f484457907ead132203e6de066e',
             ),
             dict(
                 filename='test3-TRITC 2 (560).ndpi',
-                url='http://parakon.khq:8088/api/v1/item/6501efdee53b012280515bfe/download',
+                url='https://data.kitware.com/api/v1/item/66e1af63560e61279679127e/download',
                 skip=True,
                 hash='f02985d30aa38060e83c9477a4435cb81b2a0a234d3d664195dfc5a4e2657be8',
             ),
             dict(
                 filename='test3-FITC 2 (485).ndpi',
-                url='http://parakon.khq:8088/api/v1/item/6501efdee53b012280515bfc/download',
+                url='https://data.kitware.com/api/v1/item/66e1af65560e612796791281/download',
                 skip=True,
                 hash='455069a02a761ecfedb93492f103dec8c5b23b7c46fd47e9d8d22191ea803018',
             ),
             dict(
-                filename='test3-DAPI 2 (387) .ndpi',
-                url='http://parakon.khq:8088/api/v1/item/6501efdee53b012280515bfa/download',
+                filename='test3-DAPI 2 (387).ndpi',
+                url='https://data.kitware.com/api/v1/item/66e1af68560e612796791284/download',
                 skip=True,
                 hash='9294d31f304f20ef1df1e08650d3f225b8ed44db8b2dc0d52f584449f85bdca2',
             ),

--- a/docs/format_examples_datastore.py
+++ b/docs/format_examples_datastore.py
@@ -6,6 +6,7 @@ EXAMPLES_FOLDER = Path('format_examples')
 format_examples = [
     dict(
         name='TIFF',
+        extensions=['tiff', 'tif', 'ptif', 'ptiff', 'qptiff'],
         long_name='Tagged Image File Format',
         reference='https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf',
         examples=[
@@ -14,15 +15,11 @@ format_examples = [
                 url='https://data.kitware.com/api/v1/item/66e30827560e6127967912cf/download',
                 hash='8a03ae4370a35517e2ab2249177d903c1ea52869e30dc558750c626d9edbae6f',
             ),
-            dict(
-                filename='sample_image.ptif',
-                url='https://data.kitware.com/api/v1/file/5be43e398d777f217991e21f/download',
-                hash='d73cbf87aac8f9cd9544b20d6c42537f4c609da15817928c8824d57049a2749a',
-            ),
         ],
     ),
     dict(
         name='SVS',
+        extensions=['svs', 'svslide'],
         long_name='Aperio ScanScope Virtual Slide',
         reference='https://paulbourke.net/dataformats/svs/',
         examples=[
@@ -35,6 +32,7 @@ format_examples = [
     ),
     dict(
         name='OME-TIFF',
+        extensions=['ome.tiff', 'ome.tif', 'ome'],
         long_name='Open Microscopy Environment Tagged Image File Format',
         reference='https://docs.openmicroscopy.org/ome-model/5.6.3/ome-tiff/',
         examples=[
@@ -47,6 +45,7 @@ format_examples = [
     ),
     dict(
         name='NDPI',
+        extensions=['ndpi', 'ndpis'],
         long_name='Hamamatsu NanoZoomer Digital Pathology Image',
         reference='https://openslide.org/formats/hamamatsu/',
         examples=[
@@ -77,6 +76,7 @@ format_examples = [
     ),
     dict(
         name='Zarr',
+        extensions=['zarr', 'zarray', 'zattrs', 'zgroup', 'zip', 'db', 'sqlite'],
         reference='https://wiki.earthdata.nasa.gov/display/ESO/Zarr+Format',
         examples=[
             dict(
@@ -93,6 +93,7 @@ format_examples = [
     ),
     dict(
         name='ND2',
+        extensions=['nd2'],
         long_name='Nikon NIS Elements',
         reference='https://docs.openmicroscopy.org/bio-formats/5.9.2/formats/nikon-nis-elements-nd2.html',
         examples=[
@@ -105,6 +106,7 @@ format_examples = [
     ),
     dict(
         name='CZI',
+        extensions=['czi'],
         long_name='Carl Zeiss Image',
         reference='https://www.zeiss.com/microscopy/en/products/software/zeiss-zen/czi-image-file-format.html',
         examples=[
@@ -117,6 +119,7 @@ format_examples = [
     ),
     dict(
         name='DICOM',
+        extensions=['dcm', 'dic', 'dicom'],
         long_name='Digital Imaging and Communications in Medicine',
         reference='https://www.dicomstandard.org/about',
         examples=[
@@ -129,6 +132,7 @@ format_examples = [
     ),
     dict(
         name='LIF',
+        extensions=['lif', 'liff'],
         long_name='Leica Image Format',
         reference='https://svi.nl/LeicaLif',
         examples=[
@@ -141,6 +145,7 @@ format_examples = [
     ),
     dict(
         name='PNG',
+        extensions=['png'],
         long_name='Portable Network Graphics',
         reference='http://www.libpng.org/pub/png/spec/1.2/PNG-Structure.html',
         examples=[
@@ -153,6 +158,7 @@ format_examples = [
     ),
     dict(
         name='JPEG',
+        extensions=['jpeg', 'jpe', 'jpg'],
         long_name='Joint Photographic Experts Group',
         reference='https://jpeg.org/jpeg/',
         examples=[
@@ -169,6 +175,7 @@ format_examples = [
     ),
     dict(
         name='JPEG 2000',
+        extensions=['j2c', 'j2k', 'jp2', 'jpf', 'jpx'],
         long_name='Joint Photographic Experts Group 2000',
         reference='https://jpeg.org/jpeg2000/index.html',
         examples=[
@@ -181,6 +188,7 @@ format_examples = [
     ),
     dict(
         name='GIF',
+        extensions=['gif'],
         long_name='Graphics Interchange Format',
         reference='https://www.adobe.com/creativecloud/file-types/image/raster/gif-file.html',
         examples=[
@@ -193,6 +201,7 @@ format_examples = [
     ),
     dict(
         name='Bitmap',
+        extensions=['bmp'],
         reference='https://www.ece.ualberta.ca/~elliott/ee552/studentAppNotes/2003_w/misc/bmp_file_format/bmp_file_format.htm',
         examples=[
             dict(

--- a/docs/format_examples_datastore.py
+++ b/docs/format_examples_datastore.py
@@ -9,14 +9,9 @@ format_examples = [
         reference='https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf',
         examples=[
             dict(
-                filename='utmsmall.tif',
-                url='https://github.com/OSGeo/gdal/raw/master/autotest/gcore/data/utmsmall.tif',
-                hash='f40dae6e8b5e18f3648e9f095e22a0d7027014bb463418d32f732c3756d8c54f',
-            ),
-            dict(
-                filename='tcgaextract_rgb.tiff',
-                url='https://data.kitware.com/api/v1/file/649d939c5121da8eb1a81454/download',
-                hash='3cd5e1ebde5127bafebd9432e10b2c47d9035fb4242bd6e5e941389d2b23ec1e',
+                filename='A5.pattern3.tif',
+                url='http://parakon.khq:8088/api/v1/item/650203a2cb6c25723b2b5361/download',
+                hash='c6d198c3e0a1c46bd44f2a1c2c594db9c91a013e98a127d7eed727cd1b0d8d1e',
             ),
             dict(
                 filename='sample_image.ptif',
@@ -46,9 +41,9 @@ format_examples = [
         reference='http://www.libpng.org/pub/png/spec/1.2/PNG-Structure.html',
         examples=[
             dict(
-                filename='test.png',
-                url='https://github.com/OSGeo/gdal/raw/master/autotest/gdrivers/data/png/test.png',
-                hash='16cd80a28a70e0f71a6316fd8e3c679da2a2bf62bec913718c8063aff0e4a625',
+                filename='Animated_PNG_example_bouncing_beach_ball.png',
+                url='https://upload.wikimedia.org/wikipedia/commons/1/14/Animated_PNG_example_bouncing_beach_ball.png',
+                hash='3b28e2462f1b31d0d15d795e6e58baf397899c3f864be7034bf47939b5bbbc3b',
             ),
         ],
     ),
@@ -68,7 +63,7 @@ format_examples = [
         ],
     ),
     dict(
-        name='JPEG (Joint Photgraphic Experts Group) 2000',
+        name='JPEG (Joint Photographic Experts Group) 2000',
         reference='https://jpeg.org/jpeg2000/index.html',
         examples=[
             dict(
@@ -83,9 +78,9 @@ format_examples = [
         reference='https://www.adobe.com/creativecloud/file-types/image/raster/gif-file.html',
         examples=[
             dict(
-                filename='sample_640×426.gif',
-                url='https://filesamples.com/samples/image/gif/sample_640%C3%97426.gif',
-                hash='eb04e3ff38fc7ecba1f7715ca7dae26b24e03766dc7c43ddeec75d5f1af74acd',
+                filename='SampleGIFImage_40kbmb.gif',
+                url='https://sample-videos.com/gif/3.gif',
+                hash='0ff064ba36e4f493f6a1b3d9d29c8eee1b719e39fc6768c5a6129534869c380b',
             ),
         ],
     ),
@@ -116,9 +111,9 @@ format_examples = [
         reference='https://www.zeiss.com/microscopy/en/products/software/zeiss-zen/czi-image-file-format.html',
         examples=[
             dict(
-                filename='2014_07_01__0017_pt2.czi',
-                url='https://data.kitware.com/api/v1/file/56993f1f8d777f429eac914d/download',
-                hash='37b71c49dd0f0cf9ed3cf36c526db9c66b4c31032f42f8c31239f1a560c02741',
+                filename='Plate1-Blue-A-02-Scene-1-P2-E1-01.czi',
+                url='http://parakon.khq:8088/api/v1/item/650203d4cb6c25723b2b5511/download',
+                hash='494936fa5a8c2e53b73672980986e2c44f3779e9b709ebfd406ffda723336376',
             ),
         ],
     ),
@@ -138,9 +133,27 @@ format_examples = [
         reference='https://openslide.org/formats/hamamatsu/',
         examples=[
             dict(
-                filename='small2.ndpi',
-                url='https://data.kitware.com/api/v1/file/5afd931e8d777f15ebe1b0f5/download',
-                hash='4d66b72328b383dab7981e199f0251da01097d226cbe6023cfd7ee3c3cf5fec0',
+                filename='test3.ndpis',
+                url='http://parakon.khq:8088/api/v1/item/6501efdee53b012280515c00/download',
+                hash='35542dff44d7844f1fac04c1703bdb1476f90f484457907ead132203e6de066e',
+            ),
+            dict(
+                filename='test3-TRITC 2 (560).ndpi',
+                url='http://parakon.khq:8088/api/v1/item/6501efdee53b012280515bfe/download',
+                skip=True,
+                hash='f02985d30aa38060e83c9477a4435cb81b2a0a234d3d664195dfc5a4e2657be8',
+            ),
+            dict(
+                filename='test3-FITC 2 (485).ndpi',
+                url='http://parakon.khq:8088/api/v1/item/6501efdee53b012280515bfc/download',
+                skip=True,
+                hash='455069a02a761ecfedb93492f103dec8c5b23b7c46fd47e9d8d22191ea803018',
+            ),
+            dict(
+                filename='test3-DAPI 2 (387) .ndpi',
+                url='http://parakon.khq:8088/api/v1/item/6501efdee53b012280515bfa/download',
+                skip=True,
+                hash='9294d31f304f20ef1df1e08650d3f225b8ed44db8b2dc0d52f584449f85bdca2',
             ),
         ],
     ),
@@ -153,6 +166,26 @@ format_examples = [
                 url='https://data.kitware.com/api/v1/file/5fa1cbe750a41e3d192e18eb/download',
                 hash='5dabb19081db4893d58b6680e54b566fc6246ccbde10d41413201afd96499482',
             ),
+        ],
+    ),
+    dict(
+        name='ND2 (Nikon NIS Elements)',
+        reference='https://docs.openmicroscopy.org/bio-formats/5.9.2/formats/nikon-nis-elements-nd2.html',
+        examples=[
+            dict(
+                filename='sample_image.nd2',
+                url='https://downloads.openmicroscopy.org/images/ND2/aryeh/MeOh_high_fluo_003.nd2',
+            )
+        ],
+    ),
+   dict(
+        name='DICOM (Digital Imaging and Communications in Medicine)',
+        reference='https://www.dicomstandard.org/about',
+        examples=[
+            dict(
+                filename='US-MONO2-8-8x-execho.dcm',
+                url='https://downloads.openmicroscopy.org/images/DICOM/samples/US-MONO2-8-8x-execho.dcm',
+            )
         ],
     ),
 ]

--- a/docs/format_examples_datastore.py
+++ b/docs/format_examples_datastore.py
@@ -13,6 +13,147 @@ format_examples = [
                 url='https://github.com/OSGeo/gdal/raw/master/autotest/gcore/data/utmsmall.tif',
                 hash='f40dae6e8b5e18f3648e9f095e22a0d7027014bb463418d32f732c3756d8c54f',
             ),
+            dict(
+                filename='tcgaextract_rgb.tiff',
+                url='https://data.kitware.com/api/v1/file/649d939c5121da8eb1a81454/download',
+                hash='3cd5e1ebde5127bafebd9432e10b2c47d9035fb4242bd6e5e941389d2b23ec1e',
+            ),
+            dict(
+                filename='sample_image.ptif',
+                url='https://data.kitware.com/api/v1/file/5be43e398d777f217991e21f/download',
+                hash='d73cbf87aac8f9cd9544b20d6c42537f4c609da15817928c8824d57049a2749a',
+            ),
+        ],
+    ),
+    dict(
+        name='Zarr',
+        reference='https://wiki.earthdata.nasa.gov/display/ESO/Zarr+Format',
+        examples=[
+            dict(
+                filename='WD1.1_17-03_WT_MP.ome.zarr.zip',
+                url='https://data.kitware.com/api/v1/file/6544e995fdc1508d8bec1838/download',
+                hash='f7dfb6683107d1cb21a360e31752b02641a16e0d32a87698669838418f108831',
+            ),
+            dict(
+                filename='normmedia_8well_col2_livecellgfp.db',
+                url='https://data.kitware.com/api/v1/file/6544e9f5fdc1508d8bec1860/download',
+                hash='7d6cfb6967f79eb5201eebbe93418e26445676d9ea95a3bf49ff4ffbf0993e39',
+            ),
+        ],
+    ),
+    dict(
+        name='PNG (Portable Network Graphics)',
+        reference='http://www.libpng.org/pub/png/spec/1.2/PNG-Structure.html',
+        examples=[
+            dict(
+                filename='test.png',
+                url='https://github.com/OSGeo/gdal/raw/master/autotest/gdrivers/data/png/test.png',
+                hash='16cd80a28a70e0f71a6316fd8e3c679da2a2bf62bec913718c8063aff0e4a625',
+            ),
+        ],
+    ),
+    dict(
+        name='JPEG (Joint Photographic Experts Group)',
+        reference='https://jpeg.org/jpeg/',
+        examples=[
+            dict(
+                filename='albania.jpg',
+                url='https://github.com/OSGeo/gdal/blob/master/autotest/gdrivers/data/jpeg/albania.jpg',
+                hash='c454c477056b26cceb5461648f825efdf9362c7b7998a4a0ca41050629e692de',
+            ),
+            dict(
+                filename='clouds.jpeg',
+                url='https://data.kitware.com/api/v1/file/5afd936c8d777f15ebe1b4d4/download',
+                hash='fb195bb9dae13aa85d9f46f86ab9441a3b436dabbf57c68149453cba691d4391',
+            ),
+        ],
+    ),
+    dict(
+        name='JPEG (Joint Photgraphic Experts Group) 2000',
+        reference='https://jpeg.org/jpeg2000/index.html',
+        examples=[
+            dict(
+                filename='erdas_foo.jp2',
+                url='https://github.com/OSGeo/gdal/raw/master/autotest/gdrivers/data/jpeg2000/erdas_foo.jp2',
+                hash='d08653919c41a49cd31f9116278fe6a6d8c189dc6379a280810f65df11bde006',
+            ),
+        ],
+    ),
+    dict(
+        name='GIF (Graphics Interchange Format)',
+        reference='https://www.adobe.com/creativecloud/file-types/image/raster/gif-file.html',
+        examples=[
+            dict(
+                filename='sample_640×426.gif',
+                url='https://filesamples.com/samples/image/gif/sample_640%C3%97426.gif',
+                hash='eb04e3ff38fc7ecba1f7715ca7dae26b24e03766dc7c43ddeec75d5f1af74acd',
+            ),
+        ],
+    ),
+    dict(
+        name='Bitmap',
+        reference='https://www.ece.ualberta.ca/~elliott/ee552/studentAppNotes/2003_w/misc/bmp_file_format/bmp_file_format.htm',
+        examples=[
+            dict(
+                filename='1bit.bmp',
+                url='https://github.com/OSGeo/gdal/raw/master/autotest/gcore/data/1bit.bmp',
+                hash='b0c201bee1e5a36ee698ab098aa3480e20772869d8f5c788280e532fa3620667',
+            ),
+        ],
+    ),
+    dict(
+        name='LIF (Leica Image Format)',
+        reference='https://svi.nl/LeicaLif',
+        examples=[
+            dict(
+                filename='20191025 Test FRET 585. 423, 426.lif',
+                url='https://downloads.openmicroscopy.org/images/Leica-LIF/imagesc-30856/20191025%20Test%20FRET%20585.%20423,%20426.lif',
+                hash='8d4ee62868b9616b832c2eb28e7d62ec050fb032e0bc11ea0a392f5c84390c71',
+            ),
+        ],
+    ),
+    dict(
+        name='CZI (Carl Zeiss Image)',
+        reference='https://www.zeiss.com/microscopy/en/products/software/zeiss-zen/czi-image-file-format.html',
+        examples=[
+            dict(
+                filename='2014_07_01__0017_pt2.czi',
+                url='https://data.kitware.com/api/v1/file/56993f1f8d777f429eac914d/download',
+                hash='37b71c49dd0f0cf9ed3cf36c526db9c66b4c31032f42f8c31239f1a560c02741',
+            ),
+        ],
+    ),
+    dict(
+        name='SVS (Aperio ScanScope Virtual Slide)',
+        reference='https://paulbourke.net/dataformats/svs/',
+        examples=[
+            dict(
+                filename='CMU-1.svs',
+                url='https://data.kitware.com/api/v1/file/57b5d6558d777f10f2694486/download',
+                hash='00a3d54482cd707abf254fe69dccc8d06b8ff757a1663f1290c23418c480eb30',
+            ),
+        ],
+    ),
+    dict(
+        name='NDPI (Hamamatsu NanoZoomer Digital Pathology Image)',
+        reference='https://openslide.org/formats/hamamatsu/',
+        examples=[
+            dict(
+                filename='small2.ndpi',
+                url='https://data.kitware.com/api/v1/file/5afd931e8d777f15ebe1b0f5/download',
+                hash='4d66b72328b383dab7981e199f0251da01097d226cbe6023cfd7ee3c3cf5fec0',
+            ),
+        ],
+    ),
+    dict(
+        name='OME-TIFF (Open Microscopy Environment Tagged Image File Format)',
+        reference='https://docs.openmicroscopy.org/ome-model/5.6.3/ome-tiff/',
+        examples=[
+            dict(
+                filename='DDX58_AXL_EGFR_well2_XY04.ome.tif',
+                url='https://data.kitware.com/api/v1/file/5fa1cbe750a41e3d192e18eb/download',
+                hash='5dabb19081db4893d58b6680e54b566fc6246ccbde10d41413201afd96499482',
+            ),
         ],
     ),
 ]

--- a/docs/format_examples_datastore.py
+++ b/docs/format_examples_datastore.py
@@ -21,6 +21,57 @@ format_examples = [
         ],
     ),
     dict(
+        name='SVS (Aperio ScanScope Virtual Slide)',
+        reference='https://paulbourke.net/dataformats/svs/',
+        examples=[
+            dict(
+                filename='CMU-1.svs',
+                url='https://data.kitware.com/api/v1/file/57b5d6558d777f10f2694486/download',
+                hash='00a3d54482cd707abf254fe69dccc8d06b8ff757a1663f1290c23418c480eb30',
+            ),
+        ],
+    ),
+    dict(
+        name='OME-TIFF (Open Microscopy Environment Tagged Image File Format)',
+        reference='https://docs.openmicroscopy.org/ome-model/5.6.3/ome-tiff/',
+        examples=[
+            dict(
+                filename='DDX58_AXL_EGFR_well2_XY04.ome.tif',
+                url='https://data.kitware.com/api/v1/file/5fa1cbe750a41e3d192e18eb/download',
+                hash='5dabb19081db4893d58b6680e54b566fc6246ccbde10d41413201afd96499482',
+            ),
+        ],
+    ),
+    dict(
+        name='NDPI (Hamamatsu NanoZoomer Digital Pathology Image)',
+        reference='https://openslide.org/formats/hamamatsu/',
+        examples=[
+            dict(
+                filename='test3.ndpis',
+                url='https://data.kitware.com/api/v1/item/66e1af68560e612796791287/download',
+                hash='35542dff44d7844f1fac04c1703bdb1476f90f484457907ead132203e6de066e',
+            ),
+            dict(
+                filename='test3-TRITC 2 (560).ndpi',
+                url='https://data.kitware.com/api/v1/item/66e1af63560e61279679127e/download',
+                skip=True,
+                hash='f02985d30aa38060e83c9477a4435cb81b2a0a234d3d664195dfc5a4e2657be8',
+            ),
+            dict(
+                filename='test3-FITC 2 (485).ndpi',
+                url='https://data.kitware.com/api/v1/item/66e1af65560e612796791281/download',
+                skip=True,
+                hash='455069a02a761ecfedb93492f103dec8c5b23b7c46fd47e9d8d22191ea803018',
+            ),
+            dict(
+                filename='test3-DAPI 2 (387).ndpi',
+                url='https://data.kitware.com/api/v1/item/66e1af68560e612796791284/download',
+                skip=True,
+                hash='9294d31f304f20ef1df1e08650d3f225b8ed44db8b2dc0d52f584449f85bdca2',
+            ),
+        ],
+    ),
+    dict(
         name='Zarr',
         reference='https://wiki.earthdata.nasa.gov/display/ESO/Zarr+Format',
         examples=[
@@ -33,6 +84,50 @@ format_examples = [
                 filename='normmedia_8well_col2_livecellgfp.db',
                 url='https://data.kitware.com/api/v1/file/6544e9f5fdc1508d8bec1860/download',
                 hash='7d6cfb6967f79eb5201eebbe93418e26445676d9ea95a3bf49ff4ffbf0993e39',
+            ),
+        ],
+    ),
+    dict(
+        name='ND2 (Nikon NIS Elements)',
+        reference='https://docs.openmicroscopy.org/bio-formats/5.9.2/formats/nikon-nis-elements-nd2.html',
+        examples=[
+            dict(
+                filename='sample_image.nd2',
+                url='https://downloads.openmicroscopy.org/images/ND2/aryeh/MeOh_high_fluo_003.nd2',
+                hash='8e23bb594cd18314f9c18e70d736088ae46f8bc696ab7dc047784be416d7a706',
+            ),
+        ],
+    ),
+    dict(
+        name='CZI (Carl Zeiss Image)',
+        reference='https://www.zeiss.com/microscopy/en/products/software/zeiss-zen/czi-image-file-format.html',
+        examples=[
+            dict(
+                filename='Plate1-Blue-A-02-Scene-1-P2-E1-01.czi',
+                url='https://data.kitware.com/api/v1/item/66e1af4d560e61279679127b/download',
+                hash='494936fa5a8c2e53b73672980986e2c44f3779e9b709ebfd406ffda723336376',
+            ),
+        ],
+    ),
+    dict(
+        name='DICOM (Digital Imaging and Communications in Medicine)',
+        reference='https://www.dicomstandard.org/about',
+        examples=[
+            dict(
+                filename='US-MONO2-8-8x-execho.dcm',
+                url='https://downloads.openmicroscopy.org/images/DICOM/samples/US-MONO2-8-8x-execho.dcm',
+                hash='7d3f54806d0315c6cfc8b7371649a242b5ef8f31e0d20221971dd8087f2ff1ea',
+            ),
+        ],
+    ),
+    dict(
+        name='LIF (Leica Image Format)',
+        reference='https://svi.nl/LeicaLif',
+        examples=[
+            dict(
+                filename='20191025 Test FRET 585. 423, 426.lif',
+                url='https://downloads.openmicroscopy.org/images/Leica-LIF/imagesc-30856/20191025%20Test%20FRET%20585.%20423,%20426.lif',
+                hash='8d4ee62868b9616b832c2eb28e7d62ec050fb032e0bc11ea0a392f5c84390c71',
             ),
         ],
     ),
@@ -92,101 +187,6 @@ format_examples = [
                 filename='1bit.bmp',
                 url='https://github.com/OSGeo/gdal/raw/master/autotest/gcore/data/1bit.bmp',
                 hash='b0c201bee1e5a36ee698ab098aa3480e20772869d8f5c788280e532fa3620667',
-            ),
-        ],
-    ),
-    dict(
-        name='LIF (Leica Image Format)',
-        reference='https://svi.nl/LeicaLif',
-        examples=[
-            dict(
-                filename='20191025 Test FRET 585. 423, 426.lif',
-                url='https://downloads.openmicroscopy.org/images/Leica-LIF/imagesc-30856/20191025%20Test%20FRET%20585.%20423,%20426.lif',
-                hash='8d4ee62868b9616b832c2eb28e7d62ec050fb032e0bc11ea0a392f5c84390c71',
-            ),
-        ],
-    ),
-    dict(
-        name='CZI (Carl Zeiss Image)',
-        reference='https://www.zeiss.com/microscopy/en/products/software/zeiss-zen/czi-image-file-format.html',
-        examples=[
-            dict(
-                filename='Plate1-Blue-A-02-Scene-1-P2-E1-01.czi',
-                url='https://data.kitware.com/api/v1/item/66e1af4d560e61279679127b/download',
-                hash='494936fa5a8c2e53b73672980986e2c44f3779e9b709ebfd406ffda723336376',
-            ),
-        ],
-    ),
-    dict(
-        name='SVS (Aperio ScanScope Virtual Slide)',
-        reference='https://paulbourke.net/dataformats/svs/',
-        examples=[
-            dict(
-                filename='CMU-1.svs',
-                url='https://data.kitware.com/api/v1/file/57b5d6558d777f10f2694486/download',
-                hash='00a3d54482cd707abf254fe69dccc8d06b8ff757a1663f1290c23418c480eb30',
-            ),
-        ],
-    ),
-    dict(
-        name='NDPI (Hamamatsu NanoZoomer Digital Pathology Image)',
-        reference='https://openslide.org/formats/hamamatsu/',
-        examples=[
-            dict(
-                filename='test3.ndpis',
-                url='https://data.kitware.com/api/v1/item/66e1af68560e612796791287/download',
-                hash='35542dff44d7844f1fac04c1703bdb1476f90f484457907ead132203e6de066e',
-            ),
-            dict(
-                filename='test3-TRITC 2 (560).ndpi',
-                url='https://data.kitware.com/api/v1/item/66e1af63560e61279679127e/download',
-                skip=True,
-                hash='f02985d30aa38060e83c9477a4435cb81b2a0a234d3d664195dfc5a4e2657be8',
-            ),
-            dict(
-                filename='test3-FITC 2 (485).ndpi',
-                url='https://data.kitware.com/api/v1/item/66e1af65560e612796791281/download',
-                skip=True,
-                hash='455069a02a761ecfedb93492f103dec8c5b23b7c46fd47e9d8d22191ea803018',
-            ),
-            dict(
-                filename='test3-DAPI 2 (387).ndpi',
-                url='https://data.kitware.com/api/v1/item/66e1af68560e612796791284/download',
-                skip=True,
-                hash='9294d31f304f20ef1df1e08650d3f225b8ed44db8b2dc0d52f584449f85bdca2',
-            ),
-        ],
-    ),
-    dict(
-        name='OME-TIFF (Open Microscopy Environment Tagged Image File Format)',
-        reference='https://docs.openmicroscopy.org/ome-model/5.6.3/ome-tiff/',
-        examples=[
-            dict(
-                filename='DDX58_AXL_EGFR_well2_XY04.ome.tif',
-                url='https://data.kitware.com/api/v1/file/5fa1cbe750a41e3d192e18eb/download',
-                hash='5dabb19081db4893d58b6680e54b566fc6246ccbde10d41413201afd96499482',
-            ),
-        ],
-    ),
-    dict(
-        name='ND2 (Nikon NIS Elements)',
-        reference='https://docs.openmicroscopy.org/bio-formats/5.9.2/formats/nikon-nis-elements-nd2.html',
-        examples=[
-            dict(
-                filename='sample_image.nd2',
-                url='https://downloads.openmicroscopy.org/images/ND2/aryeh/MeOh_high_fluo_003.nd2',
-                hash='8e23bb594cd18314f9c18e70d736088ae46f8bc696ab7dc047784be416d7a706',
-            ),
-        ],
-    ),
-   dict(
-        name='DICOM (Digital Imaging and Communications in Medicine)',
-        reference='https://www.dicomstandard.org/about',
-        examples=[
-            dict(
-                filename='US-MONO2-8-8x-execho.dcm',
-                url='https://downloads.openmicroscopy.org/images/DICOM/samples/US-MONO2-8-8x-execho.dcm',
-                hash='7d3f54806d0315c6cfc8b7371649a242b5ef8f31e0d20221971dd8087f2ff1ea',
             ),
         ],
     ),

--- a/docs/format_examples_datastore.py
+++ b/docs/format_examples_datastore.py
@@ -59,7 +59,6 @@ format_examples = [
             dict(
                 filename='albania.jpg',
                 url='https://github.com/OSGeo/gdal/blob/master/autotest/gdrivers/data/jpeg/albania.jpg',
-                hash='c454c477056b26cceb5461648f825efdf9362c7b7998a4a0ca41050629e692de',
             ),
             dict(
                 filename='clouds.jpeg',

--- a/docs/format_examples_datastore.py
+++ b/docs/format_examples_datastore.py
@@ -175,7 +175,8 @@ format_examples = [
             dict(
                 filename='sample_image.nd2',
                 url='https://downloads.openmicroscopy.org/images/ND2/aryeh/MeOh_high_fluo_003.nd2',
-            )
+                hash='8e23bb594cd18314f9c18e70d736088ae46f8bc696ab7dc047784be416d7a706',
+            ),
         ],
     ),
    dict(
@@ -185,7 +186,8 @@ format_examples = [
             dict(
                 filename='US-MONO2-8-8x-execho.dcm',
                 url='https://downloads.openmicroscopy.org/images/DICOM/samples/US-MONO2-8-8x-execho.dcm',
-            )
+                hash='7d3f54806d0315c6cfc8b7371649a242b5ef8f31e0d20221971dd8087f2ff1ea',
+            ),
         ],
     ),
 ]

--- a/docs/format_examples_datastore.py
+++ b/docs/format_examples_datastore.py
@@ -10,9 +10,9 @@ format_examples = [
         reference='https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf',
         examples=[
             dict(
-                filename='A5.pattern3.tif',
-                url='https://data.kitware.com/api/v1/item/66e1af78560e61279679128a/download',
-                hash='c6d198c3e0a1c46bd44f2a1c2c594db9c91a013e98a127d7eed727cd1b0d8d1e',
+                filename='tcgaextract_ihergb_labeled.tiff',
+                url='https://data.kitware.com/api/v1/item/66e30827560e6127967912cf/download',
+                hash='8a03ae4370a35517e2ab2249177d903c1ea52869e30dc558750c626d9edbae6f',
             ),
             dict(
                 filename='sample_image.ptif',

--- a/docs/format_examples_datastore.py
+++ b/docs/format_examples_datastore.py
@@ -1,0 +1,29 @@
+import pooch
+from pathlib import Path
+
+EXAMPLES_FOLDER = Path('format_examples')
+
+format_examples = [
+    dict(
+        name='TIFF (Tagged Image File Format)',
+        reference='https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf',
+        examples=[
+            dict(
+                filename='utmsmall.tif',
+                url='https://github.com/OSGeo/gdal/raw/master/autotest/gcore/data/utmsmall.tif',
+                hash='f40dae6e8b5e18f3648e9f095e22a0d7027014bb463418d32f732c3756d8c54f',
+            ),
+        ],
+    ),
+]
+
+
+def fetch_all():
+    for format_data in format_examples:
+        for example in format_data.get('examples', []):
+            pooch.retrieve(
+                url=example.get('url'),
+                known_hash=example.get('hash'),
+                fname=example.get('filename'),
+                path=EXAMPLES_FOLDER,
+            )

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -10,20 +10,4 @@ The file extensions and mime types that are listed by the core sources that can 
 
 The following table describes the some of the formats supported by ``large-image`` and the common extensions for each format. This table also describes the ``large-image-source-*`` modules that can be used to read each format.
 
-For a list of known extensions, see :ref:`extensions`.
-
 .. include:: format_table.rst
-
-.. _extensions:
-
-Extensions
-~~~~~~~~~~
-
-.. include:: ../build/docs-work/known_extensions.txt
-   :literal:
-
-Mime Types
-~~~~~~~~~~
-
-.. include:: ../build/docs-work/known_mimetypes.txt
-   :literal:

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -6,7 +6,15 @@ Preferred Extensions and Mime Types
 
 Images can generally be read regardless of their name.  By default, when opening an image with ``large_image.open()``, each tile source reader is tried in turn until one source can open the file.  Each source lists preferred file extensions and mime types with a priority level.  If the file ends with one of these extensions or has one of these mimetypes, the order that the source readers are tried is adjusted based on the specified priority.
 
-The file extensions and mime types that are listed by the core sources that can affect source processing order are listed below.  See ``large_image.listSources()`` for details about priority of the different source and the ``large_image.constants.SourcePriority`` for the priority meaning.
+The file extensions and mime types that are listed by the core sources that can affect source processing order are listed below.  See ``large_image.listSources()`` for details about priority of the different sources and the ``large_image.constants.SourcePriority`` for the priority meaning.
+
+The following table describes the primary formats supported by ``large-image`` and the acceptable extensions for each format. This table also describes the ``large-image-source-*`` modules that can be used to read each format.
+
+For a full list of all accepted extensions, see :ref:`extensions`.
+
+.. include:: format_table.rst
+
+.. _extensions:
 
 Extensions
 ~~~~~~~~~~

--- a/docs/formats.rst
+++ b/docs/formats.rst
@@ -8,9 +8,9 @@ Images can generally be read regardless of their name.  By default, when opening
 
 The file extensions and mime types that are listed by the core sources that can affect source processing order are listed below.  See ``large_image.listSources()`` for details about priority of the different sources and the ``large_image.constants.SourcePriority`` for the priority meaning.
 
-The following table describes the primary formats supported by ``large-image`` and the acceptable extensions for each format. This table also describes the ``large-image-source-*`` modules that can be used to read each format.
+The following table describes the some of the formats supported by ``large-image`` and the common extensions for each format. This table also describes the ``large-image-source-*`` modules that can be used to read each format.
 
-For a full list of all accepted extensions, see :ref:`extensions`.
+For a list of known extensions, see :ref:`extensions`.
 
 .. include:: format_table.rst
 

--- a/docs/generate_format_table.py
+++ b/docs/generate_format_table.py
@@ -15,12 +15,12 @@ def evaluate_examples():
         name = format_data.get('name')
         long_name = format_data.get('long_name')
         reference = format_data.get('reference')
+        extensions = format_data.get('extensions')
         for example in format_data.get('examples', []):
             skip = example.get('skip')
             if not skip:
                 filename = example.get('filename')
                 url = example.get('url')
-                extension = filename.split('.')[-1]
                 filepath = Path(EXAMPLES_FOLDER, filename)
                 print(f'Evaluating {filename}. ')
                 for tilesource_name, readable in large_image.canReadList(filepath):
@@ -33,7 +33,7 @@ def evaluate_examples():
                                     name=name,
                                     long_name=long_name,
                                     reference=reference,
-                                    extension=extension,
+                                    extensions=extensions,
                                     filename=filename,
                                     url=url,
                                     tilesource=tilesource_name,
@@ -59,7 +59,7 @@ def combine_rows(results):
     # combine rows that only differ on tilesource
     table_rows = {}
     for result in results:
-        row_base_key = result.get('extension')
+        row_base_key = result.get('filename')
         row_key_index = 0
         row_key = f'{row_base_key}_{row_key_index}'
         # if this source has "maybe" for multiframe
@@ -67,7 +67,7 @@ def combine_rows(results):
         if (
             isinstance(result['multiframe'], str) and
             any(
-                r['extension'] == result['extension'] and
+                r['filename'] == result['filename'] and
                 r['multiframe'] and isinstance(r['multiframe'], bool)
                 for r in results
             )
@@ -130,7 +130,7 @@ def generate():
     # generate RST-formatted table
     columns = [
         dict(label='Format', key='name'),
-        dict(label='Extension', key='extension'),
+        dict(label='Extension(s)', key='extensions'),
         dict(label='Tile Source', key='tilesource'),
         dict(label='Multiframe', key='multiframe'),
         dict(label='Geospatial', key='geospatial'),
@@ -155,9 +155,9 @@ def generate():
         for index, col in enumerate(columns):
             col_key = col.get('key')
             col_value = row.get(col_key)
-            if col_key == 'extension':
+            if col_key == 'extensions':
                 # format extensions with monospace font
-                col_value = f'``{col_value}``'
+                col_value = ', '.join([f'``{e}``' for e in col_value])
             elif col_key == 'name':
                 # include reference as link and long name as tooltip
                 reference_link = row.get('reference')

--- a/docs/generate_format_table.py
+++ b/docs/generate_format_table.py
@@ -45,7 +45,7 @@ def evaluate_examples():
                                     geospatial=hasattr(s, 'projection'),
                                     write=hasattr(s, 'addTile'),
                                     associated=(
-                                        s.getAssociatedImagesList is not
+                                        tilesource.getAssociatedImagesList is not
                                         large_image.tilesource.FileTileSource.getAssociatedImagesList
                                     ),
                                 ),

--- a/docs/generate_format_table.py
+++ b/docs/generate_format_table.py
@@ -162,10 +162,18 @@ def generate():
                 # include reference as link and long name as tooltip
                 reference_link = row.get('reference')
                 long_name = row.get('long_name')
+                raw_html = [
+                    '.. raw:: html\n\n\t\t\t\t<p>',
+                ]
+                raw_html.append(f'<a href="{reference_link}"')
                 if long_name:
-                    col_value = f':abbr:`{col_value} ({long_name})`'
-                if reference_link:
-                    col_value = f'{col_value} (`spec <{reference_link}>`__)'
+                    raw_html.append(f' title="{long_name}">{col_value}</a>')
+                else:
+                    raw_html.append(f'>{col_value}</a>')
+                raw_html.append(f'\n\t\t\t\t<a class="reference internal" href="#{row_key}">')
+                raw_html.append('<span class="std std-ref">🔗</span></a>')
+                raw_html.append('</p>\n')
+                col_value = ''.join(raw_html)
             elif col_key == 'url':
                 # reformat example download link
                 col_value = (
@@ -177,7 +185,7 @@ def generate():
                     col_value = ', '.join(col_value)
 
             if index == 0:
-                lines.append(f'   * - {col_value} :ref:`🔗 <{row_key}>`')
+                lines.append(f'   * - {col_value}')
             else:
                 lines.append(f'     - {col_value}')
 

--- a/docs/generate_format_table.py
+++ b/docs/generate_format_table.py
@@ -4,6 +4,7 @@ from format_examples_datastore import EXAMPLES_FOLDER, format_examples, fetch_al
 
 
 TABLE_FILE = Path('./format_table.rst')
+NO_MULTIFRAME_SOURCES = ['deepzoom', 'openjpeg', 'openslide']
 
 
 def evaluate_examples():
@@ -33,15 +34,15 @@ def evaluate_examples():
                                 url=url,
                                 tilesource=tilesource_name,
                                 multiframe=(
-                                    False if tilesource_name in ['deepzoom', 'openjpeg', 'openslide'] else
+                                    False if tilesource_name in NO_MULTIFRAME_SOURCES else
                                     True if s.getMetadata().get('frames') is not None else
                                     'Maybe; no multiframe sample found.'
                                 ),
                                 geospatial=hasattr(s, 'projection'),
                                 write=hasattr(s, 'addTile'),
                                 associated=(
-                                    s.getAssociatedImagesList
-                                    is not large_image.tilesource.FileTileSource.getAssociatedImagesList
+                                    s.getAssociatedImagesList is not
+                                    large_image.tilesource.FileTileSource.getAssociatedImagesList
                                 ),
                             ),
                         )

--- a/docs/generate_format_table.py
+++ b/docs/generate_format_table.py
@@ -40,7 +40,7 @@ def evaluate_examples():
                                     multiframe=(
                                         False if tilesource_name in NO_MULTIFRAME_SOURCES else
                                         True if s.getMetadata().get('frames') is not None else
-                                        'Maybe; no multiframe sample found.'
+                                        'Unknown'
                                     ),
                                     geospatial=hasattr(s, 'projection'),
                                     write=hasattr(s, 'addTile'),
@@ -106,14 +106,14 @@ def generate():
         dict(label='Format', key='name'),
         dict(label='Extension', key='extension'),
         dict(label='Tile Source', key='tilesource'),
-        dict(label='Multiframe Allowed', key='multiframe'),
-        dict(label='Geospatial Allowed', key='geospatial'),
-        dict(label='Write Allowed', key='write'),
-        dict(label='Associated Images Allowed', key='associated'),
+        dict(label='Multiframe', key='multiframe'),
+        dict(label='Geospatial', key='geospatial'),
+        dict(label='Writeable', key='write'),
+        dict(label='Associated Images', key='associated'),
         dict(label='Example File', key='url'),
     ]
     lines = [
-        '.. list-table:: Primary Formats',
+        '.. list-table:: Common Formats',
         '   :header-rows: 1',
         '',
     ]
@@ -143,7 +143,7 @@ def generate():
             elif col_key == 'url':
                 # reformat example download link
                 col_value = (
-                    f'`Download example {row.get("extension")} file <{col_value}>`__'
+                    f'`Download <{col_value}>`__'
                 )
             elif col_key == 'tilesource':
                 # join tilesource lists with commas

--- a/docs/generate_format_table.py
+++ b/docs/generate_format_table.py
@@ -66,7 +66,7 @@ def combine_rows(results):
             isinstance(result['multiframe'], str) and
             any(
                 r['extension'] == result['extension'] and
-                r['multiframe'] == True
+                r['multiframe'] and isinstance(r['multiframe'], bool)
                 for r in results
             )
         ):

--- a/docs/generate_format_table.py
+++ b/docs/generate_format_table.py
@@ -13,6 +13,7 @@ def evaluate_examples():
     results = []
     for format_data in format_examples:
         name = format_data.get('name')
+        long_name = format_data.get('long_name')
         reference = format_data.get('reference')
         for example in format_data.get('examples', []):
             skip = example.get('skip')
@@ -30,6 +31,7 @@ def evaluate_examples():
                             results.append(
                                 dict(
                                     name=name,
+                                    long_name=long_name,
                                     reference=reference,
                                     extension=extension,
                                     filename=filename,
@@ -131,10 +133,13 @@ def generate():
                 # format extensions with monospace font
                 col_value = f'``{col_value}``'
             elif col_key == 'name':
-                # include reference as link on format name
+                # include reference as link and long name as tooltip
                 reference_link = row.get('reference')
+                long_name = row.get('long_name')
+                if long_name:
+                    col_value = f':abbr:`{col_value} ({long_name})`'
                 if reference_link:
-                    col_value = f'`{col_value} <{reference_link}>`_'
+                    col_value = f'{col_value} (`spec <{reference_link}>`__)'
             elif col_key == 'url':
                 # reformat example download link
                 col_value = (

--- a/docs/generate_format_table.py
+++ b/docs/generate_format_table.py
@@ -32,13 +32,16 @@ def evaluate_examples():
                                 filename=filename,
                                 url=url,
                                 tilesource=tilesource_name,
-                                # TODO: find a way to determine if multiframe is allowed
-                                multiframe=True,
+                                multiframe=(
+                                    False if tilesource_name in ['deepzoom', 'openjpeg', 'openslide'] else
+                                    True if s.getMetadata().get('frames') is not None else
+                                    'Maybe; no multiframe sample found.'
+                                ),
                                 geospatial=hasattr(s, 'projection'),
                                 write=hasattr(s, 'addTile'),
                                 associated=(
-                                    s.getAssociatedImagesList is not
-                                    large_image.tilesource.FileTileSource.getAssociatedImagesList
+                                    s.getAssociatedImagesList
+                                    is not large_image.tilesource.FileTileSource.getAssociatedImagesList
                                 ),
                             ),
                         )
@@ -121,7 +124,7 @@ def generate():
             elif col_key == 'url':
                 # reformat example download link
                 col_value = (
-                    f'`Download example {row.get("extension")} file <{col_value}>`_'
+                    f'`Download example {row.get("extension")} file <{col_value}>`__'
                 )
             elif col_key == 'tilesource':
                 # join tilesource lists with commas

--- a/docs/generate_format_table.py
+++ b/docs/generate_format_table.py
@@ -183,7 +183,8 @@ def generate():
 
     # Extensions and Mime Types
     lines = [
-        'For a list of known mime types, see :ref:`mime_types_list`. For a list of known extensions, see :ref:`extensions_list`.',
+        'For a list of known mime types, see :ref:`mime_types_list`.',
+        'For a list of known extensions, see :ref:`extensions_list`.',
         '',
         *lines,
         '',

--- a/docs/generate_format_table.py
+++ b/docs/generate_format_table.py
@@ -96,6 +96,32 @@ def combine_rows(results):
     return table_rows
 
 
+def get_mimetypes_list():
+    mime_types = large_image.listMimeTypes()
+    return [
+        '.. _mime_types_list:',
+        '',
+        f'Mime Types ({len(mime_types)})',
+        '~~~~~~~~~~~~~~~~~~',
+        ', '.join([
+            f'``{m}``' for m in mime_types
+        ]),
+    ]
+
+
+def get_extensions_list():
+    extensions = large_image.listExtensions()
+    return [
+        '.. _extensions_list:',
+        '',
+        f'Extensions ({len(extensions)})',
+        '~~~~~~~~~~~~~~~~~~',
+        ', '.join([
+            f'``{e}``' for e in extensions
+        ]),
+    ]
+
+
 def generate():
     fetch_all()
     results = evaluate_examples()
@@ -154,7 +180,19 @@ def generate():
                 lines.append(f'   * - {col_value} :ref:`🔗 <{row_key}>`')
             else:
                 lines.append(f'     - {col_value}')
-    lines.append('')
+
+    # Extensions and Mime Types
+    lines = [
+        'For a list of known mime types, see :ref:`mime_types_list`. For a list of known extensions, see :ref:`extensions_list`.',
+        '',
+        *lines,
+        '',
+        *get_mimetypes_list(),
+        '',
+        *get_extensions_list(),
+        '',
+    ]
+
     with open(TABLE_FILE, 'w') as f:
         f.write('\n'.join(lines))
     print('Wrote format table at', str(TABLE_FILE))

--- a/docs/generate_format_table.py
+++ b/docs/generate_format_table.py
@@ -1,0 +1,131 @@
+import large_image
+from pathlib import Path
+from format_examples_datastore import EXAMPLES_FOLDER, format_examples, fetch_all
+
+
+TABLE_FILE = Path('./format_table.rst')
+
+
+def generate():
+    fetch_all()
+    large_image.tilesource.loadTileSources()
+    available_tilesources = large_image.tilesource.AvailableTileSources
+
+    results = []
+    for format_data in format_examples:
+        name = format_data.get('name')
+        reference = format_data.get('reference')
+        for example in format_data.get('examples', []):
+            filename = example.get('filename')
+            url = example.get('url')
+            extension = filename.split('.')[-1]
+            filepath = Path(EXAMPLES_FOLDER, filename)
+            print(f'Evaluating {filename}. ')
+            for tilesource_name, readable in large_image.canReadList(filepath):
+                tilesource = available_tilesources.get(tilesource_name)
+                if readable and tilesource:
+                    try:
+                        s = tilesource(filepath)
+                        results.append(
+                            dict(
+                                name=name,
+                                reference=reference,
+                                extension=extension,
+                                filename=filename,
+                                url=url,
+                                tilesource=tilesource_name,
+                                # TODO: find a way to determine if multiframe is allowed
+                                multiframe=True, 
+                                geospatial=hasattr(s, 'projection'),
+                                write=hasattr(s, 'addTile'),
+                                associated=(
+                                    s.getAssociatedImagesList
+                                    is not large_image.tilesource.FileTileSource.getAssociatedImagesList
+                                ),
+                            )
+                        )
+                    except large_image.exceptions.TileSourceError:
+                        pass
+
+    # combine rows that only differ on tilesource
+    table_rows = {}
+    for result in results:
+        row_base_key = result.get('extension')
+        row_key_index = 0
+        row_key = f'{row_base_key}_{row_key_index}'
+        while row_key in table_rows:
+            if all(
+                [
+                    value == table_rows[row_key][key]
+                    for key, value in result.items()
+                    if key != 'tilesource'
+                ]
+            ):
+                if not isinstance(table_rows[row_key]['tilesource'], list):
+                    table_rows[row_key]['tilesource'] = [
+                        table_rows[row_key]['tilesource'],
+                    ]
+                table_rows[row_key]['tilesource'] = [
+                    *table_rows[row_key]['tilesource'],
+                    result['tilesource'],
+                ]
+                break
+            else:
+                row_key_index += 1
+                row_key = f'{row_base_key}_{row_key_index}'
+        if row_key not in table_rows:
+            table_rows[row_key] = result
+
+    columns = [
+        dict(label='Format', key='name'),
+        dict(label='Extension', key='extension'),
+        dict(label='Tile Source', key='tilesource'),
+        dict(label='Multiframe Allowed', key='multiframe'),
+        dict(label='Geospatial Allowed', key='geospatial'),
+        dict(label='Write Allowed', key='write'),
+        dict(label='Associated Images Allowed', key='associated'),
+        dict(label='Example File', key='url'),
+    ]
+    lines = [
+        '.. list-table:: Primary Formats',
+        '   :header-rows: 1',
+        '',
+    ]
+    for index, col in enumerate(columns):
+        label = col.get('label')
+        if index == 0:
+            lines.append(f'   * - {label}')
+        else:
+            lines.append(f'     - {label}')
+    for row_key, row in table_rows.items():
+        lines.append('')  # blank line for ref separation
+        lines.append(f'       .. _{row_key}:')
+        for index, col in enumerate(columns):
+            col_key = col.get('key')
+            col_value = row.get(col_key)
+            if col_key == 'extension':
+                # format extensions with monospace font
+                col_value = f'``{col_value}``'
+            elif col_key == 'name':
+                # include reference as link on format name
+                reference_link = row.get('reference')
+                if reference_link:
+                    col_value = f'`{col_value} <{reference_link}>`_'
+            elif col_key == 'url':
+                # reformat example download link
+                col_value = (
+                    f'`Download example {row.get("extension")} file <{col_value}>`_'
+                )
+            elif col_key == 'tilesource':
+                # join tilesource lists with commas
+                if isinstance(col_value, list):
+                    col_value = ', '.join(col_value)
+
+            if index == 0:
+                lines.append(f'   * - {col_value} :ref:`🔗 <{row_key}>`')
+            else:
+                lines.append(f'     - {col_value}')
+    lines.append('')
+    with open(TABLE_FILE, 'w') as f:
+        f.write('\n'.join(lines))
+    print('Wrote format table at', str(TABLE_FILE))

--- a/docs/make_docs.sh
+++ b/docs/make_docs.sh
@@ -19,8 +19,6 @@ ln -s ../build/docs-work _build
 large_image_converter --help > _build/large_image_converter.txt
 python -c 'from girder_large_image_annotation.models import annotation;import json;print(json.dumps(annotation.AnnotationSchema.annotationSchema, indent=2))' > _build/annotation_schema.json
 python -c 'import large_image_source_multi, json;print(json.dumps(large_image_source_multi.MultiSourceSchema, indent=2))' > _build/multi_source_schema.json
-python -c 'import large_image, yaml;print("\n".join(large_image.listExtensions()) + "\n\n" + str(len(large_image.listExtensions())) + " extensions")' > _build/known_extensions.txt
-python -c 'import large_image, yaml;print("\n".join(large_image.listMimeTypes()) + "\n\n" + str(len(large_image.listMimeTypes())) + " mime types")' > _build/known_mimetypes.txt
 
 sphinx-apidoc -f -o _build/large_image ../large_image
 sphinx-apidoc -f -o _build/large_image_source_bioformats ../sources/bioformats/large_image_source_bioformats

--- a/docs/make_docs.sh
+++ b/docs/make_docs.sh
@@ -5,6 +5,9 @@ set -e
 cd "$(dirname $0)"
 stat make_docs.sh
 
+# generate file format table
+python -c "import generate_format_table;generate_format_table.generate()"
+
 # git clean -fxd .
 
 mkdir -p ../build/docs-work

--- a/tox.ini
+++ b/tox.ini
@@ -305,6 +305,7 @@ deps =
   sphinx-rtd-theme
   sphinxcontrib-jquery
   sphinxcontrib-mermaid
+  pooch
 changedir = {toxinidir}/docs
 allowlist_externals =
   make_docs.sh


### PR DESCRIPTION
Resolves #1489 

- [x] Create a new pooch datastore to fetch format example files
- [x] Write a function to open format examples and evaluate table columns
- [x] Write a function to save results to disk as an RST-formatted table
- [x] Invoke the file fetching and table generation as a step in `mkdocs.sh`
- [x] Copy `parakon` hosted files to a more accessible location
- [x] Confirm that all format examples are public, small enough to download during CI, multiframe if possible, and visually interesting
