### PR TITLE
Use openslide published binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Format dates in item lists ([#1707](../../pull/1707))
 
+### Changes
+
+- Openslide now requires the binary wheel on appropriate platforms ([#1709](../../pull/1709))
+
 ## 1.30.2
 
 ### Features

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ extraReqs['all'] = list(set(itertools.chain.from_iterable(extraReqs.values())) |
 # from pypi with all needed dependencies.
 extraReqs['common'] = list(set(itertools.chain.from_iterable(extraReqs[key] for key in {
     'memcached', 'redis', 'colormaps', 'performance',
-    'deepzoom', 'dicom', 'multi', 'nd2', 'test', 'tifffile', 'zarr',
+    'deepzoom', 'dicom', 'multi', 'nd2', 'openslide', 'test', 'tifffile',
+    'zarr',
 })) | {
     f'large-image-source-pil[all]{limit_version}',
     f'large-image-source-rasterio[all]{limit_version}',

--- a/sources/openslide/setup.py
+++ b/sources/openslide/setup.py
@@ -54,7 +54,12 @@ setup(
     ],
     install_requires=[
         f'large-image{limit_version}',
-        'openslide-python>=1.1.0',
+        'openslide-python>=1.4.1',
+        'openslide-bin; platform_system=="linux" and platform_machine=="x86_64"',
+        'openslide-bin; platform_system=="linux" and platform_machine=="aarch64"',
+        'openslide-bin; platform_system=="Windows" and platform_machine=="AMD64"',
+        'openslide-bin; platform_system=="Darwin" and platform_machine=="arm64"',
+        'openslide-bin; platform_system=="Darwin" and platform_machine=="x86_64"',
         'tifftools>=1.2.0',
     ],
     extras_require={


### PR DESCRIPTION
Openslide is now publishing binary wheels, but as a package called openslide-bin.  Require these for appropriate platform machine/system combinations.  This allows openslide to be added to the list of commonly supported sources.