### PR TITLE
Fix Zarr Sink adding multiple frame axes

### DIFF
--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -629,7 +629,7 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
 
     def _validateNewTile(self, tile, mask, placement, axes):
         if not isinstance(tile, np.ndarray) or axes is None:
-            axes = 'yxs'
+            axes = self._axes if hasattr(self, '_axes') else 'yxs'
             tile, mode = _imageToNumpy(tile)
         elif not isinstance(axes, str) and not isinstance(axes, list):
             err = 'Invalid type for axes. Must be str or list[str].'

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -117,6 +117,14 @@ def testXYAxis():
     assert metadata['IndexStride']['IndexXY'] == 1
 
 
+def testMultiFrameAxes():
+    sink = large_image_source_zarr.new()
+    sink.addTile(np.random.random((256, 256)), 0, 0, q=1)
+    assert sink.metadata.get('IndexRange') == dict(IndexQ=2)
+    sink.addTile(np.random.random((256, 256)), 0, 0, r=1)
+    assert sink.metadata.get('IndexRange') == dict(IndexQ=2, IndexR=2)
+
+
 @pytest.mark.parametrize('file_type', FILE_TYPES)
 def testCrop(file_type, tmp_path):
     output_file = tmp_path / f'test.{file_type}'


### PR DESCRIPTION
This PR fixes the following reported behavior of the Zarr Sink:

```
>>> import large_image, numpy as np
>>> sink = large_image.new()
>>> sink.addTile(np.random.random((256, 256)), 0, 0, q=1)
>>> sink.metadata['IndexRange']
{'IndexQ': 2}
>>> sink.addTile(np.random.random((256, 256)), 0, 0, r=1)
>>> sink.metadata['IndexRange']
{'IndexR': 2}
>>> # What happened to Q?
```