### PR TITLE
Don't include cache libraries in [common]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Suppress a warning about nd2 files that we can't do anything about ([#1749](../../pull/1749))
 - Zero empty areas in tile frames ([#1752](../../pull/1752))
+- Don't include cache libraries in [common] deployments ([#1758](../../pull/1758))
 
 ### Bug Fixes
 

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ extraReqs['all'] = list(set(itertools.chain.from_iterable(extraReqs.values())) |
 # The common packages are ones that will install on Ubuntu, OSX, and Windows
 # from pypi with all needed dependencies.
 extraReqs['common'] = list(set(itertools.chain.from_iterable(extraReqs[key] for key in {
-    'memcached', 'redis', 'colormaps', 'performance',
+    'colormaps', 'performance',
     'deepzoom', 'dicom', 'multi', 'nd2', 'openslide', 'test', 'tifffile',
     'zarr',
 })) | {


### PR DESCRIPTION
They may require other libraries that aren't present.