### PR TITLE
Specify empty_dir=yes when constructing vsicurl parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Suppress a warning about nd2 files that we can't do anything about ([#1749](../../pull/1749))
 - Zero empty areas in tile frames ([#1752](../../pull/1752))
 - Don't include cache libraries in [common] deployments ([#1758](../../pull/1758))
+- Specify empty_dir=yes when constructing vsicurl parameters ([#1760](../../pull/1760))
 
 ### Bug Fixes
 

--- a/large_image/tilesource/geo.py
+++ b/large_image/tilesource/geo.py
@@ -29,7 +29,8 @@ def make_vsi(url: Union[str, pathlib.Path, Dict[Any, Any]], **options) -> str:
         gdal_options = {
             'url': str(url),
             'use_head': 'no',
-            'list_dir': 'no',
+            'list_dir': 'no',  # don't search for adjacent files
+            'empty_dir': 'yes',  # don't probe for sidecar files
         }
         gdal_options.update(options)
         vsi = f'/vsicurl?{urlencode(gdal_options)}'


### PR DESCRIPTION
When automatically constructing a vsicurl url to allow gdal to read from https or s3 sources, set empty_dir=yes to avoid probing for sidecar files.  Prior to GDAL PR 11469, this seem to be the case with just list_dir=no, but it isn't clear from the GDAL documentation why that works.  Be explicit (open a viscurl path directly to change the behavior).