### PR TITLE
Add more options for how tox runs tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skip_missing_interpreters = true
 toxworkdir = {toxinidir}/build/tox
 
 [testenv]
-passenv = PYTEST_*,COVERAGE_*,DICOMWEB_TEST_URL,DICOMWEB_TEST_TOKEN
+passenv = PYTEST_*,COVERAGE_*,DICOMWEB_TEST_URL,DICOMWEB_TEST_TOKEN,GIRDER_BUILD_OPTIONS
 extras =
   memcached
   redis
@@ -26,7 +26,6 @@ deps =
   coverage
   mock
   pooch
-  pymongo<4
   pytest>=3.6
   pytest-cov>=2.6
   pytest-custom-exit-code
@@ -39,7 +38,7 @@ allowlist_externals =
 # Run most tests in parallel and conflicting tests sequentially
 commands =
   rm -rf build/test/coverage/web_temp
-  girder build --dev
+  girder build --dev {env:GIRDER_BUILD_OPTIONS}
   pytest --numprocesses 0 -m 'singular' --cov-config tox.ini --suppress-no-test-exit-code {posargs}
   pytest --numprocesses {env:PYTEST_NUMPROCESSES:logical} -m 'not singular and not notebook' --cov-config tox.ini --cov-append --suppress-no-test-exit-code {posargs}
   - npx nyc report --temp-dir build/test/coverage/web_temp --report-dir build/test/coverage --reporter cobertura --reporter text-summary
@@ -62,7 +61,6 @@ deps =
   coverage
   mock
   pooch
-  pymongo<4
   pytest>=3.6
   pytest-cov>=2.6
   pytest-custom-exit-code
@@ -80,7 +78,6 @@ deps =
   coverage
   mock
   pooch
-  pymongo<4
   pytest>=3.6
   pytest-cov>=2.6
   pytest-custom-exit-code
@@ -122,6 +119,11 @@ commands = {[testenv:server]commands}
 
 # For running just one test, it is often clearer to do
 #  tox -e <env> -- --numprocesses 0 --no-cov -k <test name>
+# Further, for full tests, you can skip doing an actual build by passing the
+# GIRDER_BUILD_OPTIONS environment variable, such as
+#  GIRDER_BUILD_OPTIONS=--help tox -e <env> -- --numprocesses 0 --no-cov -k <test name>
+# Another way to accomplish this is to just run pytest in the tox environment
+#  GDAL_PAM_ENABLED=no build/tox/test-py311/bin/pytest --no-cov -k <test name>
 [testenv:core]
 description = Run core tests.  This is all but Girder
 deps =


### PR DESCRIPTION
Expose an option to make it easier to rerun tests without rebuilding girder