### PR TITLE
Zarr Sink Frame Values

### DIFF
--- a/docs/notebooks/zarr_sink_example.ipynb
+++ b/docs/notebooks/zarr_sink_example.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "4ba28d02",
    "metadata": {},
    "outputs": [],
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "63c0c38f",
    "metadata": {},
    "outputs": [],
@@ -164,7 +164,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bf6d0e9480cb43ef9851d7bd3ca7e356",
+       "model_id": "97c6787b148c4b4f9639d623f32f8a3a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "0e75e6de",
    "metadata": {},
    "outputs": [],
@@ -228,10 +228,22 @@
      "data": {
       "application/json": {
        "IndexRange": {
-        "IndexI": 3
+        "IndexFOOTPRINT": 3
        },
        "IndexStride": {
-        "IndexI": 1
+        "IndexFOOTPRINT": 1
+       },
+       "ValueFOOTPRINT": {
+        "datatype": "int64",
+        "max": 50,
+        "min": 1,
+        "uniform": true,
+        "units": null,
+        "values": [
+         1,
+         10,
+         50
+        ]
        },
        "bandCount": 3,
        "channelmap": {
@@ -246,19 +258,22 @@
          "Channel": "Band 1",
          "Frame": 0,
          "Index": 0,
-         "IndexI": 0
+         "IndexFOOTPRINT": 0,
+         "ValueFOOTPRINT": 1
         },
         {
          "Channel": "Band 1",
          "Frame": 1,
          "Index": 1,
-         "IndexI": 1
+         "IndexFOOTPRINT": 1,
+         "ValueFOOTPRINT": 10
         },
         {
          "Channel": "Band 1",
          "Frame": 2,
          "Index": 2,
-         "IndexI": 2
+         "IndexFOOTPRINT": 2,
+         "ValueFOOTPRINT": 50
         }
        ],
        "levels": 6,
@@ -281,16 +296,34 @@
        " 'mm_y': 0,\n",
        " 'dtype': 'float64',\n",
        " 'bandCount': 3,\n",
-       " 'frames': [{'Frame': 0, 'IndexI': 0, 'Index': 0, 'Channel': 'Band 1'},\n",
-       "  {'Frame': 1, 'IndexI': 1, 'Index': 1, 'Channel': 'Band 1'},\n",
-       "  {'Frame': 2, 'IndexI': 2, 'Index': 2, 'Channel': 'Band 1'}],\n",
-       " 'IndexRange': {'IndexI': 3},\n",
-       " 'IndexStride': {'IndexI': 1},\n",
+       " 'frames': [{'Frame': 0,\n",
+       "   'IndexFOOTPRINT': 0,\n",
+       "   'ValueFOOTPRINT': 1,\n",
+       "   'Index': 0,\n",
+       "   'Channel': 'Band 1'},\n",
+       "  {'Frame': 1,\n",
+       "   'IndexFOOTPRINT': 1,\n",
+       "   'ValueFOOTPRINT': 10,\n",
+       "   'Index': 1,\n",
+       "   'Channel': 'Band 1'},\n",
+       "  {'Frame': 2,\n",
+       "   'IndexFOOTPRINT': 2,\n",
+       "   'ValueFOOTPRINT': 50,\n",
+       "   'Index': 2,\n",
+       "   'Channel': 'Band 1'}],\n",
+       " 'ValueFOOTPRINT': {'values': [1, 10, 50],\n",
+       "  'uniform': True,\n",
+       "  'units': None,\n",
+       "  'min': 1,\n",
+       "  'max': 50,\n",
+       "  'datatype': 'int64'},\n",
+       " 'IndexRange': {'IndexFOOTPRINT': 3},\n",
+       " 'IndexStride': {'IndexFOOTPRINT': 1},\n",
        " 'channels': ['Band 1'],\n",
        " 'channelmap': {'Band 1': 0}}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -315,7 +348,7 @@
     "\n",
     "        # add modified tile to sink\n",
     "        # specify tile x, tile y, and any arbitrary frame parameters\n",
-    "        sink.addTile(processed_tile, x=tile['x'], y=tile['y'], i=i)\n",
+    "        sink.addTile(processed_tile, x=tile['x'], y=tile['y'], footprint=i, footprint_value=footprint_size)\n",
     "# view metadata\n",
     "sink.getMetadata()"
    ]
@@ -329,7 +362,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9b8e6175005d4af89cb4cfada7b72983",
+       "model_id": "fb60c2b967274a99a632f32f99389705",
        "version_major": 2,
        "version_minor": 0
       },
@@ -398,10 +431,10 @@
      "data": {
       "application/json": {
        "IndexRange": {
-        "IndexI": 3
+        "IndexFOOTPRINT": 3
        },
        "IndexStride": {
-        "IndexI": 1
+        "IndexFOOTPRINT": 1
        },
        "bandCount": 3,
        "channelmap": {
@@ -416,19 +449,19 @@
          "Channel": "Band 1",
          "Frame": 0,
          "Index": 0,
-         "IndexI": 0
+         "IndexFOOTPRINT": 0
         },
         {
          "Channel": "Band 1",
          "Frame": 1,
          "Index": 1,
-         "IndexI": 1
+         "IndexFOOTPRINT": 1
         },
         {
          "Channel": "Band 1",
          "Frame": 2,
          "Index": 2,
-         "IndexI": 2
+         "IndexFOOTPRINT": 2
         }
        ],
        "levels": 4,
@@ -451,16 +484,16 @@
        " 'mm_y': None,\n",
        " 'dtype': 'uint16',\n",
        " 'bandCount': 3,\n",
-       " 'frames': [{'Channel': 'Band 1', 'Frame': 0, 'Index': 0, 'IndexI': 0},\n",
-       "  {'Channel': 'Band 1', 'Frame': 1, 'Index': 1, 'IndexI': 1},\n",
-       "  {'Channel': 'Band 1', 'Frame': 2, 'Index': 2, 'IndexI': 2}],\n",
-       " 'IndexRange': {'IndexI': 3},\n",
-       " 'IndexStride': {'IndexI': 1},\n",
+       " 'frames': [{'Channel': 'Band 1', 'Frame': 0, 'Index': 0, 'IndexFOOTPRINT': 0},\n",
+       "  {'Channel': 'Band 1', 'Frame': 1, 'Index': 1, 'IndexFOOTPRINT': 1},\n",
+       "  {'Channel': 'Band 1', 'Frame': 2, 'Index': 2, 'IndexFOOTPRINT': 2}],\n",
+       " 'IndexRange': {'IndexFOOTPRINT': 3},\n",
+       " 'IndexStride': {'IndexFOOTPRINT': 1},\n",
        " 'channels': ['Band 1'],\n",
        " 'channelmap': {'Band 1': 0}}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -506,7 +539,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "30812bb388a0426da9806e62bf5e8711",
+       "model_id": "a2d3df88fbd44079877b8f314ed97e6f",
        "version_major": 2,
        "version_minor": 0
       },

--- a/examples/algorithm_progression.py
+++ b/examples/algorithm_progression.py
@@ -86,12 +86,15 @@ class SweepAlgorithm:
             **tiparams,
         ):
             scaled = tile.get('scaled', 1)
+            axisparams = {
+                p['axis']: iteration_id[i] for i, p in enumerate(self.param_order.values())}
+            axisparams.update({
+                p['axis'] + '_value': params[i] for i, p in enumerate(self.param_order.values())})
             if self.overlay:
                 self.addTile(
                     tilesink,
                     tile['tile'], int(tile['x'] * scaled), int(tile['y'] * scaled),
-                    **{p['axis']: iteration_id[i] for i, p in enumerate(
-                        self.param_order.values())})
+                    **axisparams)
             altered_data = self.algorithm(tile['tile'], *params)
             mask = None
             if self.overlay:
@@ -104,7 +107,7 @@ class SweepAlgorithm:
             self.addTile(
                 tilesink,
                 altered_data, int(tile['x'] * scaled), int(tile['y'] * scaled), mask=mask,
-                **{p['axis']: iteration_id[i] for i, p in enumerate(self.param_order.values())})
+                **axisparams)
             if time.time() - lastlogtime > 10:
                 sys.stdout.write(
                     f'Processed {tile["tile_position"]["position"] + 1} of '

--- a/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
+++ b/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
@@ -45,12 +45,17 @@ export default Vue.extend({
                     const labelKey = key.replace('Value', 'Index');
                     if (info.values) {
                         if (info.uniform) {
-                            labels[labelKey] = info.values;
+                            labels[labelKey] = info.values.map((v) => {
+                                if (typeof v === 'number') return Number(v.toPrecision(5));
+                                return v;
+                            });
                         } else {
                             // non-uniform values have a value for every frame
                             // labels will change with currentFrame, so only populate current label
+                            let currentLabel = info.values[this.currentFrame];
+                            if (typeof currentLabel === 'number') currentLabel = Number(currentLabel.toPrecision(5));
                             labels[labelKey] = new Array(this.indexInfo[labelKey].range + 1).fill('');
-                            labels[labelKey][this.indexInfo[labelKey].current] = info.values[this.currentFrame];
+                            labels[labelKey][this.indexInfo[labelKey].current] = currentLabel;
                         }
                     }
                 }

--- a/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
+++ b/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
@@ -1,6 +1,7 @@
 <script>
 import Vue from 'vue';
 
+import {restRequest} from '@girder/core/rest';
 import {getChannelColor, OTHER_COLORS} from '../utils/colors';
 
 import CompositeLayers from './CompositeLayers.vue';
@@ -21,7 +22,8 @@ export default Vue.extend({
             indexInfo: {},
             style: {},
             modesShown: {1: true},
-            histogramParamStyles: {}
+            histogramParamStyles: {},
+            internalMetadata: undefined,
         };
     },
     computed: {
@@ -36,6 +38,36 @@ export default Vue.extend({
         currentStyle() {
             const curStyle = this.style[this.currentModeId];
             return curStyle ? JSON.stringify(curStyle, null, null) : '';
+        },
+        sliderLabels() {
+            const labels = {};
+            labels['IndexC'] = this.imageMetadata.channels;
+            if (
+                this.internalMetadata &&
+                this.internalMetadata.zarr &&
+                this.internalMetadata.zarr.main &&
+                this.internalMetadata.zarr.main.multiscales &&
+                this.internalMetadata.zarr.main.multiscales[0] &&
+                this.internalMetadata.zarr.main.multiscales[0].axes
+            ) {
+                this.internalMetadata.zarr.main.multiscales[0].axes.forEach((axis) => {
+                    if (axis.values) {
+                        const key = 'Index'+ axis.name.toUpperCase();
+                        const expectedLength = this.indexInfo[key].range + 1
+                        if (axis.values.length === expectedLength) {
+                            // uniform values have same length as axis
+                            labels[key] = axis.values
+                        } else if (axis.values.length === this.maxFrame + 1) {
+                            // non-uniform values have a value for every frame
+                            // labels will change with currentFrame, so only populate current label
+                            labels[key] = new Array(expectedLength).fill('')
+                            labels[key][this.indexInfo[key].current] = axis.values[this.currentFrame]
+                        }
+                    }
+                })
+
+            }
+            return labels;
         }
     },
     watch: {
@@ -47,12 +79,21 @@ export default Vue.extend({
     mounted() {
         this.metadata = Object.assign({}, this.imageMetadata);
         this.fillMetadata();
+        this.fetchInternalMetadata();
         this.maxFrame = this.metadata.frames.length - 1;
         this.populateIndices();
         this.populateModes();
         this.loaded = true;
     },
     methods: {
+        fetchInternalMetadata() {
+            restRequest({
+                type: 'GET',
+                url: 'item/' + this.itemId + '/tiles/internal_metadata/'
+            }).then((internal) => {
+                this.internalMetadata = internal;
+            })
+        },
         setCurrentMode(mode) {
             this.currentModeId = mode.id;
         },
@@ -328,7 +369,7 @@ export default Vue.extend({
         :current-value="indexInfo[index].current"
         :value-max="indexInfo[index].range"
         :label="index.replace('Index', '')"
-        :slider-labels="index === 'IndexC' ? imageMetadata.channels : []"
+        :slider-labels="sliderLabels[index]"
         :max-merge="indexInfo[index].maxMerge || false"
         @updateMaxMerge="(v) => updateMaxMergeAxis({index, maxMerge: v})"
         @updateValue="(v) => updateAxisSlider({index, frame: v})"

--- a/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
+++ b/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
@@ -2,6 +2,7 @@
 import Vue from 'vue';
 
 import {restRequest} from '@girder/core/rest';
+
 import {getChannelColor, OTHER_COLORS} from '../utils/colors';
 
 import CompositeLayers from './CompositeLayers.vue';
@@ -23,7 +24,7 @@ export default Vue.extend({
             style: {},
             modesShown: {1: true},
             histogramParamStyles: {},
-            internalMetadata: undefined,
+            internalMetadata: undefined
         };
     },
     computed: {
@@ -41,7 +42,7 @@ export default Vue.extend({
         },
         sliderLabels() {
             const labels = {};
-            labels['IndexC'] = this.imageMetadata.channels;
+            labels.IndexC = this.imageMetadata.channels;
             if (
                 this.internalMetadata &&
                 this.internalMetadata.zarr &&
@@ -52,20 +53,19 @@ export default Vue.extend({
             ) {
                 this.internalMetadata.zarr.main.multiscales[0].axes.forEach((axis) => {
                     if (axis.values) {
-                        const key = 'Index'+ axis.name.toUpperCase();
-                        const expectedLength = this.indexInfo[key].range + 1
+                        const key = 'Index' + axis.name.toUpperCase();
+                        const expectedLength = this.indexInfo[key].range + 1;
                         if (axis.values.length === expectedLength) {
                             // uniform values have same length as axis
-                            labels[key] = axis.values
+                            labels[key] = axis.values;
                         } else if (axis.values.length === this.maxFrame + 1) {
                             // non-uniform values have a value for every frame
                             // labels will change with currentFrame, so only populate current label
-                            labels[key] = new Array(expectedLength).fill('')
-                            labels[key][this.indexInfo[key].current] = axis.values[this.currentFrame]
+                            labels[key] = new Array(expectedLength).fill('');
+                            labels[key][this.indexInfo[key].current] = axis.values[this.currentFrame];
                         }
                     }
-                })
-
+                });
             }
             return labels;
         }
@@ -92,7 +92,8 @@ export default Vue.extend({
                 url: 'item/' + this.itemId + '/tiles/internal_metadata/'
             }).then((internal) => {
                 this.internalMetadata = internal;
-            })
+                return undefined;
+            });
         },
         setCurrentMode(mode) {
             this.currentModeId = mode.id;

--- a/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
+++ b/girder/girder_large_image/web_client/vue/components/FrameSelector.vue
@@ -41,21 +41,20 @@ export default Vue.extend({
             const labels = {};
             labels.IndexC = this.imageMetadata.channels;
             Object.entries(this.metadata).forEach(([key, info]) => {
-                if (key.includes("Value")) {
-                    const labelKey = key.replace('Value', 'Index')
+                if (key.includes('Value')) {
+                    const labelKey = key.replace('Value', 'Index');
                     if (info.values) {
                         if (info.uniform) {
-                            labels[labelKey] = info.values
-                        } else  {
+                            labels[labelKey] = info.values;
+                        } else {
                             // non-uniform values have a value for every frame
                             // labels will change with currentFrame, so only populate current label
                             labels[labelKey] = new Array(this.indexInfo[labelKey].range + 1).fill('');
                             labels[labelKey][this.indexInfo[labelKey].current] = info.values[this.currentFrame];
-
                         }
                     }
                 }
-            })
+            });
             return labels;
         }
     },

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1317,12 +1317,12 @@ class TileSource(IPyLeafletMixin):
 
     def _getFrameValueInformation(self, frames: List[Dict]):
         refvalues: Dict[str, Dict[str, List]] = {}
-        for idx, frame in enumerate(frames):
+        for frame in frames:
             for key, value in frame.items():
                 if 'Value' in key:
                     if key not in refvalues:
                         refvalues[key] = {}
-                    value_index = frame.get(key.replace('Value', 'Index'))
+                    value_index = str(frame.get(key.replace('Value', 'Index')))
                     if value_index not in refvalues[key]:
                         refvalues[key][value_index] = [value]
                     else:

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1355,7 +1355,6 @@ class TileSource(IPyLeafletMixin):
             )
         return frame_value_info
 
-
     def _addMetadataFrameInformation(
             self, metadata: JSONDict, channels: Optional[List[str]] = None) -> None:
         """

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1332,8 +1332,18 @@ class TileSource(IPyLeafletMixin):
             return
         maxref: Dict[str, int] = {}
         refkeys = {'IndexC'}
+        refvalues = {}
         index = 0
         for idx, frame in enumerate(metadata['frames']):
+            for key, value in frame.items():
+                if 'Value' in key:
+                    if key not in refvalues:
+                        refvalues[key] = {}
+                    value_index = frame.get(key.replace('Value', 'Index'))
+                    if value_index not in refvalues[key]:
+                        refvalues[key][value_index] = [value]
+                    else:
+                        refvalues[key][value_index].append(value)
             refkeys |= {key for key in frame
                         if key.startswith('Index') and len(key.split('Index', 1)[1])}
             for key in refkeys:
@@ -1346,6 +1356,28 @@ class TileSource(IPyLeafletMixin):
                     metadata['frames'][idx].get(key) for key in refkeys)):
                 index += 1
             frame['Index'] = index
+        for key, value_mapping in refvalues.items():
+            axis_name = key.replace('Value', '').lower()
+            units = None
+            if hasattr(self, 'frameUnits') and self.frameUnits is not None:
+                units = self.frameUnits.get(axis_name)
+            uniform = all(len(set(value_list)) <= 1 for value_list in value_mapping.values())
+            # after evaluating uniform, continue with only the first value for each index along this axis
+            first_values = [value_list[0] for value_list in value_mapping.values() if len(value_list)]
+            try:
+                min_val = min(first_values)
+                max_val = max(first_values)
+            except TypeError:
+                min_val = None
+                max_val = None
+            metadata[key] = dict(
+                values=first_values,
+                uniform=uniform,
+                units=units,
+                min=min_val,
+                max=max_val,
+                datatype=np.array(first_values).dtype.name,
+            )
         if any(val > 1 for val in maxref.values()):
             metadata['IndexRange'] = {key: value for key, value in maxref.items() if value > 1}
             metadata['IndexStride'] = {

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1316,6 +1316,15 @@ class TileSource(IPyLeafletMixin):
         return self.getMetadata()
 
     def _getFrameValueInformation(self, frames: List[Dict]):
+        """
+        Given a `frames` list from a metadata response, return a dictionary describing
+        the value info for any frame axes. Keys in this dictionary follow the pattern "Value[AXIS]"
+        and each maps to a dictionary describing the axis, including a list of values, whether the
+        axis is uniform, the units, minimum value, maximum value, and data type.
+
+        :param frames: A list of dictionaries describing each frame in the image
+        :returns: A dictionary describing the values of frame axes
+        """
         refvalues: Dict[str, Dict[str, List]] = {}
         for frame in frames:
             for key, value in frame.items():

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1334,24 +1334,27 @@ class TileSource(IPyLeafletMixin):
             if hasattr(self, 'frameUnits') and self.frameUnits is not None:
                 units = self.frameUnits.get(axis_name)
             uniform = all(len(set(value_list)) <= 1 for value_list in value_mapping.values())
-            # after evaluating uniform, continue with only
-            # the first value for each index along this axis
-            first_values = [
-                value_list[0] for value_list in value_mapping.values() if len(value_list)
-            ]
+            if uniform:
+                # for uniform values, only record values at each axis index
+                values = [
+                    value_list[0] for value_list in value_mapping.values() if len(value_list)
+                ]
+            else:
+                # for non-uniform axes, record values at every frame
+                values = [frame.get(key) for frame in frames]
             try:
-                min_val = min(first_values)
-                max_val = max(first_values)
+                min_val = min(values)
+                max_val = max(values)
             except TypeError:
                 min_val = None
                 max_val = None
             frame_value_info[key] = dict(
-                values=first_values,
+                values=values,
                 uniform=uniform,
                 units=units,
                 min=min_val,
                 max=max_val,
-                datatype=np.array(first_values).dtype.name,
+                datatype=np.array(values).dtype.name,
             )
         return frame_value_info
 

--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -502,29 +502,6 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         result = super().getMetadata()
         if self._framecount > 1:
             result['frames'] = frames = []
-            if self.frameValues is not None and self.frameAxes is not None:
-                for i, axis in enumerate(self.frameAxes):
-                    all_frame_values = self.frameValues[..., i]
-                    split = np.split(all_frame_values, all_frame_values.shape[i], axis=i)
-                    values = [a.flat[0] for a in split]
-                    uniform = all(len(np.unique(
-                        # convert all values to strings for mixed type comparison with np.unique
-                        (a[np.not_equal(a, None)]).astype(str),
-                    )) == 1 for a in split)
-                    try:
-                        min_val = min(values)
-                        max_val = max(values)
-                    except TypeError:
-                        min_val = None
-                        max_val = None
-                    result['Value' + axis.upper()] = dict(
-                        values=values,
-                        uniform=uniform,
-                        units=self.frameUnits.get(axis) if self.frameUnits is not None else None,
-                        min=min_val,
-                        max=max_val,
-                        datatype=np.array(values).dtype.name,
-                    )
             for idx in range(self._framecount):
                 frame = {'Frame': idx}
                 for axis in self._strides:

--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -363,7 +363,7 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             frame_values_shape = [baseArray.shape[self._axes[a]] for a in self.frameAxes]
             frame_values_shape.append(len(frame_values_shape))
             frame_values = np.empty(frame_values_shape, dtype=object)
-            all_frame_specs = self.getMetadata()['frames']
+            all_frame_specs = self.getMetadata().get('frames')
             for axis, values in axes_values.items():
                 if axis in self.frameAxes:
                     slicing = [slice(None) for i in range(len(frame_values_shape))]
@@ -377,11 +377,12 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                     elif len(values) == self._framecount:
                         # non-uniform values have a value for every frame
                         for i, value in enumerate(values):
-                            for k, j in all_frame_specs[i].items():
-                                if 'Index' in k:
-                                    name = k.replace('Index', '').lower()
-                                    if name:
-                                        slicing[self._frameAxes.index(name)] = j
+                            if all_frame_specs and len(all_frame_specs) > i:
+                                for k, j in all_frame_specs[i].items():
+                                    if 'Index' in k:
+                                        name = k.replace('Index', '').lower()
+                                        if name:
+                                            slicing[self._frameAxes.index(name)] = j
                             frame_values[tuple(slicing)] = value
             self._frameValues = frame_values
 

--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -400,7 +400,11 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         self._series = found['series']
         baseGroup, baseArray = self._series[0]
         self._is_ome = found['is_ome']
-        self._axes = {k.lower(): v for k, v in found['axes'].items() if baseArray.shape[v] > 1}
+        self._axes = {
+            k.lower(): v
+            for k, v in found['axes'].items()
+            if baseArray.shape[v] > 1 or k in found.get('axes_values', {})
+        }
         if len(self._series) > 1 and 'xy' in self._axes:
             msg = 'Conflicting xy axis data.'
             raise TileSourceError(msg)
@@ -697,7 +701,11 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             ])
 
             if len(frame_values.keys()) > 0:
-                self.frameAxes = [a for a in axes if a in frame_values]
+                self.frameAxes = [
+                    a for a in axes
+                    if a in frame_values or
+                    (self.frameAxes is not None and a in self.frameAxes)
+                ]
                 frames_shape = [new_dims[a] for a in self.frameAxes]
                 frames_shape.append(len(frames_shape))
                 if self.frameValues is None:

--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -513,7 +513,9 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                     )
                     current_frame_values = self.frameValues[current_frame_slice]
                     for i, axis in enumerate(self.frameAxes):
-                        frame['Value' + axis.upper()] = current_frame_values[i]
+                        value = current_frame_values[i]
+                        native_value = getattr(value, 'tolist', lambda: value)()
+                        frame['Value' + axis.upper()] = native_value
                 frames.append(frame)
             self._addMetadataFrameInformation(result, getattr(self, '_channels', None))
         return result

--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -514,7 +514,7 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                     current_frame_values = self.frameValues[current_frame_slice]
                     for i, axis in enumerate(self.frameAxes):
                         value = current_frame_values[i]
-                        native_value = getattr(value, 'tolist', lambda: value)()
+                        native_value = getattr(value, 'tolist', lambda v=value: v)()
                         frame['Value' + axis.upper()] = native_value
                 frames.append(frame)
             self._addMetadataFrameInformation(result, getattr(self, '_channels', None))

--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -225,8 +225,8 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             arrays, then total pixels, then channels.  'is_ome' is a boolean.
             'series' is a list of the found groups and arrays that match the
             best criteria.  'axes', 'axes_values', 'axes_units', and 'channels'
-            are from the best array. 'associated' is a list of all groups and 
-            arrays that might be associated images.  These have to be culled 
+            are from the best array. 'associated' is a list of all groups and
+            arrays that might be associated images.  These have to be culled
             for the actual groups used in the series.
         """
         attrs = group.attrs.asdict() if group is not None else {}
@@ -245,11 +245,11 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             axes = {axis['name']: idx for idx, axis in enumerate(
                 attrs['multiscales'][0]['axes'])}
             axes_values = {
-                axis['name']: axis.get('values') 
+                axis['name']: axis.get('values')
                 for axis in attrs['multiscales'][0]['axes']
             }
             axes_units = {
-                axis['name']: axis.get('unit') 
+                axis['name']: axis.get('unit')
                 for axis in attrs['multiscales'][0]['axes']
             }
             if isinstance(attrs['omero'].get('channels'), list):
@@ -374,7 +374,7 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                             slicing[axis_index] = i
                             frame_values[tuple(slicing)] = value
                     elif isinstance(values, dict):
-                        # non-uniform values are written as dicts 
+                        # non-uniform values are written as dicts
                         # mapping values to index permutations
                         for value, frame_specs in values.items():
                             if isinstance(value, str):
@@ -387,7 +387,7 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                                     slicing[self.frameAxes.index(a)] = i
                                 frame_values[tuple(slicing)] = value
             self._frameValues = frame_values
-    
+
     def _validateZarr(self):
         """
         Validate that we can read tiles from the zarr parent group in
@@ -796,13 +796,13 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         elif axis_name in ['s', 'c']:
             axis_metadata['type'] = 'channel'
         if self.frameAxes is not None:
-            frame_axis_index = self.frameAxes.index(axis_name) if axis_name in self.frameAxes else None
-            if frame_axis_index is not None and self.frameValues is not None:
-                all_frame_values = self.frameValues[..., frame_axis_index]
+            axis_index = self.frameAxes.index(axis_name) if axis_name in self.frameAxes else None
+            if axis_index is not None and self.frameValues is not None:
+                all_frame_values = self.frameValues[..., axis_index]
                 split = np.split(
                     all_frame_values,
-                    all_frame_values.shape[frame_axis_index],
-                    axis=frame_axis_index,
+                    all_frame_values.shape[axis_index],
+                    axis=axis_index,
                 )
                 uniform = all(len(np.unique(a)) == 1 for a in split)
                 if uniform:
@@ -819,8 +819,8 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             unit = self.frameUnits.get(axis_name) if self.frameUnits is not None else None
             if unit is not None:
                 axis_metadata['unit'] = unit
-            return axis_metadata
-    
+        return axis_metadata
+
     def _writeInternalMetadata(self):
         self._checkEditable()
         with self._threadLock and self._processLock:

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -567,7 +567,7 @@ def get_expected_metadata(axis_spec, frame_shape):
                 max=max(v['values']),
                 datatype=v['dtype'],
             ) for k, v in axis_spec.items()
-        }
+        },
     )
 
 def compare_metadata(actual, expected):
@@ -589,9 +589,13 @@ def testFrameValuesSmall(use_add_tile_args, tmp_path):
     sink = large_image_source_zarr.new()
 
     frame_shape = (300, 400, 3)
-    axis_spec = dict(
-        c=dict(values=['r', 'g', 'b'], uniform=True, units='channel', stride=1, dtype='str32'),
-    )
+    axis_spec = dict(c=dict(
+        values=['r', 'g', 'b'],
+        uniform=True,
+        units='channel',
+        stride=1,
+        dtype='str32',
+    ))
     expected_metadata = get_expected_metadata(axis_spec, frame_shape)
 
     sink.frameAxes = list(axis_spec.keys())
@@ -600,7 +604,7 @@ def testFrameValuesSmall(use_add_tile_args, tmp_path):
     }
     frame_values_shape = [
         *[len(v['values']) for v in axis_spec.values()],
-        len(axis_spec)
+        len(axis_spec),
     ]
     frame_values = np.empty(frame_values_shape, dtype=object)
 
@@ -621,7 +625,7 @@ def testFrameValuesSmall(use_add_tile_args, tmp_path):
                     IndexC=c,
                     ValueC=c_value,
                     Channel=f'Band {c + 1}',
-                )
+                ),
             )
             frame += 1
     index += 1
@@ -642,9 +646,27 @@ def testFrameValues(use_add_tile_args, tmp_path):
 
     frame_shape = (300, 400, 3)
     axis_spec = dict(
-        z=dict(values=[2, 4, 6, 8], uniform=True, units='meter', stride=9, dtype='int64'),
-        t=dict(values=[10.0, 20.0, 30.0], uniform=False, units='millisecond', stride=3, dtype='float64'),
-        c=dict(values=['r', 'g', 'b'], uniform=True, units='channel', stride=1, dtype='str32'),
+        z=dict(
+            values=[2, 4, 6, 8],
+            uniform=True,
+            units='meter',
+            stride=9,
+            dtype='int64',
+        ),
+        t=dict(
+            values=[10.0, 20.0, 30.0],
+            uniform=False,
+            units='millisecond',
+            stride=3,
+            dtype='float64',
+        ),
+        c=dict(
+            values=['r', 'g', 'b'],
+            uniform=True,
+            units='channel',
+            stride=1,
+            dtype='str32',
+        ),
     )
     expected_metadata = get_expected_metadata(axis_spec, frame_shape)
 

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -570,6 +570,7 @@ def get_expected_metadata(axis_spec, frame_shape):
         },
     )
 
+
 def compare_metadata(actual, expected):
     assert type(actual) is type(expected)
     if isinstance(actual, list):
@@ -611,23 +612,23 @@ def testFrameValuesSmall(use_add_tile_args, tmp_path):
     frame = 0
     index = 0
     for c, c_value in enumerate(axis_spec['c']['values']):
-            add_tile_args = dict(c=c, axes=['c', 'y', 'x', 's'])
-            if use_add_tile_args:
-                add_tile_args.update(c_value=c_value)
-            else:
-                frame_values[c] = [c_value]
-            random_tile = np.random.random(frame_shape)
-            sink.addTile(random_tile, 0, 0, **add_tile_args)
-            expected_metadata['frames'].append(
-                dict(
-                    Frame=frame,
-                    Index=index,
-                    IndexC=c,
-                    ValueC=c_value,
-                    Channel=f'Band {c + 1}',
-                ),
-            )
-            frame += 1
+        add_tile_args = dict(c=c, axes=['c', 'y', 'x', 's'])
+        if use_add_tile_args:
+            add_tile_args.update(c_value=c_value)
+        else:
+            frame_values[c] = [c_value]
+        random_tile = np.random.random(frame_shape)
+        sink.addTile(random_tile, 0, 0, **add_tile_args)
+        expected_metadata['frames'].append(
+            dict(
+                Frame=frame,
+                Index=index,
+                IndexC=c,
+                ValueC=c_value,
+                Channel=f'Band {c + 1}',
+            ),
+        )
+        frame += 1
     index += 1
 
     if not use_add_tile_args:
@@ -676,7 +677,7 @@ def testFrameValues(use_add_tile_args, tmp_path):
     }
     frame_values_shape = [
         *[len(v['values']) for v in axis_spec.values()],
-        len(axis_spec)
+        len(axis_spec),
     ]
     frame_values = np.empty(frame_values_shape, dtype=object)
 
@@ -687,27 +688,27 @@ def testFrameValues(use_add_tile_args, tmp_path):
             if not axis_spec['t']['uniform']:
                 t_value += 0.01 * z
             for c, c_value in enumerate(axis_spec['c']['values']):
-                    add_tile_args = dict(z=z, t=t, c=c, axes=['z', 't', 'c', 'y', 'x', 's'])
-                    if use_add_tile_args:
-                        add_tile_args.update(z_value=z_value, t_value=t_value, c_value=c_value)
-                    else:
-                        frame_values[z, t, c] = [z_value, t_value, c_value]
-                    random_tile = np.random.random(frame_shape)
-                    sink.addTile(random_tile, 0, 0, **add_tile_args)
-                    expected_metadata['frames'].append(
-                        dict(
-                            Frame=frame,
-                            Index=index,
-                            IndexZ=z,
-                            ValueZ=z_value,
-                            IndexT=t,
-                            ValueT=t_value,
-                            IndexC=c,
-                            ValueC=c_value,
-                            Channel=f'Band {c + 1}',
-                        )
-                    )
-                    frame += 1
+                add_tile_args = dict(z=z, t=t, c=c, axes=['z', 't', 'c', 'y', 'x', 's'])
+                if use_add_tile_args:
+                    add_tile_args.update(z_value=z_value, t_value=t_value, c_value=c_value)
+                else:
+                    frame_values[z, t, c] = [z_value, t_value, c_value]
+                random_tile = np.random.random(frame_shape)
+                sink.addTile(random_tile, 0, 0, **add_tile_args)
+                expected_metadata['frames'].append(
+                    dict(
+                        Frame=frame,
+                        Index=index,
+                        IndexZ=z,
+                        ValueZ=z_value,
+                        IndexT=t,
+                        ValueT=t_value,
+                        IndexC=c,
+                        ValueC=c_value,
+                        Channel=f'Band {c + 1}',
+                    ),
+                )
+                frame += 1
             index += 1
 
     if not use_add_tile_args:

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -560,11 +560,11 @@ def get_expected_metadata(axis_spec, frame_shape):
         },
         **{
             f'Value{k.upper()}': dict(
-                values=v['values'],
+                values=v.get('all_values', v['values']),
                 units=v['units'],
                 uniform=v['uniform'],
-                min=min(v['values']),
-                max=max(v['values']),
+                min=min(v.get('all_values', v['values'])),
+                max=max(v.get('all_values', v['values'])),
                 datatype=v['dtype'],
             ) for k, v in axis_spec.items()
         },
@@ -656,6 +656,20 @@ def testFrameValues(use_add_tile_args, tmp_path):
         ),
         t=dict(
             values=[10.0, 20.0, 30.0],
+            all_values=(
+                [10.00] * 3 +
+                [10.01] * 3 +
+                [10.02] * 3 +
+                [10.03] * 3 +
+                [20.00] * 3 +
+                [20.01] * 3 +
+                [20.02] * 3 +
+                [20.03] * 3 +
+                [30.00] * 3 +
+                [30.01] * 3 +
+                [30.02] * 3 +
+                [30.03] * 3
+            ),
             uniform=False,
             units='millisecond',
             stride=3,

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -743,3 +743,12 @@ def testFrameValuesEdgeCases(tmp_path):
     ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=1, z=2, z_value=6.4, c_value='CD4')
     ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=1, z=1, z_value=3.1, c_value='CD4')
     ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=0, z=1, z_value=1.1)
+
+    ts = large_image.new()
+    ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=0, z=0, z_value=1, c_value='DAPI')
+    ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=0, z=1, z_value=3.2, c_value='DAPI')
+    ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=0, z=2, z_value=6.3, c_value='DAPI')
+    ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=1, z=2, z_value=6.4, c_value='CD4')
+    ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=1, z=1, z_value=3.1, c_value='CD4')
+    ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=0, z=1, z_value=1.1)
+    assert len(ts.metadata.get('frames', [])) == 6

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -718,3 +718,28 @@ def testFrameValues(use_add_tile_args, tmp_path):
     sink.write(output_file)
     written = large_image_source_zarr.open(output_file)
     compare_metadata(dict(written.getMetadata()), expected_metadata)
+
+
+def testFrameValuesEdgeCases(tmp_path):
+    # case 1
+    ts = large_image.new()
+    ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=0, z=0, z_value=1, c_value='DAPI')
+    assert ts.metadata.get('bandCount') == 3
+    ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=1, z=0, z_value=1, c_value='CD4')
+
+    # case 2
+    ts = large_image.new()
+    ts.addTile(np.zeros((100, 100, 1)), x=0, y=0, c=0, z=0, z_value=1, c_value='DAPI')
+    ts.addTile(np.zeros((100, 100, 1)), x=0, y=0, c=1, z=0, z_value=1, c_value='CD4')
+    metadata = ts.getMetadata()
+    assert metadata.get('frames') is not None
+    assert len(metadata.get('frames')) == 2
+
+    # case 3
+    ts = large_image.new()
+    ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=0, z=0, z_value=1, c_value='DAPI')
+    ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=0, z=1, z_value=3.2, c_value='DAPI')
+    ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=0, z=2, z_value=6.3, c_value='DAPI')
+    ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=1, z=2, z_value=6.4, c_value='CD4')
+    ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=1, z=1, z_value=3.1, c_value='CD4')
+    ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=0, z=1, z_value=1.1)

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -752,4 +752,9 @@ def testFrameValuesEdgeCases(tmp_path):
     ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=1, z=2, z_value=6.4, c_value='CD4')
     ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=1, z=1, z_value=3.1, c_value='CD4')
     ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=0, z=1, z_value=1.1)
-    assert len(ts.metadata.get('frames', [])) == 6
+    frame_metadata = ts.metadata.get('frames', [])
+    assert len(frame_metadata) == 6
+
+    for frame in frame_metadata:
+        for key, value in frame.items():
+            assert not isinstance(value, np.generic)

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -744,6 +744,7 @@ def testFrameValuesEdgeCases(tmp_path):
     ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=1, z=1, z_value=3.1, c_value='CD4')
     ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=0, z=1, z_value=1.1)
 
+    # case 4
     ts = large_image.new()
     ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=0, z=0, z_value=1, c_value='DAPI')
     ts.addTile(np.zeros((100, 100, 3)), x=0, y=0, c=0, z=1, z_value=3.2, c_value='DAPI')

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -756,5 +756,6 @@ def testFrameValuesEdgeCases(tmp_path):
     assert len(frame_metadata) == 6
 
     for frame in frame_metadata:
-        for key, value in frame.items():
+        for value in frame.values():
+            # ensure that values are cast to native python types
             assert not isinstance(value, np.generic)

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -535,3 +535,109 @@ def testConcurrency(tmp_path):
         assert data is not None
         assert data.shape == seed_data.shape
         assert np.allclose(data, seed_data)
+
+
+def compare_metadata(actual, expected):
+    assert type(actual) is type(expected)
+    if isinstance(actual, list):
+        for i, v in enumerate(actual):
+            compare_metadata(v, expected[i])
+    elif isinstance(actual, dict):
+        assert len(actual.keys()) == len(expected.keys())
+        for k, v in actual.items():
+            compare_metadata(v, expected[k])
+    else:
+        assert actual == expected
+
+
+@pytest.mark.parametrize('use_add_tile_args', [True, False])
+def testFrameValuesAddTile(use_add_tile_args, tmp_path):
+    output_file = tmp_path / 'test.db'
+    sink = large_image_source_zarr.new()
+
+    frame_shape = (300, 400, 3)
+    expected = dict(
+        z=dict(values=[2, 4, 6, 8], uniform=True, units='m', stride=9, dtype='int64'),
+        t=dict(values=[10.0, 20.0, 30.0], uniform=False, units='ms', stride=3, dtype='float64'),
+        c=dict(values=['r', 'g', 'b'], uniform=True, units='channel', stride=1, dtype='str32'),
+    )
+    expected_metadata = dict(
+        levels=1,
+        sizeY=frame_shape[0],
+        sizeX=frame_shape[1],
+        bandCount=frame_shape[2],
+        frames=[],
+        tileWidth=512,
+        tileHeight=512,
+        magnification=None,
+        mm_x=0,
+        mm_y=0,
+        dtype='float64',
+        channels=[f'Band {c + 1}' for c in range(len(expected['c']['values']))],
+        channelmap={f'Band {c + 1}': c for c in range(len(expected['c']['values']))},
+        IndexRange={
+            f'Index{k.upper()}': len(v['values']) for k, v in expected.items()
+        },
+        IndexStride={
+            f'Index{k.upper()}': v['stride'] for k, v in expected.items()
+        },
+        **{
+            f'Value{k.upper()}': dict(
+                values=v['values'],
+                units=v['units'],
+                uniform=v['uniform'],
+                min=min(v['values']),
+                max=max(v['values']),
+                datatype=v['dtype'],
+            ) for k, v in expected.items()
+        }
+    )
+
+    sink.frameAxes = list(expected.keys())
+    sink.frameUnits = {
+        k: v['units'] for k, v in expected.items()
+    }
+    frame_values_shape = [
+        *[len(v['values']) for v in expected.values()],
+        len(expected)
+    ]
+    frame_values = np.empty(frame_values_shape, dtype=object)
+
+    frame = 0
+    index = 0
+    for z, z_value in enumerate(expected['z']['values']):
+        for t, t_value in enumerate(expected['t']['values']):
+            if not expected['t']['uniform']:
+                t_value += 0.01 * z
+            for c, c_value in enumerate(expected['c']['values']):
+                    add_tile_args = dict(z=z, t=t, c=c, axes=['z', 't', 'c', 'y', 'x', 's'])
+                    if use_add_tile_args:
+                        add_tile_args.update(z_value=z_value, t_value=t_value, c_value=c_value)
+                    else:
+                        frame_values[z, t, c] = [z_value, t_value, c_value]
+                    random_tile = np.random.random(frame_shape)
+                    sink.addTile(random_tile, 0, 0, **add_tile_args)
+                    expected_metadata['frames'].append(
+                        dict(
+                            Frame=frame,
+                            Index=index,
+                            IndexZ=z,
+                            ValueZ=z_value,
+                            IndexT=t,
+                            ValueT=t_value,
+                            IndexC=c,
+                            ValueC=c_value,
+                            Channel=f'Band {c + 1}',
+                        )
+                    )
+                    frame += 1
+            index += 1
+
+    if not use_add_tile_args:
+        sink.frameValues = frame_values
+
+    compare_metadata(dict(sink.getMetadata()), expected_metadata)
+
+    # sink.write(output_file)
+    # written = large_image_source_zarr.open(output_file)
+    # compare_metadata(dict(written.getMetadata()), expected_metadata)

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -557,8 +557,8 @@ def testFrameValuesAddTile(use_add_tile_args, tmp_path):
 
     frame_shape = (300, 400, 3)
     expected = dict(
-        z=dict(values=[2, 4, 6, 8], uniform=True, units='m', stride=9, dtype='int64'),
-        t=dict(values=[10.0, 20.0, 30.0], uniform=False, units='ms', stride=3, dtype='float64'),
+        z=dict(values=[2, 4, 6, 8], uniform=True, units='meter', stride=9, dtype='int64'),
+        t=dict(values=[10.0, 20.0, 30.0], uniform=False, units='millisecond', stride=3, dtype='float64'),
         c=dict(values=['r', 'g', 'b'], uniform=True, units='channel', stride=1, dtype='str32'),
     )
     expected_metadata = dict(
@@ -635,9 +635,8 @@ def testFrameValuesAddTile(use_add_tile_args, tmp_path):
 
     if not use_add_tile_args:
         sink.frameValues = frame_values
-
     compare_metadata(dict(sink.getMetadata()), expected_metadata)
 
-    # sink.write(output_file)
-    # written = large_image_source_zarr.open(output_file)
-    # compare_metadata(dict(written.getMetadata()), expected_metadata)
+    sink.write(output_file)
+    written = large_image_source_zarr.open(output_file)
+    compare_metadata(dict(written.getMetadata()), expected_metadata)

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -660,16 +660,16 @@ def testFrameValues(use_add_tile_args, tmp_path):
             values=[10.0, 20.0, 30.0],
             all_values=(
                 [10.00] * 3 +
-                [10.01] * 3 +
-                [10.02] * 3 +
-                [10.03] * 3 +
                 [20.00] * 3 +
-                [20.01] * 3 +
-                [20.02] * 3 +
-                [20.03] * 3 +
                 [30.00] * 3 +
+                [10.01] * 3 +
+                [20.01] * 3 +
                 [30.01] * 3 +
+                [10.02] * 3 +
+                [20.02] * 3 +
                 [30.02] * 3 +
+                [10.03] * 3 +
+                [20.03] * 3 +
                 [30.03] * 3
             ),
             uniform=False,
@@ -791,11 +791,11 @@ sink.addTile(np.ones((1, 1, 1)), x=2047, y=2047, t=5, z=2)
     assert sink.getRegion(
         region=dict(left=2047, top=2047, width=1, height=1),
         format='numpy',
-        frame=27,
+        frame=17,
     )[0] == 1
     assert sink.getRegion(
         region=dict(left=5000, top=4095, width=1, height=1),
         format='numpy',
-        frame=4,
+        frame=24,
     )[0] == 1
     assert sink.sizeX == 5001


### PR DESCRIPTION
Resolves #1325. This PR adds frame values to the Zarr sink, which allows a user to specify true values for each index of a frame axis. This can be done with `addTile` or by setting `frameValues` directly. Additionally, the user may set a dictionary of `frameUnits` to describe the units used by each frame axis and/or a list of `frameAxes` to assert an ordering to the frame axes. 

For example:
```
import large_image_source_zarr
import numpy as np

sink = large_image_source_zarr.new()
sink.frameAxes = ['z', 't', 'm']
sink.frameUnits = dict(z='cm', t='ms', m='mm')
for z, z_value in enumerate([2, 4, 6, 8]):
    for t, t_value in enumerate([10.0, 20.0, 30.0]):
        t_value += 0.01 * z
        for m, m_value in enumerate(['r', 'g', 'b']):
            random_tile = np.random.random((300, 400, 3))
            sink.addTile(
                random_tile,
                0, 0,
                z=z, t=t, m=m,
                z_value=z_value, t_value=t_value, m_value=m_value
            )
print(sink.getMetadata())
```

This PR also uses the frame values in the slider labels shown in the Frame Selector component. The following video demonstrates the value labels on axis sliders for a randomly-generated image using the new Zarr sink API. 
C and Z have uniform values, while T has non-uniform values. (This image was generated with the code in `testFrameValues` in `test/test_sink.py`.)
https://github.com/user-attachments/assets/4b41bcd3-8164-46f8-b78b-9d919cecefa0