### PR TITLE
Mark a subprocess test as singular

### DIFF
--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -777,6 +777,7 @@ def testFrameValuesEdgeCases(tmp_path):
             assert not isinstance(value, np.generic)
 
 
+@pytest.mark.singular
 def testSubprocess(tmp_path):
     sink = large_image_source_zarr.new()
     path = sink.largeImagePath


### PR DESCRIPTION
CI sometimes fails on this test.