### PR TITLE
ipyleaflet 0.19 fixes an issue with inverting bounds coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 - Fix scaling tiles from stripped tiffs in some instances ([#1773](../../pull/1773))
+- Updated jupyter support for ipyleaflet ([#1775](../../pull/1775))
 
 ## 1.30.6
 

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -276,21 +276,11 @@ class Map:
             crs = dict(
                 name='PixelSpace',
                 custom=True,
-                # Why does this need to be 256?
                 resolutions=[2 ** (metadata['levels'] - 1 - l) for l in range(20)],
 
-                # This works but has x and y reversed
                 proj4def='+proj=longlat +axis=esu',
-                bounds=[[0, 0], [metadata['sizeY'], metadata['sizeX']]],
-                # Why is origin X, Y but bounds Y, X?
+                bounds=[[0, 0], [metadata['sizeX'], metadata['sizeY']]],
                 origin=[0, metadata['sizeY']],
-
-                # This almost works to fix the x, y reversal, but
-                # - bounds are weird and other issues occur
-                # proj4def='+proj=longlat +axis=seu',
-                # bounds=[[-metadata['sizeX'],-metadata['sizeY']],
-                #         [metadata['sizeX'],metadata['sizeY']]],
-                # origin=[0,0],
             )
         layer = layer or self._layer
 


### PR DESCRIPTION
This fixes the issue on map coordinates.  Layers appear to still be inverted.  Note that this will break map bounds in ipyleaflet < 0.19.