### PR TITLE
Apply background color information from openslide sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.31.2
+
+### Improvements
+
+- Apply background color information from openslide sources ([#1819](../../pull/1819))
+
 ## 1.31.1
 
 ### Improvements


### PR DESCRIPTION
openslide can return RGBA tiles with transparent areas and report a background color.  Apply the background color without changing transparency.

Resolves #1814 .