### PR TITLE
Adjusting the expected full alpha value on some float tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.30.5
+
+### Changes
+
+- Adjust how compositing is done on styled images by adjusting the expected full alpha value ([#1735](../../pull/1735))
+
 ## 1.30.4
 
 ### Bug Fixes

--- a/large_image/tilesource/utilities.py
+++ b/large_image/tilesource/utilities.py
@@ -758,6 +758,12 @@ def fullAlphaValue(arr: Union[np.ndarray, npt.DTypeLike]) -> int:
         dtype = np.dtype(dtype)
     if cast(np.dtype, dtype).kind == 'u':
         return np.iinfo(dtype).max
+    if isinstance(arr, np.ndarray) and cast(np.dtype, dtype).kind == 'f':
+        amax = np.amax(arr)
+        if amax > 1 and amax < 256:
+            return 255
+        if amax > 1 and amax < 65536:
+            return 65535
     return 1
 
 

--- a/sources/multi/large_image_source_multi/__init__.py
+++ b/sources/multi/large_image_source_multi/__init__.py
@@ -300,10 +300,12 @@ SourceEntrySchema = {
                 'sampleScale is applied',
             'type': 'number',
         },
-        'style': {'type': 'object'},
+        'style': {
+            'description': 'A style specification to pass to the base tile source',
+            'type': 'object',
+        },
         'params': {
-            'description':
-                'Additional parameters to pass to the base tile source',
+            'description': 'Additional parameters to pass to the base tile source',
             'type': 'object',
         },
     },


### PR DESCRIPTION
This adjust how compositing is done on styled images.

Also, improve documentation of multi-source schema