### PR TITLE
Default to not caching sources in notebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Provide some latitude in vips multiframe detection ([#1770](../../pull/1770))
 - Don't read multiplane ndpi files with openslide ([#1772](../../pull/1772))
 - Harden sources based on more fuzz testing ([#1774](../../pull/1774))
+- Default to not caching source in notebooks ([#1776](../../pull/1776))
 
 ### Bug Fixes
 

--- a/large_image/config.py
+++ b/large_image/config.py
@@ -21,6 +21,23 @@ fallbackLogHandler = logging.NullHandler()
 fallbackLogHandler.setLevel(logging.NOTSET)
 fallbackLogger.addHandler(fallbackLogHandler)
 
+
+def _in_notebook() -> bool:
+    """
+    Try to detect if we are in an interactvie notebook.
+
+    :returns: True if we think we are in an interactive notebook.
+    """
+    try:
+        shell = get_ipython().__class__.__name__  # type: ignore[name-defined]
+        # Jupyter
+        if shell == 'ZMQInteractiveShell':
+            return True
+        return False
+    except NameError:
+        return False
+
+
 ConfigValues = {
     'logger': fallbackLogger,
     'logprint': fallbackLogger,
@@ -40,7 +57,7 @@ ConfigValues = {
     # substantial performance penalties if sources are used multiple times, so
     # should only be set in singular dynamic environments such as experimental
     # notebooks.
-    'cache_sources': True,
+    'cache_sources': not _in_notebook(),
 
     # Generally, these keys are the form of "cache_<cacheName>_<key>"
 


### PR DESCRIPTION
@annehaley This should remove the need to add `nocache=True` to let the frame selector work in notebooks.

@banesullivan This should make your work easier, too.