### PR TITLE
Fix some issues with possible numpy 2.x overflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - Fix styling images with empty tile layers ([#1650](../../pull/1650))
 - Add a guard around sorting item lists ([#1663](../../pull/1663))
+- Fix some issues with possible numpy 2.x overflows ([#1672](../../pull/1672))
 
 ## 1.29.11
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -618,11 +618,11 @@ class TileSource(IPyLeafletMixin):
         if results is None or onlyMinMax:
             return results
         results['histogram'] = [{
-            'min': results['min'][idx],
-            'max': results['max'][idx],
-            'mean': results['mean'][idx],
-            'stdev': results['stdev'][idx],
-            'range': ((results['min'][idx], results['max'][idx] + 1)
+            'min': float(results['min'][idx]),
+            'max': float(results['max'][idx]),
+            'mean': float(results['mean'][idx]),
+            'stdev': float(results['stdev'][idx]),
+            'range': ((float(results['min'][idx]), float(results['max'][idx]) + 1)
                       if histRange is None or histRange == 'round' else histRange),
             'hist': None,
             'bin_edges': None,

--- a/sources/pil/large_image_source_pil/__init__.py
+++ b/sources/pil/large_image_source_pil/__init__.py
@@ -175,7 +175,7 @@ class PILFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             except Exception:
                 msg = 'PIL cannot find loader for this file.'
                 raise TileSourceError(msg)
-            maxval = 256 ** math.ceil(math.log(np.max(imgdata) + 1, 256)) - 1
+            maxval = 256 ** math.ceil(math.log(float(np.max(imgdata)) + 1, 256)) - 1
             self._factor = 255.0 / max(maxval, 1)
             self._pilImage = PIL.Image.fromarray(np.uint8(np.multiply(
                 imgdata, self._factor)))


### PR DESCRIPTION
These issues were not caught in testing because some of our dependencies force numpy < 2.