### PR TITLE
Harden the tile cache between python versions and numpy versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - Suppress a warning about nd2 files that we can't do anything about ([#1749](../../pull/1749))
 
+### Bug Fixes
+
+- Harden the tile cache between python versions and numpy versions ([#1751](../../pull/1751))
+
 ## 1.30.5
 
 ### Improvements

--- a/large_image/cache_util/cache.py
+++ b/large_image/cache_util/cache.py
@@ -100,7 +100,7 @@ def methodcache(key: Optional[Callable] = None) -> Callable:  # noqa
                     return self.cache[k]
             except KeyError:
                 pass  # key not found
-            except (ValueError, pickle.UnpicklingError):
+            except (ValueError, pickle.UnpicklingError, ModuleNotFoundError):
                 # this can happen if a different version of python wrote the record
                 pass
             v = func(self, *args, **kwargs)


### PR DESCRIPTION
If a python version with numpy >= 2.x wrote a tile to the cache, and then a python version with numpy < 2.x tried to read the tile from the cache, the failure was a ModuleNotFoundError rather than the errors we were checking for.  This now counts as a cache miss rather than a failure.