### PR TITLE
Use zarr.empty not np.empty when creating large zarr sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 - Fix an issue with lazy tiles that have non power of two scaling ([#1797](../../pull/1797))
+- Use zarr.empty not np.empty when creating large zarr sinks ([#1801](../../pull/1801))
 
 ## 1.31.0
 


### PR DESCRIPTION
np.empty actually allocates memory, zarr.empty does not.