### PR TITLE
Build plugin client code on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,7 +296,7 @@ jobs:
           path: ~/wheels
   check_release:
     docker:
-      - image: cimg/python:3.10
+      - image: girder/tox-and-node
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,6 +297,10 @@ jobs:
   check_release:
     docker:
       - image: girder/tox-and-node
+    parameters:
+      node:
+        type: string
+        default: v20
     steps:
       - checkout
       - run:
@@ -307,6 +311,13 @@ jobs:
       - run:
           name: Install python packages
           command: pip install setuptools_scm twine
+      - run:
+          name: Switch node versions
+          command: |
+            nvm install << parameters.node >>
+            nvm alias default << parameters.node >>
+            NODE_DIR=$(dirname $(which node))
+            echo "export PATH=$NODE_DIR:\$PATH" >> $BASH_ENV
       - run:
           name: Check node versions
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,6 +322,7 @@ jobs:
       - run:
           name: Switch node versions
           command: |
+            . ~/.bashrc
             nvm install << parameters.node >>
             nvm alias default << parameters.node >>
             NODE_DIR=$(dirname $(which node))

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,6 +308,11 @@ jobs:
           name: Install python packages
           command: pip install setuptools_scm twine
       - run:
+          name: Check node versions
+          command: |
+            node --version
+            npm --version
+      - run:
           name: Check release to PyPi
           command: ./.circleci/release_pypi.sh check
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,8 +295,7 @@ jobs:
       - store_artifacts:
           path: ~/wheels
   check_release:
-    docker:
-      - image: girder/tox-and-node
+    executor: toxandnode
     parameters:
       node:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,6 +312,15 @@ jobs:
           name: Install python packages
           command: pip install setuptools_scm twine
       - run:
+          name: Use nvm
+          # see https://discuss.circleci.com/t/nvm-does-not-change-node-version-on-machine/28973/14
+          command: |
+            echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+      - restore_cache:
+          name: Restore nvm cache
+          key: v1-nvm-cache-<< parameters.node >>
+      - run:
           name: Switch node versions
           command: |
             nvm install << parameters.node >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,8 +336,11 @@ jobs:
           name: Check release to PyPi
           command: ./.circleci/release_pypi.sh check
   release:
-    docker:
-      - image: cimg/python:3.10
+    executor: toxandnode
+    parameters:
+      node:
+        type: string
+        default: v20
     steps:
       - checkout
       - run:
@@ -348,6 +351,28 @@ jobs:
       - run:
           name: Install python packages
           command: pip install setuptools_scm twine
+      - run:
+          name: Use nvm
+          # see https://discuss.circleci.com/t/nvm-does-not-change-node-version-on-machine/28973/14
+          command: |
+            echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+      - restore_cache:
+          name: Restore nvm cache
+          key: v1-nvm-cache-<< parameters.node >>
+      - run:
+          name: Switch node versions
+          command: |
+            . ~/.bashrc
+            nvm install << parameters.node >>
+            nvm alias default << parameters.node >>
+            NODE_DIR=$(dirname $(which node))
+            echo "export PATH=$NODE_DIR:\$PATH" >> $BASH_ENV
+      - run:
+          name: Check node versions
+          command: |
+            node --version
+            npm --version
       - run:
           name: Release to PyPi
           command: ./.circleci/release_pypi.sh upload

--- a/.circleci/release_pypi.sh
+++ b/.circleci/release_pypi.sh
@@ -13,12 +13,22 @@ twine ${1:-check} $( [[ "${1:-check}" == "upload" ]] && printf %s '--verbose' ) 
 cd "$ROOTPATH/girder"
 cp "$ROOTPATH/README.rst" .
 cp "$ROOTPATH/LICENSE" .
+# Build the client plugin code
+pushd "$ROOTPATH/girder/girder_large_image/web_client/"
+npm ci
+npm run build
+popd
 python setup.py sdist
 pip wheel . --no-deps -w dist
 twine ${1:-check} $( [[ "${1:-check}" == "upload" ]] && printf %s '--verbose' ) dist/*
 cd "$ROOTPATH/girder_annotation"
 cp "$ROOTPATH/README.rst" .
 cp "$ROOTPATH/LICENSE" .
+# Build the client plugin code
+pushd "$ROOTPATH/girder_annotation/girder_large_image_annotation/web_client/"
+npm ci
+npm run build
+popd
 python setup.py sdist
 pip wheel . --no-deps -w dist
 twine ${1:-check} $( [[ "${1:-check}" == "upload" ]] && printf %s '--verbose' ) dist/*
@@ -49,6 +59,7 @@ twine ${1:-check} $( [[ "${1:-check}" == "upload" ]] && printf %s '--verbose' ) 
 cd "$ROOTPATH/sources/dicom"
 cp "$ROOTPATH/README.rst" .
 cp "$ROOTPATH/LICENSE" .
+# TODO build DICOMweb plugin client code when converted
 python setup.py sdist
 pip wheel . --no-deps -w dist
 twine ${1:-check} $( [[ "${1:-check}" == "upload" ]] && printf %s '--verbose' ) dist/*

--- a/girder/MANIFEST.in
+++ b/girder/MANIFEST.in
@@ -1,0 +1,2 @@
+prune girder_large_image/web_client
+recursive-include girder_large_image/web_client/dist/ *

--- a/girder_annotation/MANIFEST.in
+++ b/girder_annotation/MANIFEST.in
@@ -1,0 +1,2 @@
+prune girder_large_image_annotation/web_client
+recursive-include girder_large_image_annotation/web_client/dist/ *


### PR DESCRIPTION
Ship Girder plugin packages with built client packages.

This makes it easier for dependent plugins to use `large_image` Girder plugins.