### PR TITLE
Don't compute channel window in zarr sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Better handle images with signed pixel data ([#1695](../../pull/1695))
 - Reduce loading geojs when switching views in Girder ([#1699](../../pull/1699))
 
+### Bug Fixes
+
+- Don't compute channel window in zarr sinks ([#1705](../../pull/1705))
+
 ## 1.30.1
 
 ### Improvements

--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -872,21 +872,21 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                         'inverted': False,
                         'label': f'Band {c + 1}',
                     }
-                    slicing = tuple(
-                        slice(None)
-                        if k != ('c' if 'c' in self._axes else 's')
-                        else c
-                        for k, v in self._axes.items()
-                    )
-                    channel_data = base_array[slicing]
-                    channel_min = np.min(channel_data)
-                    channel_max = np.max(channel_data)
-                    channel_metadata['window'] = {
-                        'end': channel_max,
-                        'max': channel_max,
-                        'min': channel_min,
-                        'start': channel_min,
-                    }
+                    # slicing = tuple(
+                    #     slice(None)
+                    #     if k != ('c' if 'c' in self._axes else 's')
+                    #     else c
+                    #     for k, v in self._axes.items()
+                    # )
+                    # channel_data = base_array[slicing]
+                    # channel_min = np.min(channel_data)
+                    # channel_max = np.max(channel_data)
+                    # channel_metadata['window'] = {
+                    #     'end': channel_max,
+                    #     'max': channel_max,
+                    #     'min': channel_min,
+                    #     'start': channel_min,
+                    # }
                     if len(self._channelNames) > c:
                         channel_metadata['label'] = self._channelNames[c]
                     if len(self._channelColors) > c:

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -1,4 +1,3 @@
-import math
 import subprocess
 from multiprocessing.pool import Pool, ThreadPool
 from os import sys
@@ -419,13 +418,13 @@ def testMetadata(tmp_path):
         assert c.get('family') == 'linear'
         assert not c.get('inverted')
         assert c.get('label') == channel_names[i]
-        window = c.get('window')
-        assert window is not None
-        # max should be nearly 1 and min should be nearly 0
-        assert math.ceil(window.get('end')) == 1
-        assert math.ceil(window.get('max')) == 1
-        assert math.floor(window.get('start')) == 0
-        assert math.floor(window.get('min')) == 0
+        # window = c.get('window')
+        # assert window is not None
+        # # max should be nearly 1 and min should be nearly 0
+        # assert math.ceil(window.get('end')) == 1
+        # assert math.ceil(window.get('max')) == 1
+        # assert math.floor(window.get('start')) == 0
+        # assert math.floor(window.get('min')) == 0
 
     rdefs = omero.get('rdefs')
     assert rdefs is not None


### PR DESCRIPTION
It can use arbitrarily large amounts of memory.  If we want to populate these values, we need to collect the data as we call addTile or use the tile iterator to collect it.