### PR TITLE
Test reading from lower tile levels in bioformats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Be more specific in casting when converting images via vips ([#1795](../../pull/1795))
 - Improve how ometiff internal metadata is exposed ([#1806](../../pull/1806))
 - Show histogram auto range calculated values ([#1803](../../pull/1803))
+- Test reading from lower tile levels in bioformats ([#1810](../../pull/1810))
 
 ### Bug Fixes
 

--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -419,6 +419,10 @@ class BioformatsFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             lastX, lastY = rdr.getSizeX(), rdr.getSizeY()
             for idx in range(1, self._metadata['seriesCount']):
                 rdr.setSeries(idx)
+                try:
+                    self._bioimage.read(series=idx, rescale=False, XYWH=(0, 0, 1, 1))
+                except Exception:
+                    continue
                 if (rdr.getSizeX() == self._metadata['sizeX'] and
                         rdr.getSizeY() == self._metadata['sizeY'] and
                         rdr.getImageCount() == self._metadata['imageCount']):


### PR DESCRIPTION
One of our test files fails when reading it with bioformats at the low tile levels but succeeds at the higher resolutions.  Do a test while opening such files so that they are read more consistently.