### PR TITLE
Relax pinning for wsidicom

### DIFF
--- a/sources/dicom/setup.py
+++ b/sources/dicom/setup.py
@@ -73,8 +73,8 @@ setup(
     install_requires=[
         f'large-image{limit_version}',
         'wsidicom>=0.9.0',
-        # Pinned until wsidicom is updated
-        'pydicom<3',
+        'pydicom<3; python_version < "3.10"',
+        'pydicom; python_version >= "3.10"',
     ],
     extras_require={
         'girder': girder_extras,


### PR DESCRIPTION
The latest version supports pydicom >= 3, but only on python 3.10+.