### PR TITLE
Test on Python 3.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,11 @@ commands:
   tox:
     description: "Run tox"
     parameters:
-      env:
+      toxenv:
         type: string
+      environ:
+        type: string
+        default: ""
     steps:
       - run:
           name: Upgrade pip
@@ -25,9 +28,9 @@ commands:
           name: Run tests via tox
           # Piping through cat does less buffering of the output but can
           # consume the exit code
-          # command: PYTEST_ADDOPTS=--forked tox -e << parameters.env >> | cat; test ${PIPESTATUS[0]} -eq 0
-          # command: PYTEST_ADDOPTS="--reruns=3 --numprocesses=0" tox -e << parameters.env >> | cat; test ${PIPESTATUS[0]} -eq 0
-          command: COVERAGE_CORE=sysmon PYTEST_NUMPROCESSES=3 PYTEST_ADDOPTS="--reruns=3" tox -e << parameters.env >> | cat; test ${PIPESTATUS[0]} -eq 0
+          # command: PYTEST_ADDOPTS=--forked tox -e << parameters.toxenv >> | cat; test ${PIPESTATUS[0]} -eq 0
+          # command: PYTEST_ADDOPTS="--reruns=3 --numprocesses=0" tox -e << parameters.toxenv >> | cat; test ${PIPESTATUS[0]} -eq 0
+          command: COVERAGE_CORE=sysmon PYTEST_NUMPROCESSES=3 PYTEST_ADDOPTS="--reruns=3" << parameters.environ >> tox -e << parameters.toxenv >> | cat; test ${PIPESTATUS[0]} -eq 0
   switchpython:
     description: "Upgrade python"
     parameters:
@@ -163,7 +166,7 @@ jobs:
           version: "3.8"
           node: v14
       - tox:
-          env: test-py38
+          toxenv: test-py38
       - coverage
       - store_artifacts:
           path: build/test/artifacts
@@ -177,7 +180,7 @@ jobs:
           version: "3.9"
           node: v14
       - tox:
-          env: test-py39
+          toxenv: test-py39
       - coverage
       - store_artifacts:
           path: build/test/artifacts
@@ -191,7 +194,7 @@ jobs:
           version: "3.10"
           node: v14
       - tox:
-          env: test-py310
+          toxenv: test-py310
       - coverage
       - store_artifacts:
           path: build/test/artifacts
@@ -205,7 +208,7 @@ jobs:
           version: "3.11"
           node: v14
       - tox:
-          env: test-py311
+          toxenv: test-py311
       - coverage
       - store_artifacts:
           path: build/test/artifacts
@@ -219,7 +222,22 @@ jobs:
           version: "3.12"
           node: v14
       - tox:
-          env: test-py312
+          toxenv: test-py312
+      - coverage
+      - store_artifacts:
+          path: build/test/artifacts
+  py313:
+    machine:
+      image: ubuntu-2204:current
+    resource_class: large
+    steps:
+      - checkout
+      - allservices:
+          version: "3.13"
+          node: v14
+      - tox:
+          toxenv: test-py313
+          environ: TOX_VERBOSE=4
       - coverage
       - store_artifacts:
           path: build/test/artifacts
@@ -234,7 +252,7 @@ jobs:
           name: Permissions for link checker
           command: find /root -type d -exec chmod 755 {} \+
       - tox:
-          env: docs,lint,lintclient,notebook
+          toxenv: docs,lint,lintclient,notebook
       - store_artifacts:
           path: build/docs
       - persist_to_workspace:
@@ -246,7 +264,7 @@ jobs:
     steps:
       - checkout
       - tox:
-          env: compare-py311
+          toxenv: compare-py311
       - store_artifacts:
           path: build/tox/compare.txt
       - store_artifacts:
@@ -257,7 +275,7 @@ jobs:
     steps:
       - checkout
       - tox:
-          env: type
+          toxenv: type
   wheels:
     executor: toxandnode
     steps:
@@ -373,6 +391,13 @@ workflows:
             branches:
               ignore:
                 - gh-pages
+      - py313:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore:
+                - gh-pages
       - lint_and_docs:
           filters:
             tags:
@@ -416,6 +441,7 @@ workflows:
             - py310
             - py311
             - py312
+            - py313
             - lint_and_docs
             - type
             - wheels
@@ -431,6 +457,7 @@ workflows:
             - py310
             - py311
             - py312
+            - py313
             - lint_and_docs
             - type
             - wheels
@@ -456,6 +483,7 @@ workflows:
       - py310
       - py311
       - py312
+      - py313
       - lint_and_docs
       - type
       - compare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
-## 1.29.12
+## 1.30.0
+
+### Features
+
+- Add support for Python 3.13 ([#1675](../../pull/1675))
 
 ### Improvements
 

--- a/girder/setup.py
+++ b/girder/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         'girder>=3.1.18',

--- a/girder_annotation/setup.py
+++ b/girder_annotation/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         'jsonschema>=2.5.1',
@@ -62,7 +63,7 @@ setup(
             'pandas ; python_version < "3.9"',
             'pandas>=2.2 ; python_version >= "3.9"',
             'python-calamine ; python_version >= "3.9"',
-            'umap-learn',
+            'umap-learn ; python_version < "3.13"',
         ],
         'tasks': [
             f'girder-large-image[tasks]{limit_version}',

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         'cachetools',

--- a/slim.Dockerfile
+++ b/slim.Dockerfile
@@ -1,5 +1,5 @@
 # Build wheels
-FROM python:3.12.7-slim as build
+FROM python:3.12-slim as build
 
 # Need git for setuptools_scm
 RUN apt-get update \
@@ -19,7 +19,7 @@ RUN echo "pylibmc>=1.5.1\nmatplotlib\npyvips\nsimplejpeg\n" \
 
 
 # Geospatial Sources
-FROM python:3.12.7-slim as geo
+FROM python:3.12-slim as geo
 COPY --from=build /opt/build-context/wheels /opt/wheels
 LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
 LABEL repo="https://github.com/girder/large_image"
@@ -37,7 +37,7 @@ RUN pip install \
 
 
 # All Sources
-FROM python:3.12.7-slim as all
+FROM python:3.12-slim as all
 COPY --from=build /opt/build-context/wheels /opt/wheels
 LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
 LABEL repo="https://github.com/girder/large_image"
@@ -52,7 +52,7 @@ RUN pip install \
 
 
 # All Sources and Girder Packages
-FROM python:3.12.7-slim as girder
+FROM python:3.12-slim as girder
 COPY --from=build /opt/build-context/wheels /opt/wheels
 LABEL maintainer="Kitware, Inc. <kitware@kitware.com>"
 LABEL repo="https://github.com/girder/large_image"

--- a/sources/bioformats/setup.py
+++ b/sources/bioformats/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/deepzoom/setup.py
+++ b/sources/deepzoom/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/dicom/setup.py
+++ b/sources/dicom/setup.py
@@ -69,6 +69,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/dummy/setup.py
+++ b/sources/dummy/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/gdal/setup.py
+++ b/sources/gdal/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/mapnik/setup.py
+++ b/sources/mapnik/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/multi/setup.py
+++ b/sources/multi/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         'jsonschema',

--- a/sources/nd2/setup.py
+++ b/sources/nd2/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/ometiff/setup.py
+++ b/sources/ometiff/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/openjpeg/setup.py
+++ b/sources/openjpeg/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/openslide/setup.py
+++ b/sources/openslide/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/pil/setup.py
+++ b/sources/pil/setup.py
@@ -50,15 +50,16 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',
     ],
     extras_require={
         'all': [
-            'rawpy',
+            'rawpy ; python_version < "3.13"',
             'pillow-heif',
-            'pillow-jxl-plugin',
+            'pillow-jxl-plugin ; python_version < "3.13"',
             'pillow-jpls',
         ],
         'girder': f'girder-large-image{limit_version}',

--- a/sources/rasterio/setup.py
+++ b/sources/rasterio/setup.py
@@ -53,6 +53,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/test/setup.py
+++ b/sources/test/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/tiff/setup.py
+++ b/sources/tiff/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/tifffile/setup.py
+++ b/sources/tifffile/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/vips/setup.py
+++ b/sources/vips/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/sources/zarr/setup.py
+++ b/sources/zarr/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image{limit_version}',

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANG=en_US.UTF-8 \
     PYENV_ROOT="/.pyenv" \
     PATH="/.pyenv/bin:/.pyenv/shims:$PATH" \
-    PYTHON_VERSIONS="3.11 3.8 3.9 3.10 3.12"
+    PYTHON_VERSIONS="3.11 3.8 3.9 3.10 3.12 3.13"
 
 # Consumers of this package aren't expecting an existing ubuntu user (there
 # wasn't one in the ubuntu:22.04 base)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  test-py{38,39,310,311,312}
+  test-py{38,39,310,311,312,313}
   docs
   lint
   lintclient
@@ -10,13 +10,14 @@ skip_missing_interpreters = true
 toxworkdir = {toxinidir}/build/tox
 
 [testenv]
-passenv = PYTEST_*,COVERAGE_*,DICOMWEB_TEST_URL,DICOMWEB_TEST_TOKEN,GIRDER_BUILD_OPTIONS
+passenv = PYTEST_*,COVERAGE_*,DICOMWEB_TEST_URL,DICOMWEB_TEST_TOKEN,GIRDER_BUILD_OPTIONS,PIP_*,CFLAGS
 extras =
   memcached
   redis
   performance
 setenv =
   PIP_FIND_LINKS=https://girder.github.io/large_image_wheels
+  PIP_PREFER_BINARY=1
   GDAL_PAM_ENABLED=no
   GDAL_HTTP_MAX_RETRY=5
   GDAL_HTTP_RETRY_DELAY=5
@@ -53,13 +54,15 @@ setenv =
   NPM_CONFIG_PROGRESS=false
   NPM_CONFIG_PREFER_OFFLINE=true
   PIP_FIND_LINKS=https://girder.github.io/large_image_wheels
+  PIP_PREFER_BINARY=1
   GDAL_PAM_ENABLED=no
   GDAL_HTTP_MAX_RETRY=5
   GDAL_HTTP_RETRY_DELAY=5
 
 # Versions that do have all tile sources.  Using the requirements-dev.txt file
 # installs in editable mode, which then includes results in coverage.
-[testenv:test-py{38,39,310,311,312}]
+[testenv:test-py{38,39,310,311,312,313}]
+passenv = {[testenv:test]passenv}
 deps =
   -rrequirements-dev.txt
   coverage
@@ -75,7 +78,7 @@ allowlist_externals = {[testenv:test]allowlist_externals}
 commands = {[testenv:test]commands}
 setenv = {[testenv:test]setenv}
 
-[testenv:monkeytype-py{37,38,39,310,311,312}]
+[testenv:monkeytype-py{38,39,310,311,312,313}]
 passenv = {[testenv:test]passenv}
 deps =
   -rrequirements-dev.txt
@@ -108,6 +111,7 @@ setenv =
   NPM_CONFIG_PROGRESS=false
   NPM_CONFIG_PREFER_OFFLINE=true
   PIP_FIND_LINKS=https://girder.github.io/large_image_wheels
+  PIP_PREFER_BINARY=1
   GDAL_PAM_ENABLED=no
   GDAL_HTTP_MAX_RETRY=5
   GDAL_HTTP_RETRY_DELAY=5
@@ -119,7 +123,7 @@ commands =
   pytest --numprocesses 0 -m 'singular and not girder_client' --cov-config tox.ini --suppress-no-test-exit-code {posargs}
   pytest --numprocesses {env:PYTEST_NUMPROCESSES:logical} -m 'not singular and not girder_client' --cov-config tox.ini --cov-append --suppress-no-test-exit-code {posargs}
 
-[testenv:server-py{38,39,310,311,312}]
+[testenv:server-py{38,39,310,311,312,313}]
 deps = {[testenv:server]deps}
 commands = {[testenv:server]commands}
 
@@ -146,7 +150,7 @@ commands =
   pytest --numprocesses 0 -m 'singular and not girder' --cov-config tox.ini --suppress-no-test-exit-code {posargs}
   pytest --numprocesses {env:PYTEST_NUMPROCESSES:logical} -m 'not singular and not girder and not notebook' --cov-config tox.ini --cov-append --suppress-no-test-exit-code {posargs}
 
-[testenv:core-py{38,39,310,311,312}]
+[testenv:core-py{38,39,310,311,312,313}]
 deps = {[testenv:core]deps}
 commands = {[testenv:core]commands}
 
@@ -166,6 +170,7 @@ commands =
   pytest --numprocesses 0 -m 'notebook' --no-cov --suppress-no-test-exit-code test/test_notebooks.py {posargs}
 setenv =
   PIP_FIND_LINKS=https://girder.github.io/large_image_wheels
+  PIP_PREFER_BINARY=1
   GDAL_PAM_ENABLED=no
   GDAL_HTTP_MAX_RETRY=5
   GDAL_HTTP_RETRY_DELAY=5
@@ -202,7 +207,7 @@ deps =
 commands =
   mypy --config-file tox.ini {posargs}
 
-[testenv:type-py{38,39,310,311,312}]
+[testenv:type-py{38,39,310,311,312,313}]
 description = {[testenv:type]description}
 skipsdist = true
 deps = {[testenv:type]deps}
@@ -293,12 +298,12 @@ use_deveop = {[testenv:dev]use_deveop}
 deps = -rrequirements-dev-osx.txt
 commands = {[testenv:dev]commands}
 
-[testenv:dev-py{38,39,310,311,312}]
+[testenv:dev-py{38,39,310,311,312,313}]
 usedevelop = true
 deps = {[testenv:dev]deps}
 commands = {[testenv:dev]commands}
 
-[testenv:dev-osx-py{38,39,310,311,312}]
+[testenv:dev-osx-py{38,39,310,311,312,313}]
 usedevelop = true
 deps = {[testenv:dev-osx]deps}
 commands = {[testenv:dev-osx]commands}
@@ -325,9 +330,10 @@ commands =
 
 [testenv:compare]
 description = Compare inputs with different sources
-passenv = PIP_FIND_LINKS
+passenv = PIP_*
 setenv =
   PIP_FIND_LINKS={env:PIP_FIND_LINKS:https://girder.github.io/large_image_wheels}
+  PIP_PREFER_BINARY=1
   GDAL_PAM_ENABLED=no
   GDAL_HTTP_MAX_RETRY=5
   GDAL_HTTP_RETRY_DELAY=5
@@ -338,7 +344,7 @@ commands =
   python -c "import test.datastore;test.datastore.fetch_all()"
   python {toxinidir}/test/lisource_compare.py --all build/tox/externaldata/* 'https://data.kitware.com/api/v1/file/hashsum/sha512/5e56cdb8fb1a02615698a153862c10d5292b1ad42836a6e8bce5627e93a387dc0d3c9b6cfbd539796500bc2d3e23eafd07550f8c214e9348880bbbc6b3b0ea0c/download' test/test_files/rgb*.tiff --projection= --projection=EPSG:3857 --yaml=build/tox/compare.yaml --out=build/tox/compare.txt
 
-[testenv:compare-py{38,39,310,311,312}]
+[testenv:compare-py{38,39,310,311,312,313}]
 description = {[testenv:compare]description}
 passenv = {[testenv:compare]passenv}
 setenv = {[testenv:compare]setenv}

--- a/utilities/converter/setup.py
+++ b/utilities/converter/setup.py
@@ -55,6 +55,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         f'large-image-source-tiff{limit_version}',

--- a/utilities/tasks/setup.py
+++ b/utilities/tasks/setup.py
@@ -55,6 +55,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
     install_requires=[
         # Packages required by both producer and consumer side installations


### PR DESCRIPTION
Currently this is very slow because some binary wheels are missing for 3.13 (numcodecs being notable) and they need to be compiled before testing begins.  Additionally, currently wsidicom requires numpy<2, partly because dicomweb-client isn't numpy 2.x compatible (yet).  Since numpy < 2 doesn't have wheels for 3.13, this is part of the slowness. To avoid having CI timeout, this increases tox verbosity.

A few optional packages don't have 3.13 support (scikit-learn, pillow-jxl-plugin, rawpy), so those are not included in install_requires options.