### PR TITLE
Harden some of the sources when trying to read bad files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Bug Fixes
 
 - Harden converting sources that report varied tile bands ([#1615](../../pull/1615))
+- Harden many of the sources from reading bad files ([#1623](../../pull/1623))
 
 ## 1.29.6
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -647,7 +647,7 @@ class TileSource(IPyLeafletMixin):
                     tile = np.array(tile, dtype=np.uint16) * 257
                 else:
                     continue
-            for idx in range(len(results['min'])):
+            for idx in range(min(len(results['min']), tile.shape[-1])):
                 entry = results['histogram'][idx]
                 hist, bin_edges = np.histogram(
                     tile[:, :, idx], entry['bins'], entry['range'], density=False)

--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -23,6 +23,7 @@
 #   IFormatReader.html for interface details.
 
 import atexit
+import builtins
 import logging
 import math
 import os
@@ -212,6 +213,17 @@ class BioformatsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         largeImagePath = str(self._getLargeImagePath())
         config._ignoreSourceNames('bioformats', largeImagePath)
 
+        header = b''
+        if os.path.isfile(largeImagePath):
+            try:
+                header = builtins.open(largeImagePath, 'rb').read(5)
+            except Exception:
+                msg = 'File cannot be opened via Bioformats'
+                raise TileSourceError(msg)
+        # Never allow pdfs; they crash the JVM
+        if header[:5] == b'%PDF-':
+            msg = 'File cannot be opened via Bioformats'
+            raise TileSourceError(msg)
         if not _startJavabridge(self.logger):
             msg = 'File cannot be opened by bioformats reader because javabridge failed to start'
             raise TileSourceError(msg)

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -116,7 +116,7 @@ class GDALFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass):
         self._largeImagePath = self._getLargeImagePath()
         try:
             self.dataset = gdal.Open(self._largeImagePath, gdalconst.GA_ReadOnly)
-        except RuntimeError:
+        except (RuntimeError, UnicodeDecodeError):
             if not os.path.isfile(self._largeImagePath):
                 raise TileSourceFileNotFoundError(self._largeImagePath) from None
             msg = 'File cannot be opened via GDAL'
@@ -143,6 +143,9 @@ class GDALFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass):
             scale = self.getPixelSizeInMeters()
         except RuntimeError as exc:
             raise TileSourceError('File cannot be opened via GDAL: %r' % exc)
+        if not self.sizeX or not self.sizeY:
+            msg = 'File cannot be opened via GDAL (no size)'
+            raise TileSourceError(msg)
         if (self.projection or self._getDriver() in {
             'PNG',
         }) and not scale and not is_netcdf:
@@ -459,7 +462,7 @@ class GDALFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass):
         if srs not in self._bounds:
             gt = self._getGeoTransform()
             nativeSrs = self.getProj4String()
-            if not nativeSrs:
+            if not nativeSrs or not gt:
                 self._bounds[srs] = None
                 return
             bounds = {
@@ -547,7 +550,7 @@ class GDALFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass):
                         # The statistics provide a min and max, so we don't
                         # fetch those separately
                         info.update(dict(zip(('min', 'max', 'mean', 'stdev'), stats)))
-                    except RuntimeError:
+                    except (RuntimeError, TypeError):
                         self.logger.info('Failed to get statistics for band %d', i + 1)
                     info['nodata'] = band.GetNoDataValue()
                     info['scale'] = band.GetScale()
@@ -714,8 +717,12 @@ class GDALFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass):
             w = int(max(1, round((x1 - x0) / factor)))
             h = int(max(1, round((y1 - y0) / factor)))
             with self._getDatasetLock:
-                tile = self.dataset.ReadAsArray(
-                    xoff=x0, yoff=y0, xsize=x1 - x0, ysize=y1 - y0, buf_xsize=w, buf_ysize=h)
+                try:
+                    tile = self.dataset.ReadAsArray(
+                        xoff=x0, yoff=y0, xsize=x1 - x0, ysize=y1 - y0, buf_xsize=w, buf_ysize=h)
+                except Exception:
+                    self.logger.exception('Failed to getTile')
+                    tile = np.zeros((1, 1))
         else:
             xmin, ymin, xmax, ymax = self.getTileCorners(z, x, y)
             bounds = self.getBounds(self.projection)
@@ -745,7 +752,11 @@ class GDALFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass):
                     # around the outputBounds.
                     polynomialOrder=1,
                     xRes=res, yRes=res, outputBounds=[xmin, ymin, xmax, ymax])
-                tile = ds.ReadAsArray()
+                try:
+                    tile = ds.ReadAsArray()
+                except Exception:
+                    self.logger.exception('Failed to getTile')
+                    tile = np.zeros((1, 1))
         if len(tile.shape) == 3:
             tile = np.rollaxis(tile, 0, 3)
         return self._outputTile(tile, TILE_FORMAT_NUMPY, x, y, z,

--- a/sources/nd2/large_image_source_nd2/__init__.py
+++ b/sources/nd2/large_image_source_nd2/__init__.py
@@ -138,7 +138,7 @@ class ND2FileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         # We use dask to allow lazy reading of large images
         try:
             self._nd2array = self._nd2.to_dask(copy=False, wrapper=False)
-        except (TypeError, ValueError) as exc:
+        except (TypeError, ValueError, OSError) as exc:
             self.logger.debug('Failed to read nd2 file: %s', exc)
             msg = 'File cannot be opened via the nd2 source.'
             raise TileSourceError(msg)

--- a/sources/openjpeg/large_image_source_openjpeg/__init__.py
+++ b/sources/openjpeg/large_image_source_openjpeg/__init__.py
@@ -114,7 +114,7 @@ class OpenjpegFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                     raise FileNotFoundError
                 msg = 'File cannot be opened via Glymur and OpenJPEG (no shape).'
                 raise TileSourceError(msg)
-        except (glymur.jp2box.InvalidJp2kError, struct.error):
+        except (glymur.jp2box.InvalidJp2kError, struct.error, IndexError):
             msg = 'File cannot be opened via Glymur and OpenJPEG.'
             raise TileSourceError(msg)
         except FileNotFoundError:
@@ -130,7 +130,11 @@ class OpenjpegFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             self.sizeY, self.sizeX = self._openjpeg.shape[:2]
         except IndexError as exc:
             raise TileSourceError('File cannot be opened via Glymur and OpenJPEG: %r' % exc)
-        self.levels = int(self._openjpeg.codestream.segment[2].num_res) + 1
+        try:
+            self.levels = int(self._openjpeg.codestream.segment[2].num_res) + 1
+        except Exception:
+            msg = 'File cannot be opened via Glymur and OpenJPEG.'
+            raise TileSourceError(msg)
         self._minlevel = 0
         self.tileWidth = self.tileHeight = 2 ** int(math.ceil(max(
             math.log(float(self.sizeX)) / math.log(2) - self.levels + 1,

--- a/sources/pil/large_image_source_pil/__init__.py
+++ b/sources/pil/large_image_source_pil/__init__.py
@@ -104,7 +104,7 @@ class PILFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         'image/jpeg': SourcePriority.LOW,
     }
 
-    def __init__(self, path, maxSize=None, **kwargs):
+    def __init__(self, path, maxSize=None, **kwargs):  # noqa
         """
         Initialize the tile class.  See the base class for other available
         parameters.
@@ -167,9 +167,16 @@ class PILFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         pilImageMode = self._pilImage.mode.split(';')[0]
         self._factor = None
         if pilImageMode in ('I', 'F'):
-            imgdata = np.asarray(self._pilImage)
+            try:
+                imgdata = np.asarray(self._pilImage)
+                if np.isnan(np.sum(imgdata)):
+                    imgdata = imgdata.copy()
+                    imgdata[np.isnan(imgdata)] = 0
+            except Exception:
+                msg = 'PIL cannot find loader for this file.'
+                raise TileSourceError(msg)
             maxval = 256 ** math.ceil(math.log(np.max(imgdata) + 1, 256)) - 1
-            self._factor = 255.0 / maxval
+            self._factor = 255.0 / max(maxval, 1)
             self._pilImage = PIL.Image.fromarray(np.uint8(np.multiply(
                 imgdata, self._factor)))
         self.sizeX = self._pilImage.width
@@ -187,14 +194,17 @@ class PILFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         self._frames = None
         self._frameCount = 1
         if hasattr(self._pilImage, 'seek'):
-            baseSize, baseMode = self._pilImage.size, self._pilImage.mode
-            self._frames = [
-                idx for idx, frame in enumerate(PIL.ImageSequence.Iterator(self._pilImage))
-                if frame.size == baseSize and frame.mode == baseMode]
-            self._pilImage.seek(0)
-            self._frameImage = self._pilImage
-            self._frameCount = len(self._frames)
-            self._tileLock = threading.RLock()
+            try:
+                baseSize, baseMode = self._pilImage.size, self._pilImage.mode
+                self._frames = [
+                    idx for idx, frame in enumerate(PIL.ImageSequence.Iterator(self._pilImage))
+                    if frame.size == baseSize and frame.mode == baseMode]
+                self._pilImage.seek(0)
+                self._frameImage = self._pilImage
+                self._frameCount = len(self._frames)
+                self._tileLock = threading.RLock()
+            except Exception:
+                self._pilImage.seek(0)
 
     def _fromRawpy(self, largeImagePath):
         """

--- a/sources/tiff/large_image_source_tiff/tiff_reader.py
+++ b/sources/tiff/large_image_source_tiff/tiff_reader.py
@@ -121,7 +121,12 @@ class TiledTiffDirectory:
         self._tileLock = threading.RLock()
 
         self._open(filePath, directoryNum, subDirectoryNum)
-        self._loadMetadata()
+        try:
+            self._loadMetadata()
+        except Exception:
+            self.logger.exception('Could not parse tiff metadata')
+            raise IOOpenTiffError(
+                'Could not open TIFF file: %s' % filePath)
         self.logger.debug(
             'TiffDirectory %d:%d Information %r',
             directoryNum, subDirectoryNum or 0, self._tiffInfo)

--- a/sources/tifffile/large_image_source_tifffile/__init__.py
+++ b/sources/tifffile/large_image_source_tifffile/__init__.py
@@ -259,14 +259,17 @@ class TifffileFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         for p in self._tf.pages:
             if (p not in pagesInSeries and getattr(p, 'keyframe', None) is not None and
                     p.hash not in hashes and not len(set(p.axes) - set('YXS'))):
-                id = 'image_%s' % p.index
-                entry = {'page': p.index}
-                entry['width'] = p.shape[p.axes.index('X')]
-                entry['height'] = p.shape[p.axes.index('Y')]
-                if (id not in self._associatedImages and
-                        max(entry['width'], entry['height']) <= self._maxAssociatedImageSize and
-                        max(entry['width'], entry['height']) >= self._minAssociatedImageSize):
-                    self._associatedImages[id] = entry
+                try:
+                    id = 'image_%s' % p.index
+                    entry = {'page': p.index}
+                    entry['width'] = p.shape[p.axes.index('X')]
+                    entry['height'] = p.shape[p.axes.index('Y')]
+                    if (id not in self._associatedImages and
+                            max(entry['width'], entry['height']) <= self._maxAssociatedImageSize and
+                            max(entry['width'], entry['height']) >= self._minAssociatedImageSize):
+                        self._associatedImages[id] = entry
+                except Exception:
+                    pass
         for sidx, s in enumerate(self._tf.series):
             if sidx not in self._series and not len(set(s.axes) - set('YXS')):
                 id = 'series_%d' % sidx

--- a/test/lisource_compare.py
+++ b/test/lisource_compare.py
@@ -144,6 +144,8 @@ def source_compare(sourcePath, opts):  # noqa
         if (getattr(opts, 'skipsource', None) is None or k not in opts.skipsource) and
            (getattr(opts, 'usesource', None) is None or k in opts.usesource)}
     canread = large_image.canReadList(sourcePath, availableSources=sublist)
+    if opts.can_read and not len([cr for cr in canread if cr[1]]):
+        return
     large_image.cache_util.cachesClear()
     slen = max([len(source) for source, _ in canread] + [10])
     sys.stdout.write('Source' + ' ' * (slen - 6))
@@ -195,6 +197,8 @@ def source_compare(sourcePath, opts):  # noqa
         if len(projections) > 1:
             sys.stdout.write('Projection: %s\n' % (str(projection)[:72]))
         for source, couldread in canread:
+            if not couldread and opts.can_read:
+                continue
             if getattr(opts, 'skipsource', None) and source in opts.skipsource:
                 continue
             if getattr(opts, 'usesource', None) and source not in opts.usesource:
@@ -388,6 +392,10 @@ def source_compare(sourcePath, opts):  # noqa
 
             # get maxval for other histograms
             h = ts.histogram(onlyMinMax=True, output=dict(maxWidth=2048, maxHeight=2048), **kwargs)
+            if 'max' not in h:
+                sys.stdout.write(' fail\n')
+                sys.stdout.flush()
+                continue
             maxval = max(h['max'].tolist())
             maxval = 2 ** (int(math.log(maxval or 1) / math.log(2)) + 1) if maxval > 1 else 1
             # thumbnail histogram
@@ -492,6 +500,10 @@ def command():
         '--all', action='store_true',
         help='All sources to read all files.  Otherwise, some sources avoid '
         'some files based on name.')
+    parser.add_argument(
+        '--can-read', action='store_true',
+        help='If a source reports it cannot read a file, it will not be '
+        'included in the full report.')
     parser.add_argument(
         '--thumbs', '--thumbnails', type=str, required=False,
         help='Location to write thumbnails of results.  If this is not an '


### PR DESCRIPTION
This was tested by running lisource_compare.py on most of the GDAL repository's autotest files.  If a source threw a traceback rather than returning that it could not read a source, it was modified to handle the condition better.

Specifically, command like `find ../gdal/autotest/{gcore,gdrivers} -type f -not -name '*.py' -not -name '*.txt' -exec python test/lisource_compare.py --all --projection= --projection=EPSG:3857 {} \+` was run, though some test files were excluded.

There are some interesting test cases that are just astonishingly slow.  For instance, some test files are conceptually single layers that are 2e9 pixels across; we currently synthesize lower levels when getting things like thumbnails in some sources (such as tiff).  We could be smarter there -- if the synthesized layer is far enough from the known parent, we could reduce the amount of work done by essentially compositing from single pixels (nearest neighbor) instead of tiles.

There are some other test cases that cause issues -- the geospatial pdfs cause bioformats to crash the jvm; when reprojected our build of gdal also has some uncaught error.