### PR TITLE
Update how some associated images are read in tiff files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Zero empty areas in tile frames ([#1752](../../pull/1752))
 - Don't include cache libraries in [common] deployments ([#1758](../../pull/1758))
 - Specify empty_dir=yes when constructing vsicurl parameters ([#1760](../../pull/1760))
+- Update how some associated images are read in tiff files ([#1763](../../pull/1763))
 
 ### Bug Fixes
 

--- a/sources/tiff/large_image_source_tiff/tiff_reader.py
+++ b/sources/tiff/large_image_source_tiff/tiff_reader.py
@@ -901,8 +901,7 @@ class TiledTiffDirectory:
         Use the underlying _tiffFile to read an image.  But, if it is in a jp2k
         encoding, read the raw data and convert it.
         """
-        if self._tiffInfo.get('compression') not in {
-                libtiff_ctypes.COMPRESSION_JPEG, 33003, 33004, 33005, 34712}:
+        if self._tiffInfo.get('compression') not in {33003, 33004, 33005, 34712}:
             return self._tiffFile.read_image()
         output = None
         for yidx, y in enumerate(range(0, self.imageHeight, self.tileHeight)):


### PR DESCRIPTION
Use the libtiff code path for jpeg, not the jp2k fall-back code path