### PR TITLE
Guard the assetstoreImportViewMap update

### DIFF
--- a/sources/dicom/large_image_source_dicom/web_client/views/DICOMwebImportView.js
+++ b/sources/dicom/large_image_source_dicom/web_client/views/DICOMwebImportView.js
@@ -93,6 +93,9 @@ const DICOMwebImportView = View.extend({
     }
 });
 
-assetstoreImportViewMap[AssetstoreType.DICOMWEB] = DICOMwebImportView;
+// This can be null if the base view is not the main Girder application
+if (assetstoreImportViewMap) {
+    assetstoreImportViewMap[AssetstoreType.DICOMWEB] = DICOMwebImportView;
+}
 
 export default DICOMwebImportView;


### PR DESCRIPTION
We can only set the assetstoreImportViewMap if the main Girder application exists.