### PR TITLE
Conform to a standard SPDX license expression

### DIFF
--- a/.circleci/release_pypi.sh
+++ b/.circleci/release_pypi.sh
@@ -7,8 +7,9 @@ ROOTPATH=`pwd`
 export SETUPTOOLS_SCM_PRETEND_VERSION=`python -m setuptools_scm | sed "s/.* //"`
 if [ ${CIRCLE_BRANCH-:} = "master" ]; then
     export SETUPTOOLS_SCM_PRETEND_VERSION=`echo $SETUPTOOLS_SCM_PRETEND_VERSION | sed "s/\+.*$//"`
-elif [ "${CIRCLE_BRANCH}" == "girder-5" ]; then
-    export SETUPTOOLS_SCM_PRETEND_VERSION=$(python -c "import re; print(re.sub(r'(\d+\.\d+\.\d+)dev(\d+)', r'\1a\2', get_version()))")
+elif [ "${CIRCLE_BRANCH-:}" == "girder-5" ]; then
+    pip install setuptools-scm
+    export SETUPTOOLS_SCM_PRETEND_VERSION=$(python -c "import setuptools_scm,re;print(re.sub(r'(\d+\.\d+\.\d+\.)dev(\d+)(\+.*$)', r'\1a\2', setuptools_scm.get_version()))")
 fi
 
 python setup.py sdist

--- a/girder/pyproject.toml
+++ b/girder/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = ".."

--- a/girder/setup.py
+++ b/girder/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='girder-large-image',
-    use_scm_version={'root': '..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/girder_annotation/pyproject.toml
+++ b/girder_annotation/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = ".."

--- a/girder_annotation/setup.py
+++ b/girder_annotation/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='girder-large-image-annotation',
-    use_scm_version={'root': '..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+
 [tool.ruff]
 include = ["*.py", "*.pyi", "**/pyproject.toml", "*.ipynb"]
 exclude = [

--- a/setup.py
+++ b/setup.py
@@ -69,11 +69,10 @@ extraReqs['common'] = list(set(itertools.chain.from_iterable(extraReqs[key] for 
 
 setup(
     name='large-image',
-    use_scm_version={'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/bioformats/pyproject.toml
+++ b/sources/bioformats/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/bioformats/setup.py
+++ b/sources/bioformats/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-bioformats',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/deepzoom/pyproject.toml
+++ b/sources/deepzoom/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/deepzoom/setup.py
+++ b/sources/deepzoom/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-deepzoom',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/dicom/pyproject.toml
+++ b/sources/dicom/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/dicom/setup.py
+++ b/sources/dicom/setup.py
@@ -35,12 +35,10 @@ if sys.version_info >= (3, 9):
 
 setup(
     name='large-image-source-dicom',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/dummy/pyproject.toml
+++ b/sources/dummy/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/dummy/setup.py
+++ b/sources/dummy/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-dummy',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/gdal/pyproject.toml
+++ b/sources/gdal/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/gdal/setup.py
+++ b/sources/gdal/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-gdal',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/mapnik/pyproject.toml
+++ b/sources/mapnik/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/mapnik/setup.py
+++ b/sources/mapnik/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-mapnik',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/multi/pyproject.toml
+++ b/sources/multi/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/multi/setup.py
+++ b/sources/multi/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-multi',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/nd2/pyproject.toml
+++ b/sources/nd2/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/nd2/setup.py
+++ b/sources/nd2/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-nd2',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/ometiff/pyproject.toml
+++ b/sources/ometiff/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/ometiff/setup.py
+++ b/sources/ometiff/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-ometiff',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/openjpeg/pyproject.toml
+++ b/sources/openjpeg/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/openjpeg/setup.py
+++ b/sources/openjpeg/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-openjpeg',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/openslide/pyproject.toml
+++ b/sources/openslide/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/openslide/setup.py
+++ b/sources/openslide/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-openslide',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/pil/pyproject.toml
+++ b/sources/pil/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/pil/setup.py
+++ b/sources/pil/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-pil',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/rasterio/pyproject.toml
+++ b/sources/rasterio/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/rasterio/setup.py
+++ b/sources/rasterio/setup.py
@@ -16,15 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-rasterio',
-    use_scm_version={
-        'root': '../..',
-
-        'fallback_version': 'development',
-    },
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/test/pyproject.toml
+++ b/sources/test/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/test/setup.py
+++ b/sources/test/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-test',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/tiff/pyproject.toml
+++ b/sources/tiff/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/tiff/setup.py
+++ b/sources/tiff/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-tiff',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/tifffile/pyproject.toml
+++ b/sources/tifffile/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/tifffile/setup.py
+++ b/sources/tifffile/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-tifffile',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/vips/pyproject.toml
+++ b/sources/vips/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/vips/setup.py
+++ b/sources/vips/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-vips',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/sources/zarr/pyproject.toml
+++ b/sources/zarr/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/sources/zarr/setup.py
+++ b/sources/zarr/setup.py
@@ -16,12 +16,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-source-zarr',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware, Inc.',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/utilities/converter/pyproject.toml
+++ b/utilities/converter/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/utilities/converter/setup.py
+++ b/utilities/converter/setup.py
@@ -19,12 +19,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-converter',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware Inc',
     author_email='kitware@kitware.com',
     classifiers=[

--- a/utilities/tasks/pyproject.toml
+++ b/utilities/tasks/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
+root = "../.."

--- a/utilities/tasks/setup.py
+++ b/utilities/tasks/setup.py
@@ -19,12 +19,10 @@ except (ImportError, LookupError):
 
 setup(
     name='large-image-tasks',
-    use_scm_version={'root': '../..',
-                     'fallback_version': '0.0.0'},
     description=description,
     long_description=long_description,
     long_description_content_type='text/x-rst',
-    license='Apache Software License 2.0',
+    license='Apache-2.0',
     author='Kitware Inc',
     author_email='kitware@kitware.com',
     classifiers=[


### PR DESCRIPTION
This also shifts more from setup.py to pyproject.toml to reduce warnings when we publish packages.