### PR TITLE
Remove no longer used code; adjust item list slightly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Better handle images without enough tile layers ([#1648](../../pull/1648))
 - Add users option to config files; have a default config file ([#1649](../../pull/1649))
+- Remove no longer used code; adjust item list slightly ([#1651](../../pull/1651))
 
 ### Bug Fixes
 

--- a/girder/girder_large_image/web_client/templates/itemList.pug
+++ b/girder/girder_large_image/web_client/templates/itemList.pug
@@ -1,23 +1,24 @@
 ul.g-item-list.li-item-list(layout_mode=(itemList.layout || {}).mode || '')
   - var colNames = [];
-  li.li-item-list-header
-    if checkboxes
-      span.li-item-list-header
-    for column, colidx in itemList.columns
-      if column.type !== 'image' || hasAnyLargeImage
-        span.li-item-list-header(
-            class=((column.type === 'record' && column.value !== 'controls') || column.type === 'metadata' ? 'sortable' : '') + ' ' + (sort && sort[0].type === column.type && ('' + sort[0].value === '' + column.value) ? sort[0].dir : ''),
-            column_type=column.type, column_value=column.value)
-          if column.title !== undefined
-            - colNames[colidx] = column.title
-          else
-            - colNames[colidx] = `${column.value.substr(0, 1).toUpperCase()}${column.value.substr(1)}`
-          = colNames[colidx]
+  if items.length
+    li.li-item-list-header
+      if checkboxes
+        span.li-item-list-header
+      for column, colidx in itemList.columns
+        if column.type !== 'image' || hasAnyLargeImage
+          span.li-item-list-header(
+              class=((column.type === 'record' && column.value !== 'controls') || column.type === 'metadata' ? 'sortable' : '') + ' ' + (sort && sort[0].type === column.type && ('' + sort[0].value === '' + column.value) ? sort[0].dir : ''),
+              column_type=column.type, column_value=column.value)
+            if column.title !== undefined
+              - colNames[colidx] = column.title
+            else
+              - colNames[colidx] = `${column.value.substr(0, 1).toUpperCase()}${column.value.substr(1)}`
+            = colNames[colidx]
   each item in items
     li.g-item-list-entry(class=(highlightItem && item.id === selectedItemId ? 'g-selected' : ''), public=(isParentPublic ? 'true' : 'false'), style=(itemList.layout || {}).mode == 'grid' ? ('max-width: ' + parseInt((itemList.layout || {})['max-width'] || 250) + 'px') : '')
       if checkboxes
-        span.li-item-list-cell
-          input.g-list-checkbox(type="checkbox", g-item-cid=item.cid)
+        label.li-item-list-cell(for='g-item-cid-' + item.cid)
+          input.g-list-checkbox(type="checkbox", g-item-cid=item.cid, id='g-item-cid-' + item.cid)
       for column, colidx in itemList.columns
         if column.type !== 'image' || hasAnyLargeImage
           -
@@ -86,7 +87,11 @@ ul.g-item-list.li-item-list(layout_mode=(itemList.layout || {}).mode || '')
                     input.input-sm.form-control.g-widget-metadata-value-input.g-widget-metadata-column(placeholder=column.description || "Value", value=value, title=column.description)
               else
                 span.large_image_metadata
-                  = value
+                  if column.format === 'text' && value
+                    //- allow long strings to be hyphenated at periods and underscores
+                    != String(value).replace(/&/g, '&amp;').replace(/</, '&lt;').replace(/>/, '&gt;').replace(/"/, '&quot').replace(/'/, '&#39;').replace(/\./g, '.&shy;').replace(/_/g, '_&shy;')
+                  else
+                    = value
                 if value
                   span.li-item-list-cell-filter(title="Only show items that match this metadata value exactly", filter-value=value, column-value=column.value)
                     i.icon-filter

--- a/girder/girder_large_image/web_client/views/configView.js
+++ b/girder/girder_large_image/web_client/views/configView.js
@@ -274,6 +274,22 @@ var ConfigView = View.extend({
                 callback(ConfigView._liconfig);
             }
             return val;
+        }).fail(() => {
+            // fallback matching server values
+            const li = {
+                columns: [
+                    {type: 'record', value: 'name', title: 'Name'},
+                    {type: 'record', value: 'controls', title: 'Contols'},
+                    {type: 'record', value: 'size', title: 'Size'}]
+            };
+            const val = {itemList: li, itemListDialog: li};
+            ConfigView._lastliconfig = folderId;
+            ConfigView._liconfigSettingsRequest = null;
+            ConfigView._liconfig = val;
+            if (callback) {
+                callback(ConfigView._liconfig);
+            }
+            return val;
         });
         return ConfigView._liconfigSettingsRequest;
     },


### PR DESCRIPTION
With the addition of #1649, we always use the large_image itemList rather than modifying the base girder item list.  We no longer need the code that did that modification.

Don't display column titles on an empty list.

Make check boxes easier to click.

Allow long strings to break more efficiently.