### PR TITLE
Extend correlating annotation element bounding boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bug Fixes
 
 - Fix scaling small images in the multi source with bicubic smoothing ([#1627](../../pull/1627))
-- Fix correlating annotation bounding boxes on adjacent items for plottable data ([#1628](../../pull/1628))
+- Fix correlating annotation bounding boxes on adjacent items for plottable data ([#1628](../../pull/1628), ([#1632](../../pull/1632))
 
 ## 1.29.7
 


### PR DESCRIPTION
This ensures that if the bounding box is correlated from data files, folders, or item metadata, the annotation id and name is also correlated with the augmented data for the annotation element.