### PR TITLE
Fix an issue searching for annotation metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - Openslide now requires the binary wheel on appropriate platforms ([#1709](../../pull/1709), [#1710](../../pull/1710))
 
+### Bug Fixes
+
+- Fix an issue searching for annotation metadata on items that a user doesn't have permissions to view ([#1723](../../pull/1723))
+
 ## 1.30.2
 
 ### Features

--- a/girder/girder_large_image/__init__.py
+++ b/girder/girder_large_image/__init__.py
@@ -428,7 +428,12 @@ def metadataSearchHandler(  # noqa
                 if id in foundIds:
                     continue
                 foundIds.add(id)
-                entry = resultModelInst.load(id=id, user=user, level=level, exc=False)
+                try:
+                    entry = resultModelInst.load(id=id, user=user, level=level, exc=False)
+                except Exception:
+                    # We might have permission to view an annotation but not
+                    # the item
+                    continue
                 if entry is not None and offset:
                     offset -= 1
                     continue


### PR DESCRIPTION
If a user has permission to view an annotation but not the item, a 403 was percolated to the UI