### PR TITLE
Reduce loading geojs when switching views in Girder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Speed up recursive item lists ([#1694](../../pull/1694))
 - Better handle images with signed pixel data ([#1695](../../pull/1695))
+- Reduce loading geojs when switching views in Girder ([#1699](../../pull/1699))
 
 ## 1.30.1
 

--- a/girder/girder_large_image/web_client/views/imageViewerWidget/geojs.js
+++ b/girder/girder_large_image/web_client/views/imageViewerWidget/geojs.js
@@ -45,11 +45,13 @@ var GeojsImageViewerWidget = ImageViewerWidget.extend({
                 }
                 return this;
             }),
-            $.ajax({ // like $.getScript, but allow caching
-                url: root + '/plugins/large_image/extra/geojs.js' + (BUILD_TIMESTAMP ? '?_=' + BUILD_TIMESTAMP : ''),
-                dataType: 'script',
-                cache: true
-            }))
+            !window.geo
+                ? $.ajax({ // like $.getScript, but allow caching
+                    url: root + '/plugins/large_image/extra/geojs.js' + (BUILD_TIMESTAMP ? '?_=' + BUILD_TIMESTAMP : ''),
+                    dataType: 'script',
+                    cache: true
+                })
+                : true)
             .done(() => {
                 this.trigger('g:beforeFirstRender', this);
                 this.render();

--- a/girder/test_girder/web_client_specs/imageViewerSpec.js
+++ b/girder/test_girder/web_client_specs/imageViewerSpec.js
@@ -11,7 +11,11 @@ $(function () {
             var GeojsViewer = girder.plugins.large_image.views.imageViewerWidget.geojs;
             girder.utilities.PluginUtils.wrap(GeojsViewer, 'initialize', function (initialize) {
                 this.once('g:beforeFirstRender', function () {
-                    window.geo.util.mockWebglRenderer();
+                    try {
+                        window.geo.util.mockWebglRenderer();
+                    } catch (err) {
+                        // if this is already mocked, do nothing.
+                    }
                     window.geo.webgl.webglRenderer._maxTextureSize = 256;
                 });
                 initialize.apply(this, _.rest(arguments));

--- a/girder_annotation/test_annotation/web_client_specs/annotationListSpec.js
+++ b/girder_annotation/test_annotation/web_client_specs/annotationListSpec.js
@@ -39,7 +39,11 @@ describe('AnnotationListWidget', function () {
                 };
 
                 this.once('g:beforeFirstRender', function () {
-                    window.geo.util.mockWebglRenderer();
+                    try {
+                        window.geo.util.mockWebglRenderer();
+                    } catch (err) {
+                        // if this is already mocked, do nothing.
+                    }
                 });
                 initialize.apply(this, _.rest(arguments));
             });

--- a/girder_annotation/test_annotation/web_client_specs/geojsSpec.js
+++ b/girder_annotation/test_annotation/web_client_specs/geojsSpec.js
@@ -140,7 +140,11 @@ $(function () {
                 hoverEvents: true
             });
             viewer.once('g:beforeFirstRender', function () {
-                window.geo.util.mockWebglRenderer();
+                try {
+                    window.geo.util.mockWebglRenderer();
+                } catch (err) {
+                    // if this is already mocked, do nothing.
+                }
             });
             waitsFor(function () {
                 return $('.geojs-layer.active').length >= 1;
@@ -1032,7 +1036,11 @@ $(function () {
                 scale: {position: {bottom: 20, right: 10}, scale: 0.0005}
             });
             viewer.once('g:beforeFirstRender', function () {
-                window.geo.util.mockWebglRenderer();
+                try {
+                    window.geo.util.mockWebglRenderer();
+                } catch (err) {
+                    // if this is already mocked, do nothing.
+                }
             });
             waitsFor(function () {
                 return $('.geojs-layer.active').length >= 1 && viewer.scaleWidget;


### PR DESCRIPTION
This checks if geojs is already in memory and doesn't replace it with itself