### PR TITLE
Exclude commonly used virtual envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -372,6 +372,8 @@ max-complexity = 14
 exclude =
   build
   docs
+  .venv
+  .direnv
   */web_client/*
   */*egg*/*
 # Ignore missing docstring errors.


### PR DESCRIPTION
Updates flake8 to exclude commonly used virtual environments