### PR TITLE
Allow specifying output path for `getRegion`

### DIFF
--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -2032,7 +2032,7 @@ class TileSource(IPyLeafletMixin):
         if image['mm_x'] and image['mm_y']:
             vimg = vimg.copy(xres=1 / image['mm_x'], yres=1 / image['mm_y'])
 
-        outputPath = kwargs.get('output').get('path')
+        outputPath = kwargs.get('output', {}).get('path')
         if outputPath is not None:
             outputPath = pathlib.Path(outputPath)
             outputPath.parent.mkdir(parents=True, exist_ok=True)

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -2031,8 +2031,15 @@ class TileSource(IPyLeafletMixin):
                 (maxHeight - image['height']) // 2 if not corner else 0)
         if image['mm_x'] and image['mm_y']:
             vimg = vimg.copy(xres=1 / image['mm_x'], yres=1 / image['mm_y'])
-        fd, outputPath = tempfile.mkstemp('.tiff', 'tiledRegion_')
-        os.close(fd)
+
+        outputPath = kwargs.get('output').get('path')
+        if outputPath is not None:
+            outputPath = pathlib.Path(outputPath)
+            outputPath.parent.mkdir(parents=True, exist_ok=True)
+        else:
+            fd, outputPath = tempfile.mkstemp('.tiff', 'tiledRegion_')
+            os.close(fd)
+
         try:
             vimg.write_to_file(outputPath, **convertParams)
             return pathlib.Path(outputPath), TileOutputMimeTypes['TILED']

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -985,7 +985,7 @@ class GDALFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass):
             '-ts', str(int(math.floor(outWidth))), str(int(math.floor(outHeight))),
         ]
 
-        outputPath = kwargs.get('output').get('path')
+        outputPath = kwargs.get('output', {}).get('path')
         if outputPath is not None:
             outputPath = pathlib.Path(outputPath)
             outputPath.parent.mkdir(parents=True, exist_ok=True)

--- a/sources/gdal/large_image_source_gdal/__init__.py
+++ b/sources/gdal/large_image_source_gdal/__init__.py
@@ -985,8 +985,13 @@ class GDALFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass):
             '-ts', str(int(math.floor(outWidth))), str(int(math.floor(outHeight))),
         ]
 
-        fd, outputPath = tempfile.mkstemp('.tiff', 'tiledGeoRegion_')
-        os.close(fd)
+        outputPath = kwargs.get('output').get('path')
+        if outputPath is not None:
+            outputPath = pathlib.Path(outputPath)
+            outputPath.parent.mkdir(parents=True, exist_ok=True)
+        else:
+            fd, outputPath = tempfile.mkstemp('.tiff', 'tiledGeoRegion_')
+            os.close(fd)
         try:
             self.logger.info('Using gdal warp %r', gdalParams)
             ds = gdal.Open(self._largeImagePath, gdalconst.GA_ReadOnly)

--- a/sources/rasterio/large_image_source_rasterio/__init__.py
+++ b/sources/rasterio/large_image_source_rasterio/__init__.py
@@ -986,7 +986,7 @@ class RasterioFileTileSource(GDALBaseFileTileSource, metaclass=LruCacheMetaclass
         width = iterInfo['output']['width']
         height = iterInfo['output']['height']
 
-        outputPath = kwargs.get('output').get('path')
+        outputPath = kwargs.get('output', {}).get('path')
         if outputPath is not None:
             outputPath = pathlib.Path(outputPath)
             outputPath.parent.mkdir(parents=True, exist_ok=True)

--- a/test/test_source_gdal.py
+++ b/test/test_source_gdal.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 from unittest import TestCase
 
 import large_image_source_gdal
@@ -37,21 +36,6 @@ class GDALSourceTests(_GDALBaseSourceTest, TestCase):
         assert tileMetadata['bounds']['ymin'] == pytest.approx(2149548, 1)
         assert '+proj=aea' in tileMetadata['bounds']['srs']
         region.unlink()
-
-    def testGetTiledRegionAsFile(self):
-        imagePath = datastore.fetch('landcover_sample_1000.tif')
-        ts = self.basemodule.open(imagePath)
-        with tempfile.TemporaryDirectory() as temp_dir:
-            resultPath = os.path.join(temp_dir, 'test_files', 'region.tiff')
-            region, _ = ts.getRegion(
-                output=dict(maxWidth=1024, maxHeight=1024, path=resultPath),
-                encoding='TILED',
-            )
-            assert region.exists()
-            assert region.name == 'region.tiff'
-            assert os.path.exists(resultPath)
-            assert os.path.getsize(resultPath) == 152321
-            region.unlink()
 
     def testGetTiledRegion16Bit(self):
         imagePath = datastore.fetch('region_gcp.tiff')

--- a/test/test_source_tiff.py
+++ b/test/test_source_tiff.py
@@ -2,6 +2,7 @@ import io
 import json
 import os
 import struct
+import tempfile
 
 import large_image_source_tiff
 import numpy as np
@@ -511,6 +512,22 @@ def testRegionTiledOutputIsTiled():
     assert tifftools.Tag.StripOffsets.value not in info['ifds'][0]['tags']
     assert tifftools.Tag.TileOffsets.value in info['ifds'][0]['tags']
     os.unlink(image)
+
+
+def testGetTiledRegionAsFile():
+    imagePath = datastore.fetch('sample_image.ptif')
+    ts = large_image_source_tiff.open(imagePath)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        resultPath = os.path.join(temp_dir, 'test_files', 'region.tiff')
+        region, _ = ts.getRegion(
+            output=dict(maxWidth=1024, maxHeight=1024, path=resultPath),
+            encoding='TILED',
+        )
+        large_image_source_tiff.open(str(region))
+        assert region.exists()
+        assert region.name == 'region.tiff'
+        assert os.path.exists(resultPath)
+        region.unlink()
 
 
 def testRegionTiledOutputLetterbox():


### PR DESCRIPTION
When calling `getRegion`, if encoding is "TILED", then the user may also specify an output path for the tiled image. Example:

```
region, _ = ts.getRegion(
   output=dict(maxWidth=1024, maxHeight=1024, path='./path/to/region.tif'),
   encoding='TILED'
)
```

Resolves #682 