### PR TITLE
Fix an order of operations issue with config values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.32.2
+
+### Bug Fixes
+
+- Fix an order of operations issue with config values ([#1886](../../pull/1886))
+
 ## 1.32.1
 
 ### Improvements

--- a/sources/bioformats/large_image_source_bioformats/__init__.py
+++ b/sources/bioformats/large_image_source_bioformats/__init__.py
@@ -62,7 +62,9 @@ _openImages = []
 
 
 # Default to ignoring files with no extension and some specific extensions.
-config.ConfigValues['source_bioformats_ignored_names'] = r'(^[^.]*|\.(jpg|jpeg|jpe|png|tif|tiff|ndpi|nd2|ome|nc|json|geojson|fits|isyntax|mrxs|zip|zarr(\.db|\.zip)))$'  # noqa
+config.ConfigValues.setdefault(
+    'source_bioformats_ignored_names',
+    r'(^[^.]*|\.(jpg|jpeg|jpe|png|tif|tiff|ndpi|nd2|ome|nc|json|geojson|fits|isyntax|mrxs|zip|zarr(\.db|\.zip)))$')  # noqa
 
 
 def _monitor_thread():

--- a/sources/pil/large_image_source_pil/__init__.py
+++ b/sources/pil/large_image_source_pil/__init__.py
@@ -60,8 +60,8 @@ except PackageNotFoundError:
 warnings.filterwarnings('ignore', category=UserWarning, module='.*PIL.*')
 
 # Default to ignoring files with some specific extensions.
-config.ConfigValues['source_pil_ignored_names'] = \
-    r'(\.mrxs|\.vsi)$'
+config.ConfigValues.setdefault(
+    'source_pil_ignored_names', r'(\.mrxs|\.vsi)$')
 
 
 def getMaxSize(size=None, maxDefault=4096):

--- a/sources/vips/large_image_source_vips/__init__.py
+++ b/sources/vips/large_image_source_vips/__init__.py
@@ -21,8 +21,8 @@ from large_image.tilesource.utilities import _imageToNumpy, _newFromFileLock, ne
 logging.getLogger('pyvips').setLevel(logging.ERROR)
 
 # Default to ignoring files with no extension and some specific extensions.
-config.ConfigValues['source_vips_ignored_names'] = \
-    r'(^[^.]*|\.(yml|yaml|json|png|svs|mrxs))$'
+config.ConfigValues.setdefault(
+    'source_vips_ignored_names', r'(^[^.]*|\.(yml|yaml|json|png|svs|mrxs))$')
 
 
 def _clearVipsCache():


### PR DESCRIPTION
If you called setConfig before loading sources, the sources' additional config values (such as ignored names) could overwrite the explicit settings.  This could happen in the girder context when getting config values from a girder config file.