### PR TITLE
Suppress a warning about nd2 files that we can't do anything about

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Add more color palettes ([#1746](../../pull/1746))
 - Improve the list of extensions the bioformats source reports ([#1748](../../pull/1748))
 
+### Changes
+
+- Suppress a warning about nd2 files that we can't do anything about ([#1749](../../pull/1749))
+
 ## 1.30.5
 
 ### Improvements

--- a/sources/nd2/large_image_source_nd2/__init__.py
+++ b/sources/nd2/large_image_source_nd2/__init__.py
@@ -17,6 +17,7 @@
 import math
 import os
 import threading
+import warnings
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _importlib_version
 
@@ -49,6 +50,9 @@ def _lazyImport():
         except ImportError:
             msg = 'nd2 module not found.'
             raise TileSourceError(msg)
+        # the dask module emits a warning about an open handle even those we
+        # close file handles properly.  Suppress them
+        warnings.filterwarnings('ignore', category=UserWarning, module='.*dask.*')
 
 
 def namedtupleToDict(obj):


### PR DESCRIPTION
Specifically, the dask module probably duplicates the ND2File object and the deletes the object without explicitly closing it.