### PR TITLE
Ipyleaflet Region Indicator

### DIFF
--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -350,7 +350,7 @@ class Map:
         return VBox(children)
 
     def add_region_indicator(self):
-        from ipyleaflet import GeomanDrawControl, FullScreenControl, Popup
+        from ipyleaflet import FullScreenControl, GeomanDrawControl, Popup
         from ipywidgets import HTML
 
         metadata = self._metadata
@@ -384,6 +384,7 @@ class Map:
 
         def handle_interaction(**kwargs):
             coords = kwargs.get('coordinates')
+            info = []
             if self._map is None or metadata is None or coords is None:
                 return
             x, y = [coords[1], coords[0]]
@@ -394,14 +395,15 @@ class Map:
                     xmin, xmax = rect_coords[0][0], rect_coords[2][0]
                     ymin, ymax = rect_coords[0][1], rect_coords[1][1]
                     width, height = metadata['sizeX'], metadata['sizeY']
-                    x_label, y_label = 'X', 'Y'
                     if (
                         x >= xmin and x <= xmax and
                         y >= ymin and y <= ymax
                     ):
-                        x0, y0, x1, y1 = None, None, None, None
+                        roi = f'[{xmin:.8g}, {ymin:.8g}, {(xmax - xmin):.8g}, {(ymax - ymin):.8g}]'
                         if transformer is not None:
-                            x_label, y_label = 'Lon', 'Lat'
+                            info.append(f'Lon Range: [{xmin:.8g}, {xmax:.8g}]')
+                            info.append(f'Lat Range: [{ymin:.8g}, {ymax:.8g}]')
+                            info.append(f'Lon/Lat ROI: {roi}')
                             x0, y0 = transformer.transform(xmin, ymin)
                             x1, y1 = transformer.transform(xmax, ymax)
                             bounds = metadata['bounds']
@@ -415,18 +417,14 @@ class Map:
                                       (bounds['ymin'] - bounds['ymax']) *
                                       height) for v in [y1, y0]
                             ]
+                            info.append(f'X/Y ROI: [{x0}, {y0}, {x1 - x0}, {y1 - y0}]')
                         else:
                             xmin, xmax = round(xmin), round(xmax)
                             ymin, ymax = round(height - ymax), round(height - ymin)
-                            x0, y0, x1, y1 = xmin, ymin, xmax, ymax
-                        self.info_label.value = f'<div>Box {x_label} Range: [{xmin}, {xmax}]</div>'
-                        self.info_label.value += f'<div>Box {y_label} Range: [{ymin}, {ymax}]</div>'
-                        if (
-                            x0 >= 0 and y0 >= 0 and
-                            x1 <= width and y1 <= height
-                        ):
-                            roi = [x0, y0, x1 - x0, y1 - y0]
-                            self.info_label.value += f'<div>ROI: {roi}</div>'
+                            info.append(f'X Range: [{xmin:.8g}, {xmax:.8g}]')
+                            info.append(f'Y Range: [{ymin:.8g}, {ymax:.8g}]')
+                            info.append(f'X/Y ROI: {roi}')
+                        self.info_label.value = ''.join(f'<div>{i}</div>' for i in info)
                         popup.open_popup((rect_coords[1][1], (xmax - xmin) / 2 + xmin))
                         if popup not in self._map.layers:
                             self._map.add(popup)

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -350,7 +350,7 @@ class Map:
         return VBox(children)
 
     def add_region_indicator(self):
-        from ipyleaflet import DrawControl, FullScreenControl, Popup
+        from ipyleaflet import GeomanDrawControl, FullScreenControl, Popup
         from ipywidgets import HTML
 
         metadata = self._metadata
@@ -360,7 +360,7 @@ class Map:
         self.info_label = HTML()
         popup = Popup(child=self.info_label)
         popup.close_popup()
-        draw_control = DrawControl(
+        draw_control = GeomanDrawControl(
             rectangle=dict(shapeOptions=dict(color='#19a7ff')),
             # enable drawing other shapes by specifying styling
             polygon=dict(),

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -357,8 +357,8 @@ class Map:
         if self._map is None or metadata is None:
             return
 
-        info_label = HTML()
-        popup = Popup(child=info_label)
+        self.info_label = HTML()
+        popup = Popup(child=self.info_label)
         popup.close_popup()
         draw_control = DrawControl(
             rectangle=dict(shapeOptions=dict(color='#19a7ff')),
@@ -393,6 +393,7 @@ class Map:
                     rect_coords = rectangle.get('geometry', {}).get('coordinates', [[]])[0]
                     xmin, xmax = rect_coords[0][0], rect_coords[2][0]
                     ymin, ymax = rect_coords[0][1], rect_coords[1][1]
+                    width, height = metadata['sizeX'], metadata['sizeY']
                     x_label, y_label = 'X', 'Y'
                     if (
                         x >= xmin and x <= xmax and
@@ -407,26 +408,25 @@ class Map:
                             x0, x1 = [
                                 round((v - bounds['xmin']) /
                                       (bounds['xmax'] - bounds['xmin']) *
-                                      metadata['sizeX']) for v in [x0, x1]
+                                      width) for v in [x0, x1]
                             ]
                             y0, y1 = [
                                 round((v - bounds['ymax']) /
                                       (bounds['ymin'] - bounds['ymax']) *
-                                      metadata['sizeY']) for v in [y1, y0]
+                                      height) for v in [y1, y0]
                             ]
                         else:
                             xmin, xmax = round(xmin), round(xmax)
-                            ymin = round(metadata.get('sizeY') - ymax)
-                            ymax = round(metadata.get('sizeY') - ymin)
+                            ymin, ymax = round(height - ymax), round(height - ymin)
                             x0, y0, x1, y1 = xmin, ymin, xmax, ymax
-                        info_label.value = f'<div>Box {x_label} Range: [{xmin}, {xmax}]</div>'
-                        info_label.value += f'<div>Box {y_label} Range: [{ymin}, {ymax}]</div>'
+                        self.info_label.value = f'<div>Box {x_label} Range: [{xmin}, {xmax}]</div>'
+                        self.info_label.value += f'<div>Box {y_label} Range: [{ymin}, {ymax}]</div>'
                         if (
                             x0 >= 0 and y0 >= 0 and
-                            x1 <= metadata['sizeX'] and y1 <= metadata['sizeY']
+                            x1 <= width and y1 <= height
                         ):
                             roi = [x0, y0, x1 - x0, y1 - y0]
-                            info_label.value += f'<div>ROI: {roi}</div>'
+                            self.info_label.value += f'<div>ROI: {roi}</div>'
                         popup.open_popup((rect_coords[1][1], (xmax - xmin) / 2 + xmin))
                         if popup not in self._map.layers:
                             self._map.add(popup)

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -346,8 +346,9 @@ class Map:
         self._map = m
         children.append(m)
 
-        info_label = HTML(f"{metadata.get('sizeX')}, {metadata.get('sizeY')}")
+        info_label = HTML()
         popup = Popup(child=info_label)
+        popup.close_popup()
         draw_control = DrawControl(
             rectangle=dict(shapeOptions=dict(color='#19a7ff')),
             # enable drawing other shapes by specifying styling
@@ -380,9 +381,7 @@ class Map:
                         info_label.value += f'<div>Mouse X: {round(coords[1])}</div>'
                         info_label.value += f'<div>Mouse Y: {round(metadata.get("sizeY") - coords[0])}</div>'
                         center_x = (x_range[1] - x_range[0]) / 2 + x_range[0]
-                        popup.location = (y_range[1], center_x)
-                        popup.close_popup()
-                        popup.open_popup()
+                        popup.open_popup((y_range[1], center_x))
                         return
             popup.close_popup()
 

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -405,9 +405,9 @@ class Map:
                                       metadata['sizeX']) for v in [x0, x1]
                             ]
                             y0, y1 = [
-                                round((v - bounds['ymin']) /
-                                      (bounds['ymax'] - bounds['ymin']) *
-                                      metadata['sizeY']) for v in [y0, y1]
+                                round((v - bounds['ymax']) /
+                                      (bounds['ymin'] - bounds['ymax']) *
+                                      metadata['sizeY']) for v in [y1, y0]
                             ]
                         else:
                             xmin, xmax = round(xmin), round(xmax)

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -353,6 +353,10 @@ class Map:
         from ipyleaflet import DrawControl, FullScreenControl, Popup
         from ipywidgets import HTML
 
+        metadata = self._metadata
+        if self._map is None or metadata is None:
+            return
+
         info_label = HTML()
         popup = Popup(child=info_label)
         popup.close_popup()
@@ -369,7 +373,6 @@ class Map:
         )
 
         transformer = None
-        metadata = self._metadata
         if metadata.get('geospatial'):
             import pyproj
 
@@ -381,6 +384,8 @@ class Map:
 
         def handle_interaction(**kwargs):
             coords = kwargs.get('coordinates')
+            if self._map is None or metadata is None or coords is None:
+                return
             x, y = [coords[1], coords[0]]
             interaction_type = kwargs.get('type')
             if interaction_type == 'click':

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -278,8 +278,8 @@ class Map:
         Create an ipyleaflet map given large_image metadata, an optional
         ipyleaflet layer, and the center of the tile source.
         """
-        from ipyleaflet import DrawControl, FullScreenControl, Map, Popup, basemaps, projections
-        from ipywidgets import HTML, VBox
+        from ipyleaflet import Map, basemaps, projections
+        from ipywidgets import VBox
 
         try:
             default_zoom = metadata['levels'] - metadata['sourceLevels']
@@ -346,6 +346,13 @@ class Map:
         self._map = m
         children.append(m)
 
+        self.add_region_indicator()
+        return VBox(children)
+
+    def add_region_indicator(self):
+        from ipyleaflet import DrawControl, FullScreenControl, Popup
+        from ipywidgets import HTML
+
         info_label = HTML()
         popup = Popup(child=info_label)
         popup.close_popup()
@@ -362,6 +369,7 @@ class Map:
         )
 
         transformer = None
+        metadata = self._metadata
         if metadata.get('geospatial'):
             import pyproj
 
@@ -415,14 +423,12 @@ class Map:
                             roi = [x0, y0, x1 - x0, y1 - y0]
                             info_label.value += f'<div>ROI: {roi}</div>'
                         popup.open_popup((rect_coords[1][1], (xmax - xmin) / 2 + xmin))
-                        if popup not in m.layers:
-                            m.add(popup)
+                        if popup not in self._map.layers:
+                            self._map.add(popup)
 
-        m.on_interaction(handle_interaction)
-        m.add(draw_control)
-        m.add(FullScreenControl())
-
-        return VBox(children)
+        self._map.on_interaction(handle_interaction)
+        self._map.add(draw_control)
+        self._map.add(FullScreenControl())
 
     @property
     def layer(self) -> Any:

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -395,39 +395,38 @@ class Map:
                     xmin, xmax = rect_coords[0][0], rect_coords[2][0]
                     ymin, ymax = rect_coords[0][1], rect_coords[1][1]
                     width, height = metadata['sizeX'], metadata['sizeY']
-                    if (
-                        x >= xmin and x <= xmax and
-                        y >= ymin and y <= ymax
-                    ):
+                    if (not (x >= xmin and x <= xmax and y >= ymin and y <= ymax)):
+                        return
+                    if transformer is not None:
                         roi = f'[{xmin:.8g}, {ymin:.8g}, {(xmax - xmin):.8g}, {(ymax - ymin):.8g}]'
-                        if transformer is not None:
-                            info.append(f'Lon Range: [{xmin:.8g}, {xmax:.8g}]')
-                            info.append(f'Lat Range: [{ymin:.8g}, {ymax:.8g}]')
-                            info.append(f'Lon/Lat ROI: {roi}')
-                            x0, y0 = transformer.transform(xmin, ymin)
-                            x1, y1 = transformer.transform(xmax, ymax)
-                            bounds = metadata['bounds']
-                            x0, x1 = [
-                                round((v - bounds['xmin']) /
-                                      (bounds['xmax'] - bounds['xmin']) *
-                                      width) for v in [x0, x1]
-                            ]
-                            y0, y1 = [
-                                round((v - bounds['ymax']) /
-                                      (bounds['ymin'] - bounds['ymax']) *
-                                      height) for v in [y1, y0]
-                            ]
-                            info.append(f'X/Y ROI: [{x0}, {y0}, {x1 - x0}, {y1 - y0}]')
-                        else:
-                            xmin, xmax = round(xmin), round(xmax)
-                            ymin, ymax = round(height - ymax), round(height - ymin)
-                            info.append(f'X Range: [{xmin:.8g}, {xmax:.8g}]')
-                            info.append(f'Y Range: [{ymin:.8g}, {ymax:.8g}]')
-                            info.append(f'X/Y ROI: {roi}')
-                        self.info_label.value = ''.join(f'<div>{i}</div>' for i in info)
-                        popup.open_popup((rect_coords[1][1], (xmax - xmin) / 2 + xmin))
-                        if popup not in self._map.layers:
-                            self._map.add(popup)
+                        info.append(f'Lon Range: [{xmin:.8g}, {xmax:.8g}]')
+                        info.append(f'Lat Range: [{ymin:.8g}, {ymax:.8g}]')
+                        info.append(f'Lon/Lat ROI: {roi}')
+                        x0, y0 = transformer.transform(xmin, ymin)
+                        x1, y1 = transformer.transform(xmax, ymax)
+                        bounds = metadata['bounds']
+                        x0, x1 = [
+                            round((v - bounds['xmin']) /
+                                  (bounds['xmax'] - bounds['xmin']) *
+                                  width) for v in [x0, x1]
+                        ]
+                        y0, y1 = [
+                            round((v - bounds['ymax']) /
+                                  (bounds['ymin'] - bounds['ymax']) *
+                                  height) for v in [y1, y0]
+                        ]
+                        info.append(f'X/Y ROI: [{x0}, {y0}, {x1 - x0}, {y1 - y0}]')
+                    else:
+                        xmin, xmax = round(xmin), round(xmax)
+                        ymin, ymax = round(height - ymax), round(height - ymin)
+                        roi = f'[{xmin:.8g}, {ymin:.8g}, {(xmax - xmin):.8g}, {(ymax - ymin):.8g}]'
+                        info.append(f'X Range: [{xmin:.8g}, {xmax:.8g}]')
+                        info.append(f'Y Range: [{ymin:.8g}, {ymax:.8g}]')
+                        info.append(f'X/Y ROI: {roi}')
+                    self.info_label.value = ''.join(f'<div>{i}</div>' for i in info)
+                    popup.open_popup((rect_coords[1][1], (xmax - xmin) / 2 + xmin))
+                    if popup not in self._map.layers:
+                        self._map.add(popup)
 
         def handle_draw(target, action, geo_json):
             if action == 'deleted':

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -426,6 +426,11 @@ class Map:
                         if popup not in self._map.layers:
                             self._map.add(popup)
 
+        def handle_draw(target, action, geo_json):
+            if action == 'deleted':
+                popup.close_popup()
+
+        draw_control.on_draw(handle_draw)
         self._map.on_interaction(handle_interaction)
         self._map.add(draw_control)
         self._map.add(FullScreenControl())

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -373,7 +373,7 @@ class Map:
         )
 
         transformer = None
-        if metadata.get('geospatial'):
+        if metadata.get('geospatial') and metadata.get('projection'):
             import pyproj
 
             transformer = pyproj.Transformer.from_crs(

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -396,7 +396,7 @@ class Map:
                     ymin, ymax = rect_coords[0][1], rect_coords[1][1]
                     width, height = metadata['sizeX'], metadata['sizeY']
                     if (not (x >= xmin and x <= xmax and y >= ymin and y <= ymax)):
-                        return
+                        continue
                     if transformer is not None:
                         roi = f'[{xmin:.8g}, {ymin:.8g}, {(xmax - xmin):.8g}, {(ymax - ymin):.8g}]'
                         info.append(f'Lon Range: [{xmin:.8g}, {xmax:.8g}]')

--- a/test/test_jupyter.py
+++ b/test/test_jupyter.py
@@ -109,9 +109,9 @@ def testJupyterIpyleafletMapRegion():
     height = source.metadata['sizeY']
     xmin, xmax, ymin, ymax = 10, 90, 30, 100
     x, y = 50, 100
-    expected = f'<div>Box X Range: [{xmin}, {xmax}]</div>'
-    expected += f'<div>Box Y Range: [{ymin}, {ymax}]</div>'
-    expected += f'<div>ROI: [{xmin}, {ymin}, {xmax - xmin}, {ymax - ymin}]</div>'
+    expected = [f'X Range: [{xmin}, {xmax}]']
+    expected.append(f'Y Range: [{ymin}, {ymax}]')
+    expected.append(f'X/Y ROI: [{xmin}, {ymin}, {xmax - xmin}, {ymax - ymin}]')
 
     rectangle = [[
         [xmin, height - ymax],
@@ -126,7 +126,7 @@ def testJupyterIpyleafletMapRegion():
             ]
     for callback in m._interaction_callbacks.callbacks:
         callback(type='click', coordinates=[y, x])
-    assert source._map.info_label.value == expected
+    assert source._map.info_label.value == ''.join([f'<div>{e}</div>' for e in expected])
 
 
 def testJupyterIpyleafletMapGeospatialRegion():
@@ -145,9 +145,10 @@ def testJupyterIpyleafletMapGeospatialRegion():
     lonmin, lonmax, latmin, latmax = -118, -116, 32.5, 34
     lon, lat = -117, 33
     roi = [11562, 7156, 52322, 46301]
-    expected = f'<div>Box Lon Range: [{lonmin}, {lonmax}]</div>'
-    expected += f'<div>Box Lat Range: [{latmin}, {latmax}]</div>'
-    expected += f'<div>ROI: {roi}</div>'
+    expected = [f'Lon Range: [{lonmin}, {lonmax}]']
+    expected.append(f'Lat Range: [{latmin}, {latmax}]')
+    expected.append(f'Lon/Lat ROI: [{lonmin}, {latmin}, {lonmax - lonmin}, {latmax - latmin}]')
+    expected.append(f'X/Y ROI: {roi}')
 
     rectangle = [[
         [lonmin, latmin],
@@ -162,4 +163,4 @@ def testJupyterIpyleafletMapGeospatialRegion():
             ]
     for callback in m._interaction_callbacks.callbacks:
         callback(type='click', coordinates=[lat, lon])
-    assert source._map.info_label.value == expected
+    assert source._map.info_label.value == ''.join([f'<div>{e}</div>' for e in expected])

--- a/test/test_jupyter.py
+++ b/test/test_jupyter.py
@@ -94,7 +94,7 @@ async def testJupyterIpyleaflet():
 
 
 def testJupyterIpyleafletMapRegion():
-    from ipyleaflet import DrawControl
+    from ipyleaflet import GeomanDrawControl
 
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'test_orient0.tif')
@@ -120,7 +120,7 @@ def testJupyterIpyleafletMapRegion():
         [xmax, height - ymin],
     ]]
     for control in m.controls:
-        if isinstance(control, DrawControl):
+        if isinstance(control, GeomanDrawControl):
             control.data = [
                 dict(geometry=dict(coordinates=rectangle)),
             ]
@@ -130,7 +130,7 @@ def testJupyterIpyleafletMapRegion():
 
 
 def testJupyterIpyleafletMapGeospatialRegion():
-    from ipyleaflet import DrawControl
+    from ipyleaflet import GeomanDrawControl
 
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
@@ -156,7 +156,7 @@ def testJupyterIpyleafletMapGeospatialRegion():
         [lonmax, latmin],
     ]]
     for control in m.controls:
-        if isinstance(control, DrawControl):
+        if isinstance(control, GeomanDrawControl):
             control.data = [
                 dict(geometry=dict(coordinates=rectangle)),
             ]


### PR DESCRIPTION
This PR adds widgets to the `ipyleaflet` image viewer in Jupyter notebooks. The user may draw (and remove) rectangles on the image. Clicking on the rectangle shows a popup with information about the selected region. This PR also adds a fullscreen view button to the options along the side of the viewer. The following screenshots are captured in fullscreen mode.

Geospatial example:
![image](https://github.com/user-attachments/assets/05004b62-97ff-46a1-9017-455ef04d971e)

Non-geospatial example:
![image](https://github.com/user-attachments/assets/c31b6f73-1529-46ab-af66-023c8532c921)
