### PR TITLE
Fix zarr sink adding an xy axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix an issue with lazy tiles that have non power of two scaling ([#1797](../../pull/1797))
 - Use zarr.empty not np.empty when creating large zarr sinks ([#1801](../../pull/1801))
 - Fix zarr sink addTile when no samples axis is specified ([#1805](../../pull/1805))
+- Fix zarr sink adding an xy axis ([#1807](../../pull/1807))
 
 ## 1.31.0
 

--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -455,7 +455,7 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         self._axisCounts = {}
         for _, k in sorted(
             (-self._axes.get(k, 'tzc'.index(k) if k in 'tzc' else -1), k)
-            for k in self._axes if k not in 'xys'
+            for k in self._axes if k not in {'x', 'y', 's'}
         ):
             self._strides[k] = stride
             self._axisCounts[k] = baseArray.shape[self._axes[k]]

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -110,6 +110,13 @@ def testExtraAxis():
     assert len(metadata.get('frames')) == 2
 
 
+def testXYAxis():
+    sink = large_image_source_zarr.new()
+    sink.addTile(np.random.random((256, 256)), 0, 0, xy=1)
+    metadata = sink.getMetadata()
+    assert metadata['IndexStride']['IndexXY'] == 1
+
+
 @pytest.mark.parametrize('file_type', FILE_TYPES)
 def testCrop(file_type, tmp_path):
     output_file = tmp_path / f'test.{file_type}'


### PR DESCRIPTION
In a check if we were handling the x, y, or s axes, we did the comparison `if axis in 'xys'`, but this succeeds for `xy` (and would have also succeeded for ys and xys).  Use a proper set comparison rather than an implicit set comparison.