### PR TITLE
Fix scaling tiles from stripped tiffs in some instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Provide some latitude in vips multiframe detection ([#1770](../../pull/1770))
 - Don't read multiplane ndpi files with openslide ([#1772](../../pull/1772))
 
+### Bug Fixes
+
+Vy- Fix scaling tiles from stripped tiffs in some instances ([#1773](../../pull/1773))
+
 ## 1.30.6
 
 ### Features

--- a/girder/girder_large_image/models/image_item.py
+++ b/girder/girder_large_image/models/image_item.py
@@ -237,7 +237,9 @@ class ImageItem(Item):
             # tileSource = girder_tilesource.getGirderTileSource(item, **kwargs)
             # but, instead, log that the original source no longer works are
             # reraise the exception
-            logger.warning('The original tile source for item %s is not working', item['_id'])
+            logger.warning(
+                'The original tile source (%s) for item %s is not working',
+                sourceName, item['_id'])
             try:
                 file = File().load(item['largeImage']['fileId'], force=True)
                 localPath = File().getLocalFilePath(file)

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1625,9 +1625,16 @@ class TileSource(IPyLeafletMixin):
                 mode = subtile.mode
                 tile.paste(subtile, (newX * self.tileWidth,
                                      newY * self.tileHeight))
-        return tile.resize(
-            (self.tileWidth, self.tileHeight),
-            getattr(PIL.Image, 'Resampling', PIL.Image).LANCZOS).convert(mode), TILE_FORMAT_PIL
+        tile = tile.resize(
+            (min(self.tileWidth, (tile.width + scale - 1) // scale),
+             min(self.tileHeight, (tile.height + scale - 1) // scale)),
+            getattr(PIL.Image, 'Resampling', PIL.Image).LANCZOS)
+        if tile.width != self.tileWidth or tile.height != self.tileHeight:
+            fulltile = PIL.Image.new('RGBA', (self.tileWidth, self.tileHeight))
+            fulltile.paste(tile, (0, 0))
+            tile = fulltile
+        tile = tile.convert(mode)
+        return (tile, TILE_FORMAT_PIL)
 
     @methodcache()
     def getTile(self, x: int, y: int, z: int, pilImageAllowed: bool = False,


### PR DESCRIPTION
In some cases when trying to use a strip-based tiff file, the lower resolution tile would be horizontal scaled to the strip width.