### PR TITLE
Cast histogram ranges to floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Bug Fixes
 
 - Harden the tile cache between python versions and numpy versions ([#1751](../../pull/1751))
+- Cast histogram ranges to floats ([#1762](../../pull/1762))
 
 ## 1.30.5
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -650,7 +650,8 @@ class TileSource(IPyLeafletMixin):
             for idx in range(min(len(results['min']), tile.shape[-1])):
                 entry = results['histogram'][idx]
                 hist, bin_edges = np.histogram(
-                    tile[:, :, idx], entry['bins'], entry['range'], density=False)
+                    tile[:, :, idx], entry['bins'],
+                    (float(entry['range'][0]), float(entry['range'][1])), density=False)
                 if entry['hist'] is None:
                     entry['hist'] = hist
                     entry['bin_edges'] = bin_edges


### PR DESCRIPTION
There was a case where a tile with >u2 data and int histogram ranges caused numpy 2.x to segfault.  Using float histogram ranges avoids this