### PR TITLE
Fix Zarr Sink `addTile` when no samples axis is specified

### DIFF
--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -637,6 +637,7 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         axes = [x.lower() for x in axes]
         if axes[-1] != 's':
             axes.append('s')
+            tile = tile[..., np.newaxis]
         if mask is not None and len(axes) - 1 == len(mask.shape):
             mask = mask[:, :, np.newaxis]
         if 'x' not in axes or 'y' not in axes:

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -93,6 +93,15 @@ def testAddTileWithLevel():
     assert arrays.get('1') is None
 
 
+def testNoSamplesAxis(tmp_path):
+    output_file = tmp_path / 'test.tiff'
+    sink = large_image_source_zarr.new()
+    data = np.zeros((4, 1040, 1388))
+    sink.addTile(data, 0, 0, axes=['c', 'y', 'x'])
+    sink.write(output_file)
+    assert sink.metadata.get('bandCount') == 1
+
+
 def testExtraAxis():
     sink = large_image_source_zarr.new()
     sink.addTile(np.random.random((256, 256)), 0, 0, z=1)


### PR DESCRIPTION
Resolves #1804 