### PR TITLE
Speed up style composition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Default to not caching source in notebooks ([#1776](../../pull/1776))
 - Automatically set the JUPYTER_PROXY value ([#1781](../../pull/1781))
 - Add a general channelNames property to tile sources ([#1783](../../pull/1783))
+- Speed up compositing styles ([#1784](../../pull/1784))
 
 ### Changes
 

--- a/docs/tilesource_options.rst
+++ b/docs/tilesource_options.rst
@@ -111,7 +111,7 @@ A band definition is an object which can contain the following keys:
 
     - ``band``: the band numpy image in a band stage.
 
-    - ``mask``: a mask numpy image to use when applying the band.
+    - ``mask``: a mask numpy image to use when applying the band.  None for no mask (this is the equivalent of the mask being all True).
 
     - ``palette``: the normalized palette for a band.
 

--- a/test/lisource_compare.py
+++ b/test/lisource_compare.py
@@ -146,7 +146,6 @@ def source_compare(sourcePath, opts):  # noqa
     canread = large_image.canReadList(sourcePath, availableSources=sublist)
     if opts.can_read and not len([cr for cr in canread if cr[1]]):
         return None
-    large_image.cache_util.cachesClear()
     slen = max([len(source) for source, _ in canread] + [10])
     sys.stdout.write('Source' + ' ' * (slen - 6))
     sys.stdout.write('  Width Height')
@@ -208,7 +207,8 @@ def source_compare(sourcePath, opts):  # noqa
                     '_geospatial_source', None):
                 continue
             result = results['styles'][-1]['sources'][source] = {}
-            large_image.cache_util.cachesClear()
+            if couldread:
+                large_image.cache_util.cachesClear()
             try:
                 t = time.time()
                 ts = large_image.tilesource.AvailableTileSources[source](sourcePath, **kwargs)


### PR DESCRIPTION
The speed up is achieved by have a special case for palettes that have two entries with the first entry 0 and for conditions where no mask is required.

Slightly speed up source comparison