### PR TITLE
Modify a function to keep the type checker happy

### DIFF
--- a/large_image/config.py
+++ b/large_image/config.py
@@ -160,7 +160,7 @@ def cpu_count(logical: bool = True) -> int:
     try:
         import psutil
 
-        count = min(count, psutil.cpu_count(logical))
+        count = min(count, psutil.cpu_count(logical) or count)
     except ImportError:
         pass
     return max(1, count)


### PR DESCRIPTION
psutil can return none for the number of logical cpus