### PR TITLE
Unpin a package

### DIFF
--- a/sources/multi/setup.py
+++ b/sources/multi/setup.py
@@ -66,7 +66,7 @@ setup(
     keywords='large_image, tile source',
     packages=find_packages(exclude=['test', 'test.*']),
     url='https://github.com/girder/large_image',
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     entry_points={
         'large_image.source': [
             'multi = large_image_source_multi:MultiFileTileSource',

--- a/sources/pil/setup.py
+++ b/sources/pil/setup.py
@@ -57,7 +57,7 @@ setup(
     ],
     extras_require={
         'all': [
-            'rawpy ; python_version < "3.13"',
+            'rawpy',
             'pillow-heif',
             'pillow-jxl-plugin',
             'pillow-jpls',


### PR DESCRIPTION
scikit-image has been released for Python 3.13, so all packages we have even as optional dependencies are available.