### PR TITLE
Put back some of the locking in bioformats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-- Change where locking occurs with bioformats ([#1896](../../pull/1896))
+- Change where locking occurs with bioformats ([#1896](../../pull/1896), [#1897](../../pull/1897))
 
 ## 1.32.3
 


### PR DESCRIPTION
Bioformats is less thread safe than desired.  Put back some of the locking.  This is still marginally faster that before the locking changes, but doesn't benefit from multiprocessing.