### PR TITLE
Speed up correlating data files with annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Only list computable plot columns if there are other numeric columns ([#1634](../../pull/1634))
 - List official yaml mime type for the multi source ([#1636](../../pull/1636))
+- Speed up correlating data files with annotations ([#1642](../../pull/1642))
+
 
 ### Bug Fixes
 

--- a/girder_annotation/setup.py
+++ b/girder_annotation/setup.py
@@ -59,7 +59,9 @@ setup(
     extras_require={
         'compute': [
             'openpyxl',
-            'pandas',
+            'pandas ; python_version < "3.9"',
+            'pandas>=2.2 ; python_version >= "3.9"',
+            'python-calamine ; python_version >= "3.9"',
             'umap-learn',
         ],
         'tasks': [


### PR DESCRIPTION
Use a simple quad-set lookup to avoid walking all rows.

Use calamine rather than openpyxl for reading xlsx files.

Don't read needless data files.

Don't read headless columns from data files.

Change column sort order to show multi-value columns sooner.