### PR TITLE
Histogram AutoRange True Values

### DIFF
--- a/large_image/widgets/HistogramEditor.vue
+++ b/large_image/widgets/HistogramEditor.vue
@@ -3,7 +3,7 @@ function clamp(num, min, max) {
     return Math.min(Math.max(num, min), max);
 }
 
-function makeDraggableSVG(svg, validateDrag, callback, xRange) {
+function makeDraggableSVG(svg, validateDrag, dragCallback, endCallback, xRange) {
     // Modified from https://www.w3schools.com/howto/howto_js_draggable.asp
     let selectedShape;
     let posOffset;
@@ -55,11 +55,13 @@ function makeDraggableSVG(svg, validateDrag, callback, xRange) {
             selectedShape.setAttributeNS(null, 'x1', `${coord.x}`);
             selectedShape.setAttributeNS(null, 'x2', `${coord.x}`);
             selectedShape.setAttributeNS(null, 'y1', `${coord.y}`);
-            callback(selectedShape, coord);
+            dragCallback(selectedShape, coord);
         }
     }
+
     function endDrag() {
         selectedShape = undefined;
+        endCallback();
     }
 }
 
@@ -109,6 +111,7 @@ module.exports = {
                 this.$refs.svg,
                 this.validateHandleDrag,
                 this.dragHandle,
+                () => { this.$refs.handleTooltip.style.visibility = 'hidden'; },
                 this.xRange
             );
             this.initializePositions();
@@ -286,6 +289,9 @@ module.exports = {
         dragHandle(selected, newLocation) {
             const name = selected.getAttribute('name');
             let newValue = this.xPositionToValue(newLocation.x);
+            this.$refs.handleTooltip.innerText = newValue;
+            this.$refs.handleTooltip.style.visibility = 'visible';
+            this.$refs.handleTooltip.style.left = `${newLocation.x + 70}px`;
             if (this.autoRange !== undefined) {
                 newValue = this.toDistributionPercentage(newValue);
                 if (name === 'max') {
@@ -347,6 +353,7 @@ module.exports = {
 
 <template>
   <div class="range-editor">
+    <div ref="handleTooltip" class="handle-tooltip"></div>
     <input
       v-if="histogram"
       type="number"
@@ -434,6 +441,16 @@ module.exports = {
 </template>
 
 <style scoped>
+.handle-tooltip {
+    position: absolute;
+    background-color: white;
+    z-index: 2;
+    top: 18px;
+    padding: 5px;
+    border: 1px solid black;
+    border-radius: 5px;
+    visibility: hidden;
+}
 .range-editor {
     position: absolute;
     display: flex;

--- a/large_image/widgets/HistogramEditor.vue
+++ b/large_image/widgets/HistogramEditor.vue
@@ -3,7 +3,7 @@ function clamp(num, min, max) {
     return Math.min(Math.max(num, min), max);
 }
 
-function makeDraggableSVG(svg, validateDrag, dragCallback, endCallback, xRange) {
+function makeDraggableSVG(svg, validateDrag, callback, xRange) {
     // Modified from https://www.w3schools.com/howto/howto_js_draggable.asp
     let selectedShape;
     let posOffset;
@@ -55,13 +55,12 @@ function makeDraggableSVG(svg, validateDrag, dragCallback, endCallback, xRange) 
             selectedShape.setAttributeNS(null, 'x1', `${coord.x}`);
             selectedShape.setAttributeNS(null, 'x2', `${coord.x}`);
             selectedShape.setAttributeNS(null, 'y1', `${coord.y}`);
-            dragCallback(selectedShape, coord);
+            callback(selectedShape, coord);
         }
     }
 
     function endDrag() {
         selectedShape = undefined;
-        endCallback();
     }
 }
 
@@ -111,7 +110,6 @@ module.exports = {
                 this.$refs.svg,
                 this.validateHandleDrag,
                 this.dragHandle,
-                () => { this.$refs.handleTooltip.style.visibility = 'hidden'; },
                 this.xRange
             );
             this.initializePositions();
@@ -289,9 +287,6 @@ module.exports = {
         dragHandle(selected, newLocation) {
             const name = selected.getAttribute('name');
             let newValue = this.xPositionToValue(newLocation.x);
-            this.$refs.handleTooltip.innerText = newValue;
-            this.$refs.handleTooltip.style.visibility = 'visible';
-            this.$refs.handleTooltip.style.left = `${newLocation.x + 70}px`;
             if (this.autoRange !== undefined) {
                 newValue = this.toDistributionPercentage(newValue);
                 if (name === 'max') {
@@ -353,7 +348,6 @@ module.exports = {
 
 <template>
   <div class="range-editor">
-    <div ref="handleTooltip" class="handle-tooltip"></div>
     <input
       v-if="histogram"
       type="number"
@@ -398,7 +392,9 @@ module.exports = {
         x2="5"
         y1="0"
         y2="30"
-      />
+      >
+        <title>{{ minVal }}</title>
+      </line>
       <text
         v-if="vRange[1] !== undefined"
         :x="xRange[1] && vRange[1] ? xRange[1] - (`${vRange[1]}`.length * 8): 0"
@@ -425,7 +421,9 @@ module.exports = {
         x2="5"
         y1="0"
         y2="30"
-      />
+      >
+        <title>{{ maxVal }}</title>
+      </line>
     </svg>
     <input
       v-if="histogram"
@@ -441,16 +439,6 @@ module.exports = {
 </template>
 
 <style scoped>
-.handle-tooltip {
-    position: absolute;
-    background-color: white;
-    z-index: 2;
-    top: 18px;
-    padding: 5px;
-    border: 1px solid black;
-    border-radius: 5px;
-    visibility: hidden;
-}
 .range-editor {
     position: absolute;
     display: flex;

--- a/large_image/widgets/HistogramEditor.vue
+++ b/large_image/widgets/HistogramEditor.vue
@@ -123,6 +123,16 @@ module.exports = {
             this.initializePositions();
         }
     },
+    computed: {
+        minVal() {
+            if (this.autoRange) return Math.round(this.fromDistributionPercentage(this.autoRange / 100))
+            return this.currentMin || parseFloat(this.histogram.min.toFixed(2));
+        },
+        maxVal() {
+            if (this.autoRange) return Math.round(this.fromDistributionPercentage((100 - this.autoRange) / 100))
+            return this.currentMax || parseFloat(this.histogram.max.toFixed(2));
+        },
+    },
     mounted() {
         this.fetchHistogram();
     },
@@ -338,12 +348,13 @@ module.exports = {
 <template>
   <div class="range-editor">
     <input
-      v-if="histogram && autoRange === undefined"
+      v-if="histogram"
       type="number"
       class="input-80 min-input"
+      :disabled="autoRange"
       :min="histogram.min"
       :max="currentMax"
-      :value="currentMin || parseFloat(histogram.min.toFixed(2))"
+      :value="minVal"
       @input="(e) => updateFromInput('min', e.target.value)"
     >
     <canvas
@@ -410,12 +421,13 @@ module.exports = {
       />
     </svg>
     <input
-      v-if="histogram && autoRange === undefined"
+      v-if="histogram"
       type="number"
       class="input-80 max-input"
+      :disabled="autoRange"
       :max="histogram.max"
       :min="currentMin"
-      :value="currentMax || parseFloat(histogram.max.toFixed(2))"
+      :value="maxVal"
       @input="(e) => updateFromInput('max', e.target.value)"
     >
   </div>

--- a/large_image/widgets/HistogramEditor.vue
+++ b/large_image/widgets/HistogramEditor.vue
@@ -126,12 +126,12 @@ module.exports = {
     },
     computed: {
         minVal() {
-            if (!this.histogram) return 0
+            if (!this.histogram) return 0;
             if (this.autoRange !== undefined) return Math.round(this.fromDistributionPercentage(this.autoRange / 100));
             return this.currentMin || parseFloat(this.histogram.min.toFixed(2));
         },
         maxVal() {
-            if (!this.histogram) return 1
+            if (!this.histogram) return 1;
             if (this.autoRange !== undefined) return Math.round(this.fromDistributionPercentage((100 - this.autoRange) / 100));
             return this.currentMax || parseFloat(this.histogram.max.toFixed(2));
         }
@@ -274,23 +274,25 @@ module.exports = {
                 if (this.autoRange === undefined && newValue >= this.currentMax) {
                     moveX = false;
                 } else if (this.autoRange !== undefined) {
-                    const percentage = this.toDistributionPercentage(newValue)
+                    const percentage = this.toDistributionPercentage(newValue);
                     if (
                         percentage >= 50 ||
                         parseFloat(parseFloat(percentage).toFixed(2)) === this.autoRange
-                    )
-                    moveX = false;
+                    ) {
+                        moveX = false;
+                    }
                 }
             } else if (handleName === 'max') {
                 if (this.autoRange === undefined && newValue <= this.currentMin) {
                     moveX = false;
                 } else if (this.autoRange !== undefined) {
-                    const percentage = this.toDistributionPercentage(newValue)
+                    const percentage = this.toDistributionPercentage(newValue);
                     if (
                         percentage <= 50 ||
                         parseFloat(parseFloat(100 - percentage).toFixed(2)) === this.autoRange
-                    )
-                    moveX = false;
+                    ) {
+                        moveX = false;
+                    }
                 }
             }
 

--- a/large_image/widgets/HistogramEditor.vue
+++ b/large_image/widgets/HistogramEditor.vue
@@ -125,13 +125,13 @@ module.exports = {
     },
     computed: {
         minVal() {
-            if (this.autoRange) return Math.round(this.fromDistributionPercentage(this.autoRange / 100))
+            if (this.autoRange) return Math.round(this.fromDistributionPercentage(this.autoRange / 100));
             return this.currentMin || parseFloat(this.histogram.min.toFixed(2));
         },
         maxVal() {
-            if (this.autoRange) return Math.round(this.fromDistributionPercentage((100 - this.autoRange) / 100))
+            if (this.autoRange) return Math.round(this.fromDistributionPercentage((100 - this.autoRange) / 100));
             return this.currentMax || parseFloat(this.histogram.max.toFixed(2));
-        },
+        }
     },
     mounted() {
         this.fetchHistogram();

--- a/large_image/widgets/HistogramEditor.vue
+++ b/large_image/widgets/HistogramEditor.vue
@@ -126,11 +126,13 @@ module.exports = {
     },
     computed: {
         minVal() {
-            if (this.autoRange) return Math.round(this.fromDistributionPercentage(this.autoRange / 100));
+            if (!this.histogram) return 0
+            if (this.autoRange !== undefined) return Math.round(this.fromDistributionPercentage(this.autoRange / 100));
             return this.currentMin || parseFloat(this.histogram.min.toFixed(2));
         },
         maxVal() {
-            if (this.autoRange) return Math.round(this.fromDistributionPercentage((100 - this.autoRange) / 100));
+            if (!this.histogram) return 1
+            if (this.autoRange !== undefined) return Math.round(this.fromDistributionPercentage((100 - this.autoRange) / 100));
             return this.currentMax || parseFloat(this.histogram.max.toFixed(2));
         }
     },
@@ -229,7 +231,7 @@ module.exports = {
             if (this.currentMax) {
                 newMaxPosition = this.valueToXPosition(this.currentMax);
             }
-            if (this.autoRange) {
+            if (this.autoRange !== undefined) {
                 newMinPosition = this.valueToXPosition(
                     this.fromDistributionPercentage(this.autoRange / 100)
                 );
@@ -268,16 +270,26 @@ module.exports = {
             const moveY = false;
             const handleName = selected.getAttribute('name');
             const newValue = this.xPositionToValue(newLocation.x);
-            if (handleName === 'updateMin') {
-                if (!this.autoRange && newValue >= this.currentMax) {
+            if (handleName === 'min') {
+                if (this.autoRange === undefined && newValue >= this.currentMax) {
                     moveX = false;
-                } else if (this.autoRange && this.toDistributionPercentage(newValue) >= 50) {
+                } else if (this.autoRange !== undefined) {
+                    const percentage = this.toDistributionPercentage(newValue)
+                    if (
+                        percentage >= 50 ||
+                        parseFloat(parseFloat(percentage).toFixed(2)) === this.autoRange
+                    )
                     moveX = false;
                 }
-            } else if (handleName === 'updateMax') {
-                if (!this.autoRange && newValue <= this.currentMin) {
+            } else if (handleName === 'max') {
+                if (this.autoRange === undefined && newValue <= this.currentMin) {
                     moveX = false;
-                } else if (this.autoRange && this.toDistributionPercentage(newValue) <= 50) {
+                } else if (this.autoRange !== undefined) {
+                    const percentage = this.toDistributionPercentage(newValue)
+                    if (
+                        percentage <= 50 ||
+                        parseFloat(parseFloat(100 - percentage).toFixed(2)) === this.autoRange
+                    )
                     moveX = false;
                 }
             }
@@ -352,7 +364,7 @@ module.exports = {
       v-if="histogram"
       type="number"
       class="input-80 min-input"
-      :disabled="autoRange"
+      :disabled="autoRange !== undefined"
       :min="histogram.min"
       :max="currentMax"
       :value="minVal"
@@ -429,7 +441,7 @@ module.exports = {
       v-if="histogram"
       type="number"
       class="input-80 max-input"
-      :disabled="autoRange"
+      :disabled="autoRange !== undefined"
       :max="histogram.max"
       :min="currentMin"
       :value="maxVal"


### PR DESCRIPTION
When using the Histogram Editor within the Frame Selector component, this PR keeps the min and max input boxes visible even when autoRange is enabled (though they are disabled in that case). The min and max inputs show the real values when specifying range with a distribution percentage.

Resolves #1030.

![image](https://github.com/user-attachments/assets/46f386fb-5fa6-4bea-b667-7633b6126030)
