### PR TITLE
Fix Frame Selector component in Colab Notebooks

### DIFF
--- a/docs/notebooks/frame_viewer_example.ipynb
+++ b/docs/notebooks/frame_viewer_example.ipynb
@@ -36,7 +36,7 @@
     }
    ],
    "source": [
-    "!pip install large_image[tiff] 'ipyleaflet>=0.19' 'numpy<2' 'ipywidgets<8' ipyvue --find-links=https://girder.github.io/large_image_wheel"
+    "!pip install large_image[tiff] 'ipyleaflet>=0.19' ipyvue --find-links=https://girder.github.io/large_image_wheels"
    ]
   },
   {

--- a/docs/notebooks/frame_viewer_example.ipynb
+++ b/docs/notebooks/frame_viewer_example.ipynb
@@ -32,13 +32,11 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-     ]
+     "text": []
     }
    ],
    "source": [
-    "# We just ask for the tifffile source; the tiff source might be faster, but isn't available on as many platforms\n",
-    "!pip install large_image[tifffile] 'ipyleaflet>=0.19'"
+    "!pip install large_image[tiff] 'ipyleaflet>=0.19' 'numpy<2' 'ipywidgets<8' ipyvue --find-links=https://girder.github.io/large_image_wheel"
    ]
   },
   {

--- a/large_image/config.py
+++ b/large_image/config.py
@@ -29,14 +29,7 @@ def _in_notebook() -> bool:
     :returns: True if we think we are in an interactive notebook.
     """
     try:
-        shell = get_ipython().__class__.__name__  # type: ignore[name-defined]
-        # Jupyter
-        if shell == 'ZMQInteractiveShell':
-            return True
-        # Google Colab
-        if shell == 'Shell':
-            return True
-        return False
+        return get_ipython() is not None
     except NameError:
         return False
 

--- a/large_image/config.py
+++ b/large_image/config.py
@@ -24,7 +24,7 @@ fallbackLogger.addHandler(fallbackLogHandler)
 
 def _in_notebook() -> bool:
     """
-    Try to detect if we are in an interactvie notebook.
+    Try to detect if we are in an interactive notebook.
 
     :returns: True if we think we are in an interactive notebook.
     """
@@ -32,6 +32,9 @@ def _in_notebook() -> bool:
         shell = get_ipython().__class__.__name__  # type: ignore[name-defined]
         # Jupyter
         if shell == 'ZMQInteractiveShell':
+            return True
+        # Google Colab
+        if shell == 'Shell':
             return True
         return False
     except NameError:

--- a/large_image/config.py
+++ b/large_image/config.py
@@ -29,7 +29,7 @@ def _in_notebook() -> bool:
     :returns: True if we think we are in an interactive notebook.
     """
     try:
-        return get_ipython() is not None
+        return get_ipython() is not None  # type: ignore[name-defined]
     except NameError:
         return False
 

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -27,7 +27,7 @@ from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunparse
 import numpy as np
 
 import large_image
-from large_image.exceptions import TileSourceXYZRangeError, TileSourceError
+from large_image.exceptions import TileSourceError, TileSourceXYZRangeError
 from large_image.tilesource.utilities import JSONDict
 
 ipyleafletPresent = importlib.util.find_spec('ipyleaflet') is not None

--- a/large_image/tilesource/jupyter.py
+++ b/large_image/tilesource/jupyter.py
@@ -27,7 +27,7 @@ from urllib.parse import parse_qs, quote, urlencode, urlparse, urlunparse
 import numpy as np
 
 import large_image
-from large_image.exceptions import TileSourceXYZRangeError
+from large_image.exceptions import TileSourceXYZRangeError, TileSourceError
 from large_image.tilesource.utilities import JSONDict
 
 ipyleafletPresent = importlib.util.find_spec('ipyleaflet') is not None
@@ -98,6 +98,10 @@ class IPyLeafletMixin:
 
     def as_leaflet_layer(self, **kwargs) -> Any:
         # NOTE: `as_leaflet_layer` is supported by ipyleaflet.Map.add
+
+        if not getattr(self, '_noCache', False):
+            msg = 'Cannot set the style of a cached source'
+            raise TileSourceError(msg)
 
         if self._jupyter_server_manager is None:
             # Must relaunch to ensure style updates work

--- a/large_image/widgets/CompositeLayers.vue
+++ b/large_image/widgets/CompositeLayers.vue
@@ -504,14 +504,14 @@ module.exports = {
     cursor: pointer;
 }
 .picker{
-    background-color: white;
+    background-color: transparent;
     border: none;
     width: 100%
 }
 .table-header {
     position: sticky;
     top: 0px;
-    background-color: white;
+    background-color: transparent;
     z-index: 2;
     border-bottom: 3px solid !important;
 }

--- a/large_image/widgets/components.py
+++ b/large_image/widgets/components.py
@@ -6,13 +6,14 @@ import ipyvue
 import traitlets
 
 parent = Path(__file__).parent
-colors_file = parent / 'colors.json'
-with open(colors_file) as f:
+with open(parent / 'colors.json') as f:
     colors_data = json.load(f)
-
-ipyvue.register_component_from_file(None, 'dual-input', parent / 'DualInput.vue')
-ipyvue.register_component_from_file(None, 'composite-layers', parent / 'CompositeLayers.vue')
-ipyvue.register_component_from_file(None, 'histogram-editor', parent / 'HistogramEditor.vue')
+with open(parent / 'DualInput.vue') as f:
+    dual_input = f.read()
+with open(parent / 'CompositeLayers.vue') as f:
+    composite_layers = f.read()
+with open(parent / 'HistogramEditor.vue') as f:
+    histogram_editor = f.read()
 
 
 class FrameSelector(ipyvue.VueTemplate):  # type: ignore
@@ -26,6 +27,12 @@ class FrameSelector(ipyvue.VueTemplate):  # type: ignore
 
     updateFrameCallback: Union[Callable, None] = None
     getFrameHistogram: Union[Callable, None] = None
+
+    components = traitlets.Dict({
+        'dual-input': dual_input,
+        'composite-layers': composite_layers,
+        'histogram-editor': histogram_editor,
+    }).tag(sync=True)
 
     def vue_frameUpdate(self, data=None):
         frame = int(data.get('frame', 0))

--- a/large_image/widgets/components.py
+++ b/large_image/widgets/components.py
@@ -28,6 +28,8 @@ class FrameSelector(ipyvue.VueTemplate):  # type: ignore
     updateFrameCallback: Union[Callable, None] = None
     getFrameHistogram: Union[Callable, None] = None
 
+    # register_component_from_file function does not work in Google Colab;
+    # register child components from strings instead
     components = traitlets.Dict({
         'dual-input': dual_input,
         'composite-layers': composite_layers,

--- a/test/test_jupyter.py
+++ b/test/test_jupyter.py
@@ -18,7 +18,7 @@ except ImportError:  # pragma: no cover
 def testJupyterIpyleafletGeospatial():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
-    source = large_image.open(imagePath, projection='EPSG:3857')
+    source = large_image.open(imagePath, projection='EPSG:3857', noCache=True)
     assert source.geospatial
     assert source.projection
     source._ipython_display_()  # smoke test
@@ -32,7 +32,7 @@ def testJupyterIpyleafletGeospatial():
 async def testJupyterIpyleafletMultiFrame():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'multi_channels.yml')
-    source = large_image.open(imagePath, projection='EPSG:3857')
+    source = large_image.open(imagePath, projection='EPSG:3857', noCache=True)
     assert source.frames
 
     # get display in same method as _ipython_display_
@@ -76,7 +76,7 @@ async def testJupyterIpyleafletMultiFrame():
 async def testJupyterIpyleaflet():
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'test_orient0.tif')
-    source = large_image.open(imagePath)
+    source = large_image.open(imagePath, noCache=True)
     source._ipython_display_()  # smoke test
     port = source._jupyter_server_manager.port
 
@@ -98,7 +98,7 @@ def testJupyterIpyleafletMapRegion():
 
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'test_orient0.tif')
-    source = large_image.open(imagePath)
+    source = large_image.open(imagePath, noCache=True)
     display = source._map.make_map(
         source.metadata, source.as_leaflet_layer(), source.getCenter(srs='EPSG:4326'),
     )
@@ -134,7 +134,7 @@ def testJupyterIpyleafletMapGeospatialRegion():
 
     testDir = os.path.dirname(os.path.realpath(__file__))
     imagePath = os.path.join(testDir, 'test_files', 'rgb_geotiff.tiff')
-    source = large_image.open(imagePath, projection='EPSG:3857')
+    source = large_image.open(imagePath, projection='EPSG:3857', noCache=True)
     display = source._map.make_map(
         source.metadata, source.as_leaflet_layer(), source.getCenter(srs='EPSG:4326'),
     )


### PR DESCRIPTION
Resolves #1883 

- 500 errors from the tile server were raised due to `'Cannot set the style of a cached source'`
    - Updated `_in_notebook` to expect Colab's shell name
    - Added an exception to warn the user that caching is enabled prior to displaying the interactive viewer
- Child components of Frame Selector did not render because ipyvue's `register_component_from_file` doesn't work in Colab context
    - Refactored to register child components from strings read from files
- Use `tiff` source instead of `tifffile` source
- Add `ipyvue` installation