### PR TITLE
Fix an issue with lazy tiles that have non power of two scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Improve how we use vips to read lower tile levels ([#1794](../../pull/1794))
 - Be more specific in casting when converting images via vips ([#1795](../../pull/1795))
 
+### Bug Fixes
+
+- Fix an issue with lazy tiles that have non power of two scaling ([#1797](../../pull/1797))
+
 ## 1.31.0
 
 ### Features
@@ -58,7 +62,7 @@
 ### Changes
 
 - Suppress a warning about nd2 files that we can't do anything about ([#1749](../../pull/1749))
-- Zero empty areas in tile frames ([#1752](../../pull/1752))
+- Zero empty areas in tile frames ([#1755](../../pull/1755))
 - Don't include cache libraries in [common] deployments ([#1758](../../pull/1758))
 - Specify empty_dir=yes when constructing vsicurl parameters ([#1760](../../pull/1760))
 - Update how some associated images are read in tiff files ([#1763](../../pull/1763))

--- a/large_image/tilesource/tiledict.py
+++ b/large_image/tilesource/tiledict.py
@@ -87,7 +87,7 @@ class LazyTileDict(dict):
             self['tile_x'] = self.get('tile_x', self['x'])
             self['tile_y'] = self.get('tile_y', self['y'])
             self['tile_width'] = self.get('tile_width', self.width)
-            self['tile_height'] = self.get('tile_width', self.height)
+            self['tile_height'] = self.get('tile_height', self.height)
             if self.get('magnification', None):
                 self['tile_magnification'] = self.get('tile_magnification', self['magnification'])
             self['tile_mm_x'] = self.get('mm_x')

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -372,6 +372,26 @@ def testTileOverlapWithRegionOffset():
     assert firstTile['tile_overlap']['right'] == 200
 
 
+def testLazyTileWithScale():
+    imagePath = datastore.fetch('sample_Easy1.png')
+    ts = large_image.open(imagePath)
+    tile = ts.getSingleTile(
+        format=large_image.constants.TILE_FORMAT_NUMPY,
+        tile_size={'width': 256}, output={'maxWidth': 800}, tile_position=3)
+    assert tile['width'] == 31
+    assert tile['height'] == 256
+    tile = ts.getSingleTile(
+        format=large_image.constants.TILE_FORMAT_NUMPY,
+        tile_size={'width': 256}, output={'maxWidth': 800}, tile_position=4)
+    assert tile['width'] == 256
+    assert tile['height'] == 211
+    tile = ts.getSingleTile(
+        format=large_image.constants.TILE_FORMAT_NUMPY,
+        tile_size={'width': 256}, output={'maxWidth': 800}, tile_position=7)
+    assert tile['width'] == 31
+    assert tile['height'] == 211
+
+
 def testGetRegionAutoOffset():
     imagePath = datastore.fetch('sample_image.ptif')
     source = large_image.open(imagePath)


### PR DESCRIPTION
Specifically, the height reported for a unloaded tile that had been scaled was reporting the width instead.