### PR TITLE
Better repr of large_image classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Automatically set the JUPYTER_PROXY value ([#1781](../../pull/1781))
 - Add a general channelNames property to tile sources ([#1783](../../pull/1783))
 - Speed up compositing styles ([#1784](../../pull/1784))
+- Better repr of large_image classes ([#1787](../../pull/1787))
 
 ### Changes
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -200,10 +200,29 @@ class TileSource(IPyLeafletMixin):
         return functools.partial(type(self), **self._initValues[1]), self._initValues[0]
 
     def __repr__(self) -> str:
-        return self.getState()
+        if hasattr(self, '_initValues') and not hasattr(self, '_unpickleable'):
+            param = [
+                f'{k}={v!r}' if k != 'style' or not isinstance(v, dict) or
+                not getattr(self, '_jsonstyle', None) else
+                f'style={json.loads(self._jsonstyle)}'
+                for k, v in self._initValues[1].items()]
+            return (
+                f'{self.__class__.__name__}('
+                f'{", ".join(repr(val) for val in self._initValues[0])}'
+                f'{", " if len(self._initValues[1]) else ""}'
+                f'{", ".join(param)}'
+                ')')
+        return '<' + self.getState() + '>'
 
     def _repr_png_(self) -> bytes:
         return self.getThumbnail(encoding='PNG')[0]
+
+    def __rich_repr__(self) -> Iterator[Any]:
+        if not hasattr(self, '_initValues') or hasattr(self, '_unpickleable'):
+            yield self.getState()
+        else:
+            yield from self._initValues[0]
+            yield from self._initValues[1].items()
 
     @property
     def geospatial(self) -> bool:

--- a/sources/pil/large_image_source_pil/__init__.py
+++ b/sources/pil/large_image_source_pil/__init__.py
@@ -224,9 +224,11 @@ class PILFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         """
         # if rawpy is present, try reading via that library first
         try:
+            import builtins
+
             import rawpy
 
-            with contextlib.redirect_stderr(open(os.devnull, 'w')):
+            with contextlib.redirect_stderr(builtins.open(os.devnull, 'w')):
                 rgb = rawpy.imread(largeImagePath).postprocess()
                 rgb = large_image.tilesource.utilities._imageToNumpy(rgb)[0]
                 if rgb.shape[2] == 2:

--- a/sources/pil/setup.py
+++ b/sources/pil/setup.py
@@ -58,7 +58,8 @@ setup(
         'all': [
             'rawpy',
             'pillow-heif',
-            'pillow-jxl-plugin',
+            'pillow-jxl-plugin < 1.3 ; python_version < "3.8"',
+            'pillow-jxl-plugin ; python_version >= "3.9"',
             'pillow-jpls',
         ],
         'girder': f'girder-large-image{limit_version}',


### PR DESCRIPTION
Before, the repr of a large_image tile source was something like `OpenslideFileTileSource ('/data/samplefile.svs', 'JPEG', 95, 0, 'raw', False, '__STYLESTART__', {'bands': [{'band': 1, 'palette': 'white'}]}, '__STYLEEND__')`.  Now, this is
`OpenslideFileTileSource('/data/samplefile.svs', style={'bands': [{'band': 1, 'palette': 'white'}]})`, which could actually be used to open the tile source again.  If the class is unpickleable (for instance, a vips tile sink), the repr is surrounded by `<>` to indicate this.

As an added feature, `__rich_repr__` has been added to make the results prettier for those using the rich text library.