### PR TITLE
Require a minimum version of Pillow to avoid a CVE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Apply background color information from openslide sources ([#1819](../../pull/1819))
 - Memoize a check for DICOM series UID ([#1827](../../pull/1827))
 
+### Changes
+
+- Require a minimum version of Pillow to avoid a CVE ([#1828](../../pull/1828))
+
 ## 1.31.1
 
 ### Improvements

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
     install_requires=[
         'cachetools',
         'palettable',
-        'Pillow',
+        'Pillow>=10.3',
         'numpy',
         'typing-extensions',
     ],


### PR DESCRIPTION
Resolves #1825.