### PR TITLE
Harden reading a variety of test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Improve writing to zarr sinks from multiple processes ([#1713](../../pull/1713))
 - Slightly faster GDAL validateCOG ([#1761](../../pull/1761))
 - Improve clearing caches ([#1766](../../pull/1766))
+- Harden many of the source reads ([#1768](../../pull/1768))
 
 ### Changes
 

--- a/large_image/tilesource/geo.py
+++ b/large_image/tilesource/geo.py
@@ -1,3 +1,4 @@
+import math
 import pathlib
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 from urllib.parse import urlencode, urlparse
@@ -186,7 +187,7 @@ class GDALBaseFileTileSource(GeoBaseFileTileSource):
         self._bandNames = {}
         for idx, band in self.getBandInformation().items():
             if band.get('interpretation'):
-                self._bandNames[band['interpretation'].lower()] = idx
+                self._bandNames[str(band['interpretation']).lower()] = idx
         if isinstance(getattr(self, '_style', None), dict) and (
                 not self._style or 'icc' in self._style and len(self._style) == 1):
             return
@@ -277,6 +278,8 @@ class GDALBaseFileTileSource(GeoBaseFileTileSource):
         :return: width of a pixel in mm, height of a pixel in mm.
         """
         scale = self.getPixelSizeInMeters()
+        if scale and not math.isfinite(scale):
+            scale = None
         return {
             'magnification': None,
             'mm_x': scale * 100 if scale else None,

--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -62,7 +62,7 @@ _openImages = []
 
 
 # Default to ignoring files with no extension and some specific extensions.
-config.ConfigValues['source_bioformats_ignored_names'] = r'(^[^.]*|\.(jpg|jpeg|jpe|png|tif|tiff|ndpi|nd2|ome|nc|json|geojson|isyntax|mrxs|zip|zarr(\.db|\.zip)))$'  # noqa
+config.ConfigValues['source_bioformats_ignored_names'] = r'(^[^.]*|\.(jpg|jpeg|jpe|png|tif|tiff|ndpi|nd2|ome|nc|json|geojson|fits|isyntax|mrxs|zip|zarr(\.db|\.zip)))$'  # noqa
 
 
 def _monitor_thread():

--- a/sources/mapnik/large_image_source_mapnik/__init__.py
+++ b/sources/mapnik/large_image_source_mapnik/__init__.py
@@ -97,6 +97,15 @@ class MapnikFileTileSource(GDALFileTileSource, metaclass=LruCacheMetaclass):
             projection = projection.lower()
         super().__init__(
             path, projection=projection, unitsPerPixel=unitsPerPixel, **kwargs)
+        if self.dataset.GetDriver().ShortName in {'MBTiles', 'Rasterlite', 'SQLite'}:
+            msg = 'File will not be opened via mapbox'
+            raise TileSourceError(msg)
+        self.logger.debug('mapnik source using the GDAL %s driver',
+                          self.dataset.GetDriver().ShortName)
+
+    def _openVectorSource(self, ds):
+        msg = 'File will not be opened via mapnik'
+        raise TileSourceError(msg)
 
     def _checkNetCDF(self):
         """

--- a/sources/rasterio/large_image_source_rasterio/__init__.py
+++ b/sources/rasterio/large_image_source_rasterio/__init__.py
@@ -642,7 +642,11 @@ class RasterioFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass
                     width=self.tileWidth,
                     add_alpha=add_alpha,
                 ) as vrt:
-                    tile = vrt.read(resampling=rio.enums.Resampling.nearest)
+                    try:
+                        tile = vrt.read(resampling=rio.enums.Resampling.nearest)
+                    except Exception:
+                        self.logger.exception('Failed to getTile')
+                        tile = np.zeros((1, 1))
 
         # necessary for multispectral images:
         # set the coordinates first and the bands at the end

--- a/test/lisource_compare.py
+++ b/test/lisource_compare.py
@@ -208,14 +208,16 @@ def source_compare(sourcePath, opts):  # noqa
                     '_geospatial_source', None):
                 continue
             result = results['styles'][-1]['sources'][source] = {}
-            sys.stdout.write('%s' % (source + ' ' * (slen - len(source))))
-            sys.stdout.flush()
             large_image.cache_util.cachesClear()
             try:
                 t = time.time()
                 ts = large_image.tilesource.AvailableTileSources[source](sourcePath, **kwargs)
                 opentime = time.time() - t
             except Exception as exp:
+                if opts.can_read and projection and None in projections:
+                    continue
+                sys.stdout.write('%s' % (source + ' ' * (slen - len(source))))
+                sys.stdout.flush()
                 result['exception'] = str(exp)
                 result['error'] = 'open'
                 sexp = str(exp).replace('\n', ' ').replace('  ', ' ').strip()
@@ -224,6 +226,8 @@ def source_compare(sourcePath, opts):  # noqa
                 sys.stdout.write('%s %s\n' % (' ' * slen, sexp[78 - slen: 2 * (78 - slen)]))
                 sys.stdout.flush()
                 continue
+            sys.stdout.write('%s' % (source + ' ' * (slen - len(source))))
+            sys.stdout.flush()
             sizeX, sizeY = ts.sizeX, ts.sizeY
             result['sizeX'], result['sizeY'] = ts.sizeX, ts.sizeY
             try:
@@ -304,7 +308,13 @@ def source_compare(sourcePath, opts):  # noqa
             sys.stdout.flush()
             write_thumb(img[0], source, thumbs, 'thumbnail', opts, styleidx, projidx)
             t = time.time()
-            img = ts.getTile(tx0, ty0, tz0, sparseFallback=True)
+            try:
+                img = ts.getTile(tx0, ty0, tz0, sparseFallback=True)
+            except Exception as exp:
+                result['exception'] = str(exp)
+                result['error'] = 'gettile'
+                sys.stdout.write(' fail\n')
+                continue
             tile0time = time.time() - t
             result['tile0time'] = tile0time
             sys.stdout.write(' %8.3fs' % tile0time)
@@ -395,11 +405,19 @@ def source_compare(sourcePath, opts):  # noqa
                 onlyMinMax=True, output=dict(maxWidth=2048, maxHeight=2048),
                 resample=0, **kwargs)
             if 'max' not in h:
+                result['error'] = 'max'
                 sys.stdout.write(' fail\n')
                 sys.stdout.flush()
                 continue
-            maxval = max(h['max'].tolist())
-            maxval = 2 ** (int(math.log(maxval or 1) / math.log(2)) + 1) if maxval > 1 else 1
+            try:
+                maxval = max(h['max'].tolist())
+                maxval = 2 ** (int(math.log(maxval or 1) / math.log(2)) + 1) if maxval > 1 else 1
+            except (TypeError, OverflowError) as exp:
+                result['exception'] = str(exp)
+                result['error'] = 'maxval'
+                sys.stdout.write(' fail\n')
+                sys.stdout.flush()
+                continue
             # thumbnail histogram
             h = ts.histogram(bins=9, output=dict(maxWidth=256, maxHeight=256),
                              range=[0, maxval], resample=0, **kwargs)


### PR DESCRIPTION
The goal is that no source will crash on any of GDAL's test data set, no matter how ill-formed