### PR TITLE
Better scale float-valued tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Guard dtype types ([#1711](../../pull/1711), [#1714](../../pull/1714), [#1716](../../pull/1716))
 - Better handle IndicaLabs tiff files ([#1717](../../pull/1717))
 - Better detect files with geotransform data that aren't geospatial ([#1718](../../pull/1718))
+- Better scale float-valued tiles ([#1725](../../pull/1725))
 
 ### Changes
 

--- a/large_image/tilesource/geo.py
+++ b/large_image/tilesource/geo.py
@@ -143,7 +143,8 @@ class GDALBaseFileTileSource(GeoBaseFileTileSource):
         }
         style = []
         if hasattr(self, '_style'):
-            styleBands = self.style['bands'] if 'bands' in self.style else [self.style]
+            styleBands = (cast(JSONDict, self.style)['bands']
+                          if 'bands' in cast(JSONDict, self.style) else [self.style])
             for styleBand in styleBands:
 
                 styleBand = styleBand.copy()
@@ -189,7 +190,8 @@ class GDALBaseFileTileSource(GeoBaseFileTileSource):
                 not self._style or 'icc' in self._style and len(self._style) == 1):
             return
         if hasattr(self, '_style'):
-            styleBands = self.style['bands'] if 'bands' in self.style else [self.style]
+            styleBands = (cast(JSONDict, self.style)['bands']
+                          if 'bands' in cast(JSONDict, self.style) else [self.style])
             if not len(styleBands) or (len(styleBands) == 1 and isinstance(
                     styleBands[0].get('band', 1), int) and styleBands[0].get('band', 1) <= 0):
                 del self._style

--- a/large_image/tilesource/tiledict.py
+++ b/large_image/tilesource/tiledict.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple, cast
+from typing import Any, Dict, Optional, Tuple, Union, cast
 
 import numpy as np
 import PIL
@@ -8,7 +8,7 @@ import PIL.ImageDraw
 
 from .. import exceptions
 from ..constants import TILE_FORMAT_IMAGE, TILE_FORMAT_NUMPY, TILE_FORMAT_PIL
-from .utilities import _encodeImage, _imageToNumpy, _imageToPIL
+from .utilities import ImageBytes, _encodeImage, _imageToNumpy, _imageToPIL
 
 
 class LazyTileDict(dict):
@@ -159,6 +159,48 @@ class LazyTileDict(dict):
                     :th, :tw, :retile.shape[2]]  # type: ignore[misc]
         return cast(np.ndarray, retile)
 
+    def _resample(self, tileData: Union[ImageBytes, PIL.Image.Image, bytes, np.ndarray]) -> Tuple[
+        Union[ImageBytes, PIL.Image.Image, bytes, np.ndarray], Optional[PIL.Image.Image],
+    ]:
+        """
+        If we need to resample a tile, use PIL if it is uint8 or we are using
+        a specific resampling mode that is PIL-specific.  Otherwise, use
+        skimage if available.
+
+        :param tileData: the image to scale.
+        :returns: tileData, pilData.  pilData will be None if the results are a
+            numpy array.
+        """
+        pilData = None
+        if self.resample in (False, None) or not self.requestedScale:
+            return tileData, pilData
+        pilResize = True
+        if (isinstance(tileData, np.ndarray) and tileData.dtype.kind != np.uint8 and
+                TILE_FORMAT_NUMPY in self.format and self.resample in {True, 2, 3}):
+            try:
+                import skimage.transform
+                pilResize = False
+            except ImportError:
+                pass
+        if pilResize:
+            pilData = _imageToPIL(tileData)
+
+            self['width'] = max(1, int(
+                pilData.size[0] / self.requestedScale))
+            self['height'] = max(1, int(
+                pilData.size[1] / self.requestedScale))
+            pilData = tileData = pilData.resize(
+                (self['width'], self['height']),
+                resample=getattr(PIL.Image, 'Resampling', PIL.Image).LANCZOS
+                if self.resample is True else self.resample)
+        else:
+            tileData = skimage.transform.resize(
+                cast(np.ndarray, tileData),
+                (self['width'], self['height'],
+                 cast(np.ndarray, tileData).shape[2]),  # type: ignore[misc]
+                order=3 if self.resample is True else self.resample)
+        return tileData, pilData
+
     def __getitem__(self, key: str, *args, **kwargs) -> Any:
         """
         If this is the first time either the tile or format key is requested,
@@ -187,16 +229,7 @@ class LazyTileDict(dict):
             pilData = None
             # resample if needed
             if self.resample not in (False, None) and self.requestedScale:
-                pilData = _imageToPIL(tileData)
-
-                self['width'] = max(1, int(
-                    pilData.size[0] / self.requestedScale))
-                self['height'] = max(1, int(
-                    pilData.size[1] / self.requestedScale))
-                pilData = tileData = pilData.resize(
-                    (self['width'], self['height']),
-                    resample=getattr(PIL.Image, 'Resampling', PIL.Image).LANCZOS
-                    if self.resample is True else self.resample)
+                tileData, pilData = self._resample(tileData)
 
             tileFormat = (TILE_FORMAT_PIL if isinstance(tileData, PIL.Image.Image)
                           else (TILE_FORMAT_NUMPY if isinstance(tileData, np.ndarray)

--- a/test/lisource_compare.py
+++ b/test/lisource_compare.py
@@ -391,7 +391,9 @@ def source_compare(sourcePath, opts):  # noqa
             sys.stdout.flush()
 
             # get maxval for other histograms
-            h = ts.histogram(onlyMinMax=True, output=dict(maxWidth=2048, maxHeight=2048), **kwargs)
+            h = ts.histogram(
+                onlyMinMax=True, output=dict(maxWidth=2048, maxHeight=2048),
+                resample=0, **kwargs)
             if 'max' not in h:
                 sys.stdout.write(' fail\n')
                 sys.stdout.flush()
@@ -400,7 +402,7 @@ def source_compare(sourcePath, opts):  # noqa
             maxval = 2 ** (int(math.log(maxval or 1) / math.log(2)) + 1) if maxval > 1 else 1
             # thumbnail histogram
             h = ts.histogram(bins=9, output=dict(maxWidth=256, maxHeight=256),
-                             range=[0, maxval], **kwargs)
+                             range=[0, maxval], resample=0, **kwargs)
             maxchan = len(h['histogram'])
             if maxchan == 4:
                 maxchan = 3
@@ -409,13 +411,13 @@ def source_compare(sourcePath, opts):  # noqa
             sys.stdout.flush()
             # full image histogram
             h = ts.histogram(bins=9, output=dict(maxWidth=2048, maxHeight=2048),
-                             range=[0, maxval], **kwargs)
+                             range=[0, maxval], resample=0, **kwargs)
             result['full_2048_histogram'] = histotext(h, maxchan)
             sys.stdout.write(' %s' % histotext(h, maxchan))
             sys.stdout.flush()
             if opts.full:
                 # at full res
-                h = ts.histogram(bins=9, range=[0, maxval], **kwargs)
+                h = ts.histogram(bins=9, range=[0, maxval], resample=0, **kwargs)
                 result['full_max_histogram'] = histotext(h, maxchan)
                 sys.stdout.write(' %s' % histotext(h, maxchan))
                 sys.stdout.flush()
@@ -426,12 +428,14 @@ def source_compare(sourcePath, opts):  # noqa
                 if not opts.full:
                     h = ts.histogram(
                         bins=9, output=dict(maxWidth=2048, maxHeight=2048),
-                        range=[0, maxval], frame=frames - 1, **kwargs)
+                        range=[0, maxval], frame=frames - 1, resample=0,
+                        **kwargs)
                     result['full_f_2048_histogram'] = histotext(h, maxchan)
                     sys.stdout.write(' %s' % histotext(h, maxchan))
                 else:
                     # at full res
-                    h = ts.histogram(bins=9, range=[0, maxval], frame=frames - 1, **kwargs)
+                    h = ts.histogram(bins=9, range=[0, maxval],
+                                     frame=frames - 1, resample=0, **kwargs)
                     result['full_f_max_histogram'] = histotext(h, maxchan)
                     sys.stdout.write(' %s' % histotext(h, maxchan))
                 sys.stdout.flush()
@@ -444,7 +448,7 @@ def source_compare(sourcePath, opts):  # noqa
                         h = ts.histogram(bins=32, output=dict(
                             maxWidth=int(math.ceil(ts.sizeX / 2 ** (levels - 1 - ll))),
                             maxHeight=int(math.ceil(ts.sizeY / 2 ** (levels - 1 - ll))),
-                        ), range=[0, maxval], frame=f, **kwargs)
+                        ), range=[0, maxval], frame=f, resample=0, **kwargs)
                         t += time.time()
                         result[f'level_{ll}_f_{f}_histogram'] = histotext(h, maxchan)
                         sys.stdout.write('%3d%5d %s' % (ll, f, histotext(h, maxchan)))


### PR DESCRIPTION
If scaling non uint8 tiles in numpy format, possibly use scikit-image rather than converting to an 8-bit pil image for the process.

Add some missing type hints.