### PR TITLE
Unpin numpy in girder 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add utility functions for converting between frame and axes ([#1777](../../pull/1777))
+- Add utility functions for converting between frame and axes ([#1778](../../pull/1778))
 
 ### Improvements
 
@@ -13,6 +13,10 @@
 - Don't read multiplane ndpi files with openslide ([#1772](../../pull/1772))
 - Harden sources based on more fuzz testing ([#1774](../../pull/1774))
 - Default to not caching source in notebooks ([#1776](../../pull/1776))
+
+### Changes
+
+- Allow umap-learn for graphing in girder annotations in python 3.13 ([#1780](../../pull/1780))
 
 ### Bug Fixes
 

--- a/girder_annotation/setup.py
+++ b/girder_annotation/setup.py
@@ -62,7 +62,7 @@ setup(
             'pandas ; python_version < "3.9"',
             'pandas>=2.2 ; python_version >= "3.9"',
             'python-calamine ; python_version >= "3.9"',
-            'umap-learn ; python_version < "3.13"',
+            'umap-learn',
         ],
         'tasks': [
             f'girder-large-image[tasks]{limit_version}',

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1006,7 +1006,7 @@ class TileSource(IPyLeafletMixin):
                 elif sc.mainImage.dtype.kind == 'f':
                     sc.dtype = 'float'
             sc.axis = sc.axis if sc.axis is not None else entry.get('axis')
-            sc.bandidx = 0 if image.shape[2] <= 2 else 1  # type: ignore[misc]
+            sc.bandidx = 0 if image.shape[2] <= 2 else 1
             sc.band = None
             if ((entry.get('frame') is None and not entry.get('framedelta')) or
                     entry.get('frame') == sc.mainFrame):
@@ -1021,29 +1021,29 @@ class TileSource(IPyLeafletMixin):
                               :sc.mainImage.shape[1],
                               :sc.mainImage.shape[2]]
             if (isinstance(entry.get('band'), int) and
-                    entry['band'] >= 1 and entry['band'] <= image.shape[2]):  # type: ignore[misc]
+                    entry['band'] >= 1 and entry['band'] <= image.shape[2]):
                 sc.bandidx = entry['band'] - 1
             sc.composite = entry.get('composite', 'lighten')
             if (hasattr(self, '_bandnames') and entry.get('band') and
                     str(entry['band']).lower() in self._bandnames and
-                    image.shape[2] > self._bandnames[  # type: ignore[misc]
+                    image.shape[2] > self._bandnames[
                         str(entry['band']).lower()]):
                 sc.bandidx = self._bandnames[str(entry['band']).lower()]
-            if entry.get('band') == 'red' and image.shape[2] > 2:  # type: ignore[misc]
+            if entry.get('band') == 'red' and image.shape[2] > 2:
                 sc.bandidx = 0
-            elif entry.get('band') == 'blue' and image.shape[2] > 2:  # type: ignore[misc]
+            elif entry.get('band') == 'blue' and image.shape[2] > 2:
                 sc.bandidx = 2
                 sc.band = image[:, :, 2]
             elif entry.get('band') == 'alpha':
-                sc.bandidx = (image.shape[2] - 1 if image.shape[2] in (2, 4)  # type: ignore[misc]
+                sc.bandidx = (image.shape[2] - 1 if image.shape[2] in (2, 4)
                               else None)
-                sc.band = (image[:, :, -1] if image.shape[2] in (2, 4) else  # type: ignore[misc]
+                sc.band = (image[:, :, -1] if image.shape[2] in (2, 4) else
                            np.full(image.shape[:2], 255, np.uint8))
                 sc.composite = entry.get('composite', 'multiply')
             if sc.band is None:
                 sc.band = image[
-                    :, :, sc.bandidx  # type: ignore[index]
-                    if sc.bandidx is not None and sc.bandidx < image.shape[2]  # type: ignore[misc]
+                    :, :, sc.bandidx
+                    if sc.bandidx is not None and sc.bandidx < image.shape[2]
                     else 0]
             sc.band = self._applyStyleFunction(sc.band, sc, 'preband')
             sc.palette = getPaletteColors(entry.get(
@@ -1076,7 +1076,7 @@ class TileSource(IPyLeafletMixin):
             # divide.
             # See https://docs.gimp.org/en/gimp-concepts-layer-modes.html for
             # some details.
-            for channel in range(sc.output.shape[2]):  # type: ignore[misc]
+            for channel in range(sc.output.shape[2]):
                 if np.all(sc.palette[:, channel] == sc.palette[0, channel]):
                     if ((sc.palette[0, channel] == 0 and sc.composite != 'multiply') or
                             (sc.palette[0, channel] == 255 and sc.composite == 'multiply')):
@@ -1117,7 +1117,7 @@ class TileSource(IPyLeafletMixin):
             sc.output = (sc.output * 65535 / 255).astype(np.uint16)
         elif sc.dtype == 'float':
             sc.output /= 255
-        if sc.axis is not None and 0 <= int(sc.axis) < sc.output.shape[2]:  # type: ignore[misc]
+        if sc.axis is not None and 0 <= int(sc.axis) < sc.output.shape[2]:
             sc.output = sc.output[:, :, sc.axis:sc.axis + 1]
         sc.output = self._applyStyleFunction(sc.output, sc, 'post')
         return sc.output
@@ -1145,7 +1145,7 @@ class TileSource(IPyLeafletMixin):
             tile = self._applyStyle(tile, getattr(self, 'style', None), x, y, z, frame)
         if tile.shape[0] != self.tileHeight or tile.shape[1] != self.tileWidth:
             extend = np.zeros(
-                (self.tileHeight, self.tileWidth, tile.shape[2]),  # type: ignore[misc]
+                (self.tileHeight, self.tileWidth, tile.shape[2]),
                 dtype=tile.dtype)
             extend[:min(self.tileHeight, tile.shape[0]),
                    :min(self.tileWidth, tile.shape[1])] = tile

--- a/large_image/tilesource/stylefuncs.py
+++ b/large_image/tilesource/stylefuncs.py
@@ -93,9 +93,9 @@ def medianFilter(
         pimg: np.ndarray = image.astype(float)
         if len(pimg.shape) == 2:
             pimg = np.resize(pimg, (pimg.shape[0], pimg.shape[1], 1))
-        pimg = pimg[:, :, :fimg.shape[2]]  # type: ignore[index,misc]
+        pimg = pimg[:, :, :fimg.shape[2]]
         dimg = (pimg - fimg.astype(float) * mul) * weight
-        pimg = pimg[:, :, :fimg.shape[2]] + dimg  # type: ignore[index,misc]
+        pimg = pimg[:, :, :fimg.shape[2]] + dimg
         if clip:
             pimg = pimg.clip(0, clip)
         if len(image.shape) != 3:

--- a/large_image/tilesource/tiledict.py
+++ b/large_image/tilesource/tiledict.py
@@ -156,7 +156,7 @@ class LazyTileDict(dict):
                 elif tileData.shape[2] < retile.shape[2]:
                     retile = retile[:, :, :tileData.shape[2]]
                 retile[y0:y0 + th, x0:x0 + tw] = tileData[
-                    :th, :tw, :retile.shape[2]]  # type: ignore[misc]
+                    :th, :tw, :retile.shape[2]]
         return cast(np.ndarray, retile)
 
     def _resample(self, tileData: Union[ImageBytes, PIL.Image.Image, bytes, np.ndarray]) -> Tuple[
@@ -197,7 +197,7 @@ class LazyTileDict(dict):
             tileData = skimage.transform.resize(
                 cast(np.ndarray, tileData),
                 (self['width'], self['height'],
-                 cast(np.ndarray, tileData).shape[2]),  # type: ignore[misc]
+                 cast(np.ndarray, tileData).shape[2]),
                 order=3 if self.resample is True else self.resample)
         return tileData, pilData
 

--- a/setup.py
+++ b/setup.py
@@ -108,10 +108,7 @@ setup(
         'cachetools',
         'palettable',
         'Pillow',
-        # Newer versions of numpy include some typing changes that may need to be addressed in
-        # large_image.
-        # https://github.com/numpy/numpy/issues/28076
-        'numpy<2.1.0',
+        'numpy',
         'typing-extensions',
     ],
     extras_require=extraReqs,


### PR DESCRIPTION
Brings in changes from #1780 to fix the type checking problems and removes the numpy pin.