### PR TITLE
Fix styling images with empty tile layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Better handle images without enough tile layers ([#1648](../../pull/1648))
 - Add users option to config files; have a default config file ([#1649](../../pull/1649))
 
+### Bug Fixes
+
+- Fix styling images with empty tile layers ([#1650](../../pull/1650))
+
 ## 1.29.11
 
 ### Changes

--- a/sources/tiff/large_image_source_tiff/__init__.py
+++ b/sources/tiff/large_image_source_tiff/__init__.py
@@ -664,7 +664,6 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         else:
             dir = self._tiffDirectories[z]
         try:
-            allowStyle = True
             if dir is None:
                 try:
                     if not kwargs.get('inSparseFallback'):
@@ -676,7 +675,6 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                         raise IOTiffError('Missing z level %d' % z)
                     else:
                         raise
-                allowStyle = False
             else:
                 tile = dir.getTile(x, y, asarray=numpyAllowed == 'always')
                 format = 'JPEG'
@@ -685,7 +683,7 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             if isinstance(tile, np.ndarray):
                 format = TILE_FORMAT_NUMPY
             return self._outputTile(tile, format, x, y, z, pilImageAllowed,
-                                    numpyAllowed, applyStyle=allowStyle, **kwargs)
+                                    numpyAllowed, **kwargs)
         except InvalidOperationTiffError as e:
             raise TileSourceError(e.args[0])
         except IOTiffError as e:
@@ -734,7 +732,7 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             else:
                 image = PIL.Image.new('RGBA', (self.tileWidth, self.tileHeight))
             return self._outputTile(image, TILE_FORMAT_PIL, x, y, z, pilImageAllowed,
-                                    numpyAllowed, applyStyle=False, **kwargs)
+                                    numpyAllowed, **kwargs)
         raise TileSourceError('Internal I/O failure: %s' % exception.args[0])
 
     def _nonemptyLevelsList(self, frame=0):


### PR DESCRIPTION
Before, when an empty level existed and we wanted a styled tile, we generated styled subtiles and composited them.  This had some quirks between what the tiff reader did and all other readers.  It has now been harmonized.