### PR TITLE
Better detect files with geotransform data that aren't geospatial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Format dates in item lists ([#1707](../../pull/1707))
 - Guard dtype types ([#1711](../../pull/1711), [#1714](../../pull/1714), [#1716](../../pull/1716))
 - Better handle IndicaLabs tiff files ([#1717](../../pull/1717))
+- Better detect files with geotransform data that aren't geospatial ([#1718](../../pull/1718))
 
 ### Changes
 

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -979,7 +979,13 @@ class GDALFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass):
             if ds.GetProjection():
                 return True
             if ds.GetGeoTransform(can_return_null=True):
-                return True
+                w = ds.RasterXSize
+                h = ds.RasterYSize
+                trans = ds.GetGeoTransform(can_return_null=True)
+                cornersy = [trans[3] + x * trans[4] + y * trans[5]
+                            for x, y in {(0, 0), (0, h), (w, 0), (w, h)}]
+                if min(cornersy) >= -90 and max(cornersy) <= 90:
+                    return True
             if ds.GetDriver().ShortName in {'NITF', 'netCDF'}:
                 return True
         return False


### PR DESCRIPTION
gdalwarp and gdal_translate can be used to transform images in pixel space.  If such an image has no projection specified and cannot be interpreted as latitude and longitude, assume it is not geospatial.