### PR TITLE
Add `default_encoding` and `default_projection` config values

### DIFF
--- a/docs/config_options.rst
+++ b/docs/config_options.rst
@@ -24,6 +24,18 @@ Some functionality of large_image is controlled through configuration parameters
      - ``logging.Logger``
      - This defaults to the standard python logger using the name large_image. When using Girder, this default to Girder's logger, which allows colored console output.
 
+       .. _config_default_encoding:
+   * - ``default_encoding`` :ref:`🔗 <config_default_encoding>`
+     - Default encoding for tile sources.
+     - ``'JPEG' | 'PNG' | 'TIFF' | 'TILED' | None``
+     - ``None``
+
+       .. _config_default_projection:
+   * - ``default_projection`` :ref:`🔗 <config_default_projection>`
+     - Default projection for geospatial tile sources. Use a proj4 projection string or a case-insensitive string of the form 'EPSG:<epsg number>'.
+     - ``str | None``
+     - ``None``
+
        .. _config_cache_backend:
    * - ``cache_backend`` :ref:`🔗 <config_cache_backend>`
      - String specifying how tiles are cached.  If memcached is not available for any reason, the python cache is used instead.

--- a/large_image/config.py
+++ b/large_image/config.py
@@ -42,6 +42,10 @@ ConfigValues = {
     'logger': fallbackLogger,
     'logprint': fallbackLogger,
 
+    # Encoding and Projection
+    'default_encoding': 'PNG' if _in_notebook() else 'JPEG',
+    'default_projection': 'EPSG:3857' if _in_notebook() else None,
+
     # For tiles
     'cache_backend': None,  # 'python', 'redis' or 'memcached'
     # 'python' cache can use 1/(val) of the available memory

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -72,7 +72,7 @@ class TileSource(IPyLeafletMixin):
     _initValues: Tuple[Tuple[Any, ...], Dict[str, Any]]
     _iccprofilesObjects: List[Any]
 
-    def __init__(self, encoding: str = 'JPEG', jpegQuality: int = 95,
+    def __init__(self, encoding: Optional[str] = None, jpegQuality: int = 95,
                  jpegSubsampling: int = 0, tiffCompression: str = 'raw',
                  edge: Union[bool, str] = False,
                  style: Optional[Union[str, Dict[str, int]]] = None,
@@ -166,6 +166,7 @@ class TileSource(IPyLeafletMixin):
         self._dtype: Optional[Union[npt.DTypeLike, str]] = None
         self._bandCount: Optional[int] = None
 
+        encoding = encoding or config.getConfig('default_encoding')
         if encoding not in TileOutputMimeTypes:
             raise ValueError('Invalid encoding "%s"' % encoding)
 

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -26,6 +26,7 @@ from importlib.metadata import version as _importlib_version
 import numpy as np
 import PIL.Image
 
+from large_image import config
 from large_image.cache_util import LruCacheMetaclass, _cacheClearFuncs, methodcache
 from large_image.constants import (TILE_FORMAT_IMAGE, TILE_FORMAT_NUMPY,
                                    TILE_FORMAT_PIL, SourcePriority,
@@ -140,6 +141,8 @@ class GDALFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass):
         self.tileSize = 256
         self.tileWidth = self.tileSize
         self.tileHeight = self.tileSize
+        if projection is None:
+            projection = config.getConfig('default_projection')
         if projection and projection.lower().startswith('epsg:'):
             projection = projection.lower()
         if projection and not isinstance(projection, bytes):

--- a/sources/mapnik/large_image_source_mapnik/__init__.py
+++ b/sources/mapnik/large_image_source_mapnik/__init__.py
@@ -23,6 +23,7 @@ import PIL.Image
 from large_image_source_gdal import GDALFileTileSource
 from osgeo import gdal, gdalconst
 
+from large_image import config
 from large_image.cache_util import LruCacheMetaclass, methodcache
 from large_image.constants import TILE_FORMAT_PIL, SourcePriority
 from large_image.exceptions import TileSourceError
@@ -93,6 +94,8 @@ class MapnikFileTileSource(GDALFileTileSource, metaclass=LruCacheMetaclass):
             projections that are not latlong (is_geographic is False) must
             specify unitsPerPixel.
         """
+        if projection is None:
+            projection = config.getConfig('default_projection')
         if projection and projection.lower().startswith('epsg'):
             projection = projection.lower()
         super().__init__(

--- a/sources/rasterio/large_image_source_rasterio/__init__.py
+++ b/sources/rasterio/large_image_source_rasterio/__init__.py
@@ -28,6 +28,7 @@ import numpy as np
 import PIL.Image
 
 import large_image
+from large_image import config
 from large_image.cache_util import LruCacheMetaclass, methodcache
 from large_image.constants import (TILE_FORMAT_IMAGE, TILE_FORMAT_NUMPY,
                                    TILE_FORMAT_PIL, SourcePriority,
@@ -142,6 +143,9 @@ class RasterioFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass
         self._bounds = {}
         self.tileWidth = self.tileSize
         self.tileHeight = self.tileSize
+
+        if projection is None:
+            projection = config.getConfig('default_projection')
         self.projection = make_crs(projection) if projection else None
 
         # get width and height parameters


### PR DESCRIPTION
This PR adds two new configuration values `default_encoding` and `default_projection`. These new config values are also added to the "Configuration Options" documentation page. May resolve #1105 and #1106.