### PR TITLE
Use paginated item lists.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Handle a rasterio deprecation ([#1655](../../pull/1655))
 - Handle a variation in a bioformats exception ([#1656](../../pull/1656))
 - Increase logging slow histograms ([#1658](../../pull/1658))
+- Use paginated item lists ([#1664](../../pull/1664))
 
 ### Bug Fixes
 

--- a/girder/girder_large_image/web_client/views/itemList.js
+++ b/girder/girder_large_image/web_client/views/itemList.js
@@ -7,6 +7,7 @@ import {getApiRoot} from '@girder/core/rest';
 import {AccessType} from '@girder/core/constants';
 import {formatSize, parseQueryString, splitRoute} from '@girder/core/misc';
 import HierarchyWidget from '@girder/core/views/widgets/HierarchyWidget';
+import ItemCollection from '@girder/core/collections/ItemCollection';
 import FolderListWidget from '@girder/core/views/widgets/FolderListWidget';
 import ItemListWidget from '@girder/core/views/widgets/ItemListWidget';
 
@@ -16,6 +17,16 @@ import {addToRoute} from '../routes';
 import '../stylesheets/itemList.styl';
 import ItemListTemplate from '../templates/itemList.pug';
 import {MetadatumWidget, validateMetadataValue} from './metadataWidget';
+
+ItemCollection.prototype.pageLimit = Math.max(250, ItemCollection.prototype.pageLimit);
+
+wrap(HierarchyWidget, 'initialize', function (initialize, settings) {
+    settings = settings || {};
+    if (settings.paginated === undefined) {
+        settings.paginated = true;
+    }
+    return initialize.call(this, settings);
+});
 
 wrap(HierarchyWidget, 'render', function (render) {
     render.call(this);


### PR DESCRIPTION
With the item list table, this is expected.

This is being done in the HistomicsUI, plugin, but really needs to be here since we now default to the table item lists.