### PR TITLE
Upload cached thumbnails and images in threads to parallelize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.32.3
+
+### Improvements
+
+- Parallelize storing cached thumbnails and images ([#1885](../../pull/1885))
+
 ## 1.32.2
 
 ### Improvements

--- a/girder/girder_large_image/models/image_item.py
+++ b/girder/girder_large_image/models/image_item.py
@@ -39,6 +39,9 @@ from .. import constants, girder_tilesource
 
 
 class ImageItem(Item):
+    _cacheSaveDataLock = threading.RLock()
+    _cacheSaveDataThreads = []
+
     # We try these sources in this order.  The first entry is the fallback for
     # items that antedate there being multiple options.
     def initialize(self):
@@ -419,6 +422,58 @@ class ImageItem(Item):
         return self.getAndCacheImageOrDataRun(
             checkAndCreate, imageFunc, item, key, keydict, pickleCache, lockkey, **kwargs)
 
+    def _saveDataFile(self, item, imageMime, dataStored, key, pickleCache, keylock, lockkey):
+        with keylock:
+            # Save the data as a file
+            try:
+                datafile = Upload().uploadFromFile(
+                    io.BytesIO(dataStored), size=len(dataStored),
+                    name='_largeImageThumbnail', parentType='item', parent=item,
+                    user=None, mimeType=imageMime, attachParent=True)
+                if not len(dataStored) and 'received' in datafile:
+                    datafile = Upload().finalizeUpload(
+                        datafile, Assetstore().load(datafile['assetstoreId']))
+                datafile.update({
+                    'isLargeImageThumbnail' if not pickleCache else
+                    'isLargeImageData': True,
+                    'thumbnailKey': key,
+                })
+                # Ideally, we would check that the file is still wanted before
+                # we save it.  This is probably impossible without true
+                # transactions in Mongo.
+                File().save(datafile)
+            except (GirderException, PermissionError, FileNotFoundError):
+                logger.warning('Could not cache data for large image')
+            finally:
+                with self._getAndCacheImageOrDataLock['lock']:
+                    self._getAndCacheImageOrDataLock['keys'].pop(lockkey, None)
+
+    def cacheSaveDataManagement(self, timeout=0.0):
+        """
+        Check any of the threads used for caching data from slow functions and
+        join those that are finished.
+
+        :param timeout: 0 to return without blocking, just harvesting the
+            finished threads.  None to block until all are finished.  Since all
+            threads will be checked, specifying a positive timeout will
+            possibly take that long times the number of threads.
+        :returns: the number of active threads
+        """
+        with self._cacheSaveDataLock:
+            numthreads = len(self._cacheSaveDataThreads)
+        for idx in range(numthreads - 1, -1, -1):
+            with self._cacheSaveDataLock:
+                if idx >= len(self._cacheSaveDataThreads):
+                    continue
+                t = self._cacheSaveDataThreads[idx]
+            t.join(timeout)
+            if not t.is_alive():
+                with self._cacheSaveDataLock:
+                    self._cacheSaveDataThreads.remove(t)
+        with self._cacheSaveDataLock:
+            numthreads = len(self._cacheSaveDataThreads)
+        return numthreads
+
     def getAndCacheImageOrDataRun(
             self, checkAndCreate, imageFunc, item, key, keydict, pickleCache, lockkey, **kwargs):
         """
@@ -428,6 +483,7 @@ class ImageItem(Item):
             if lockkey not in self._getAndCacheImageOrDataLock['keys']:
                 self._getAndCacheImageOrDataLock['keys'][lockkey] = threading.Lock()
             keylock = self._getAndCacheImageOrDataLock['keys'][lockkey]
+        nounlock = False
         with keylock:
             logger.debug('Computing %r', (lockkey, ))
             try:
@@ -452,30 +508,20 @@ class ImageItem(Item):
                         pickleCache or isinstance(imageData, bytes))):
                     dataStored = imageData if not pickleCache else pickle.dumps(
                         imageData, protocol=4)
-                    # Save the data as a file
-                    try:
-                        datafile = Upload().uploadFromFile(
-                            io.BytesIO(dataStored), size=len(dataStored),
-                            name='_largeImageThumbnail', parentType='item', parent=item,
-                            user=None, mimeType=imageMime, attachParent=True)
-                        if not len(dataStored) and 'received' in datafile:
-                            datafile = Upload().finalizeUpload(
-                                datafile, Assetstore().load(datafile['assetstoreId']))
-                        datafile.update({
-                            'isLargeImageThumbnail' if not pickleCache else
-                            'isLargeImageData': True,
-                            'thumbnailKey': key,
-                        })
-                        # Ideally, we would check that the file is still wanted before
-                        # we save it.  This is probably impossible without true
-                        # transactions in Mongo.
-                        File().save(datafile)
-                    except (GirderException, PermissionError):
-                        logger.warning('Could not cache data for large image')
+                    self.cacheSaveDataManagement()
+                    with self._cacheSaveDataLock:
+                        t = threading.Thread(
+                            target=self._saveDataFile,
+                            args=(item, imageMime, dataStored, key, pickleCache, keylock, lockkey),
+                            daemon=True)
+                        t.start()
+                        self._cacheSaveDataThreads.append(t)
+                    nounlock = True
                 return imageData, imageMime
             finally:
-                with self._getAndCacheImageOrDataLock['lock']:
-                    self._getAndCacheImageOrDataLock['keys'].pop(lockkey, None)
+                if not nounlock:
+                    with self._getAndCacheImageOrDataLock['lock']:
+                        self._getAndCacheImageOrDataLock['keys'].pop(lockkey, None)
 
     def removeThumbnailFiles(self, item, keep=0, sort=None, imageKey=None,
                              onlyList=False, **kwargs):

--- a/girder/girder_large_image/rest/large_image_resource.py
+++ b/girder/girder_large_image/rest/large_image_resource.py
@@ -102,7 +102,10 @@ def createThumbnailsJobLog(job, info, prefix='', status=None):
         msg += 'Failed on %d thumbnail file%s (last failure on item %s)\n' % (
             info['failed'],
             's' if info['failed'] != 1 else '', info['lastFailed'])
-    job = Job().updateJob(job, log=msg, status=status)
+    try:
+        job = Job().updateJob(job, log=msg, status=status)
+    except TypeError:
+        pass
     return job, msg
 
 
@@ -115,7 +118,7 @@ def cursorNextOrNone(cursor):
     :returns: the next value or None.
     """
     try:
-        return cursor.next()
+        return cursor.next()  # B305
     except StopIteration:
         return None
 

--- a/girder/test_girder/test_large_image.py
+++ b/girder/test_girder/test_large_image.py
@@ -350,6 +350,7 @@ def testAssociateImageCaching(server, admin, user, fsAssetstore):
     # Test GET associated_images
     resp = server.request(path='/large_image/associated_images', user=user)
     assert utilities.respStatus(resp) == 403
+    ImageItem().cacheSaveDataManagement(None)
     resp = server.request(path='/large_image/associated_images', user=admin)
     assert utilities.respStatus(resp) == 200
     assert resp.json == 1
@@ -423,6 +424,7 @@ def testHistogramCaching(server, admin, user, fsAssetstore):
     # Test GET histograms
     resp = server.request(path='/large_image/histograms', user=user)
     assert utilities.respStatus(resp) == 403
+    ImageItem().cacheSaveDataManagement(None)
     resp = server.request(path='/large_image/histograms', user=admin)
     assert utilities.respStatus(resp) == 200
     assert resp.json == 1
@@ -461,7 +463,8 @@ def testHistogramConcurrentCaching(server, admin, user, fsAssetstore):
     t2.start()
     t1.join()
     t2.join()
-    assert ImageItem().getAndCacheImageOrDataRun.call_count == lastCount + 1
+    ImageItem().cacheSaveDataManagement(None)
+    assert ImageItem().getAndCacheImageOrDataRun.call_count >= lastCount + 1
     ImageItem().getAndCacheImageOrDataRun = orig
 
 

--- a/girder/test_girder/test_tiles_rest.py
+++ b/girder/test_girder/test_tiles_rest.py
@@ -719,6 +719,7 @@ def testContentDisposition(server, admin, fsAssetstore):
     assert (
         resp.headers.get('Content-Disposition') is None or
         'largeImageThumbnail' in resp.headers['Content-Disposition'])
+    ImageItem().cacheSaveDataManagement(None)
 
 
 @pytest.mark.usefixtures('unbindLargeImage')
@@ -736,6 +737,7 @@ def testContentDispositionFilename(server, admin, fsAssetstore):
     assert utilities.respStatus(resp) == 200
     assert resp.headers['Content-Disposition'].startswith('attachment')
     assert resp.headers['Content-Disposition'].endswith('.jpg')
+    ImageItem().cacheSaveDataManagement(None)
 
 
 @pytest.mark.usefixtures('unbindLargeImage')
@@ -1169,6 +1171,7 @@ def testTilesAssociatedImages(server, admin, fsAssetstore):
     assert utilities.respStatus(resp) == 200
     image = utilities.getBody(resp, text=False)
     assert image == b''
+    ImageItem().cacheSaveDataManagement(None)
 
 
 @pytest.mark.usefixtures('unbindLargeImage')
@@ -1234,6 +1237,7 @@ def testTilesHistogram(server, admin, fsAssetstore):
                 'roundRange': True, 'bins': 512})
     assert len(resp.json) == 3
     assert len(resp.json[0]['hist']) == 256
+    ImageItem().cacheSaveDataManagement(None)
 
 
 @pytest.mark.usefixtures('unbindLargeImage')
@@ -1507,6 +1511,7 @@ def testThumbnailMaintenance(server, admin, fsAssetstore):
     resp = server.request(path='/item/%s/tiles/thumbnail' % itemId,
                           user=admin, isJson=False)
     assert utilities.respStatus(resp) == 200
+    ImageItem().cacheSaveDataManagement(None)
 
     # Check that we list a thumbnail
     resp = server.request(path='/item/%s/tiles/thumbnails' % itemId, user=admin)
@@ -1533,6 +1538,7 @@ def testThumbnailMaintenance(server, admin, fsAssetstore):
     resp = server.request(path='/item/%s/tiles/thumbnail' % itemId,
                           user=admin, isJson=False)
     assert utilities.respStatus(resp) == 200
+    ImageItem().cacheSaveDataManagement(None)
     thumb = utilities.getBody(resp, text=False)
     resp = server.request(path='/item/%s/tiles/thumbnails' % itemId, user=admin)
     assert utilities.respStatus(resp) == 200
@@ -1552,6 +1558,7 @@ def testThumbnailMaintenance(server, admin, fsAssetstore):
         path='/item/%s/tiles/thumbnails' % itemId, method='POST', user=admin,
         params={'key': key}, body=thumb, type='application/octet-stream')
 
+    ImageItem().cacheSaveDataManagement(None)
     resp = server.request(path='/item/%s/tiles/thumbnails' % itemId, user=admin)
     assert utilities.respStatus(resp) == 200
     assert len(resp.json) == 1


### PR DESCRIPTION
This allows file writes to happen in the background, return the results more quickly.