### PR TITLE
Some projected bounds in the rasterio source could be off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Harden converting sources that report varied tile bands ([#1615](../../pull/1615))
 - Harden many of the sources from reading bad files ([#1623](../../pull/1623))
+- Some projected bounds in the rasterio source could be off ([#1624](../../pull/1624))
 
 ## 1.29.6
 

--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -106,7 +106,7 @@ def _reduceLogging():
             'org/slf4j/LoggerFactory', 'getLogger',
             '(Ljava/lang/String;)Lorg/slf4j/Logger;', rootLoggerName)
         logLevel = javabridge.get_static_field(
-            'ch/qos/logback/classic/Level', 'ERROR', 'Lch/qos/logback/classic/Level;')
+            'ch/qos/logback/classic/Level', 'OFF', 'Lch/qos/logback/classic/Level;')
         javabridge.call(rootLogger, 'setLevel', '(Lch/qos/logback/classic/Level;)V', logLevel)
     except Exception:
         pass

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -494,12 +494,11 @@ class GDALFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass):
                 keys = ('ll', 'ul', 'lr', 'ur')
                 for key in keys:
                     bounds[key]['y'] = max(min(bounds[key]['y'], yBound), -yBound)
-                while any(bounds[key]['x'] > 180 for key in keys):
+                dx = min(bounds[key]['x'] for key in keys)
+                if dx < -180 or dx >= 180:
+                    dx = ((dx + 180) % 360 - 180) - dx
                     for key in keys:
-                        bounds[key]['x'] -= 360
-                while any(bounds[key]['x'] < -180 for key in keys):
-                    for key in keys:
-                        bounds[key]['x'] += 360
+                        bounds[key]['x'] += dx
                 if any(bounds[key]['x'] >= 180 for key in keys):
                     bounds['ul']['x'] = bounds['ll']['x'] = -180
                     bounds['ur']['x'] = bounds['lr']['x'] = 180

--- a/sources/rasterio/large_image_source_rasterio/__init__.py
+++ b/sources/rasterio/large_image_source_rasterio/__init__.py
@@ -417,15 +417,14 @@ class RasterioFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass
             for k in bounds:
                 bounds[k]['y'] = max(min(bounds[k]['y'], yBounds), -yBounds)
 
-            # for each corner rotate longitude until it's within -180, 180
-            while any(v['x'] > 180 for v in bounds.values()):
+            # rotate longitude so the western-most corner is within [-180, 180)
+            dx = min(v['x'] for v in bounds.values())
+            if dx < -180 or dx >= 180:
+                dx = ((dx + 180) % 360 - 180) - dx
                 for k in bounds:
-                    bounds[k]['x'] -= 180
-            while any(v['x'] < -180 for v in bounds.values()):
-                for k in bounds:
-                    bounds[k]['x'] += 360
+                    bounds[k]['x'] += dx
 
-            # if one of the corner is > 180 set all the corner to world width
+            # if one of the corner is >= 180 set all the corners to world width
             if any(v['x'] >= 180 for v in bounds.values()):
                 bounds['ul']['x'] = bounds['ll']['x'] = -180
                 bounds['ur']['x'] = bounds['lr']['x'] = 180

--- a/sources/rasterio/setup.py
+++ b/sources/rasterio/setup.py
@@ -56,7 +56,9 @@ setup(
     ],
     install_requires=[
         f'large-image{limit_version}',
-        'rasterio>=1.3',  # to get the statistics attribute (<=> gdalinfo)
+        'rasterio>=1.3,<1.3.11 ; python_version < "3.9"',
+        # We need rasterio > 1.3 to get the statistics attribute (<=> gdalinfo)
+        'rasterio>=1.3 ; python_version >= "3.9"',
         'packaging',
     ],
     extras_require={


### PR DESCRIPTION
This simplifies some of the math in bounds computations to make this sort of error harder to occur.

Also, turn down warning messages in bioformats