### PR TITLE
Guard against switching on and off overlay layers quickly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Fix an issue searching for annotation metadata on items that a user doesn't have permissions to view ([#1723](../../pull/1723))
 - Fix a typo in a column header ([#1727](../../pull/1727))
+- Guard against switching on and off overlay layers quickly ([#1729](../../pull/1729))
 
 ## 1.30.2
 

--- a/girder_annotation/girder_large_image_annotation/rest/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/rest/annotation.py
@@ -255,7 +255,7 @@ class AnnotationResource(Resource):
                 # could be used in its most default mode instead like so:
                 #   result = json.dumps(element, separators=(',', ':'))
                 # Collect multiple elements before emitting them.  This
-                # balances using less memoryand streaming right away with
+                # balances using less memory and streaming right away with
                 # efficiency in dumping the json.  Experimentally, 100 is
                 # significantly faster than 10 and not much slower than 1000.
                 collect.append(element)

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -415,9 +415,13 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                 restRequest({
                     url: `item/${overlayItemId}/tiles`
                 }).done((response) => {
-                    // Since overlay layers are created asynchronously, we need to ensure that an attempt
-                    // to draw the same overlays happening at roughly the same time does not create
-                    // extra layers
+                    // Since overlay layers are created asynchronously, we need
+                    // to ensure that an attempt to draw the same overlays
+                    // happening at roughly the same time does not create extra
+                    // layers
+                    if (!this.viewer) {
+                        return;
+                    }
                     const conflictingLayers = this.viewer.layers().filter(
                         (layer) => layer.id() === overlay.id);
                     if (conflictingLayers.length > 0) {


### PR DESCRIPTION
If an overlay annotation was requested and then dismissed before obtaining data about it, a javascript error would be raised.  This didn't cause an issue, but should be cleaned up properly.