### PR TITLE
vips could use too much memory during image conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 ### Improvements
 
 - Zarr sink: Set projection and GCPs ([#1882](../../pull/1882))
+- Debounce frame update in FrameSelector in jupyter widget ([#1894](../../pull/1894))
 
 ### Bug Fixes
 
-- Change where locking occurs with bioformats ([#1896](../../pull/1896), [#1897](../../pull/1897))
+- Change where locking occurs with bioformats ([#1896](../../pull/1896), [#1898](../../pull/1898))
+- vips could use too much memory during image conversion ([#1899](../../pull/1899))
 
 ## 1.32.3
 

--- a/utilities/converter/large_image_converter/__init__.py
+++ b/utilities/converter/large_image_converter/__init__.py
@@ -573,6 +573,14 @@ def _convert_large_image_frame(
     maxbands = max(strip.bands for strip in strips)
     if minbands != maxbands:
         strips = [strip[:minbands] for strip in strips]
+    # Persist the strips to temp files to build them into single objects;
+    # otherwise vips will use arbitrarily large amounts of memory
+    for sidx in range(len(strips)):
+        _pool_log(len(strips) - sidx, len(strips), 'resolving strips')
+        strip = strips[sidx]
+        vimgTemp = pyvips.Image.new_temp_file('%s.v')
+        strip.write(vimgTemp)
+        strips[sidx] = vimgTemp
     img = strips[0]
     for stripidx in range(1, len(strips)):
         img = img.insert(strips[stripidx], 0, stripidx * _iterTileSize, expand=True)


### PR DESCRIPTION
When we convert an image via vips, we collect tiled regions into strips and then strips into a file image.  This is done because vips won't handle more than some number of actions in its action list, but can handle a tree of actions (each tile add being an action).  However, vips appears to read most of the strips into memory as it goes in this memory model.  If we save each strip as a vips temp file, we have more disk access, but avoid the memory spike.