### PR TITLE
PATCH annotation/{id} endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.32.5
 
+### Improvements
+
+- Add a PATCH annotation endpoint ([#1904](../../pull/1904))
+
 ### Bug Fixes
 
 - Always use api root where appropriate ([#1902](../../pull/1902))

--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -903,7 +903,7 @@ class Annotation(AccessControlledModel):
             expires=datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=1))
         return result
 
-    def save(self, annotation, *args, **kwargs):
+    def save(self, annotation, *args, **kwargs):  # noqa
         """
         When saving an annotation, override the collection insert_one and
         replace_one methods so that we don't save the elements with the main
@@ -940,6 +940,9 @@ class Annotation(AccessControlledModel):
         _elementQuery = annotation.pop('_elementQuery', None)
         annotation.pop('_active', None)
         annotation.pop('_annotationId', None)
+        if annotation['annotation'] and not annotation['annotation'].get('name'):
+            now = datetime.datetime.now(datetime.timezone.utc)
+            annotation['annotation']['name'] = now.strftime('Annotation %Y-%m-%d %H:%M')
 
         def replaceElements(query, doc, *args, **kwargs):
             Annotationelement().updateElements(doc)

--- a/girder_annotation/girder_large_image_annotation/rest/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/rest/annotation.py
@@ -53,6 +53,7 @@ class AnnotationResource(Resource):
         self.route('GET', (':id',), self.getAnnotation)
         self.route('GET', (':id', ':format'), self.getAnnotationWithFormat)
         self.route('PUT', (':id',), self.updateAnnotation)
+        self.route('PATCH', (':id',), self.patchAnnotation)
         self.route('DELETE', (':id',), self.deleteAnnotation)
         self.route('GET', (':id', 'access'), self.getAnnotationAccess)
         self.route('PUT', (':id', 'access'), self.updateAnnotationAccess)
@@ -393,6 +394,130 @@ class AnnotationResource(Resource):
         if not returnElements and 'elements' in annotation['annotation']:
             del annotation['annotation']['elements']
         return annotation
+
+    def _patchElement(self, elements, fullpath, op, value, elementdict):
+        logger.debug('Patch element %s %s', op, fullpath)
+        elpath = fullpath.split(':', 1)[1]
+        if 'empty' in elementdict:
+            elementdict.pop('empty')
+            for el in elements:
+                elementdict[el['id']] = el
+        if '/' in elpath:
+            return self._patchEntry(elementdict, elpath, op, value, fullpath)
+        elid = elpath.split('/', 1)[0].lower()
+        if op == 'add' and elid in elementdict:
+            msg = f'Cannot add element {elid} as it already exists'
+            raise ValidationException(msg)
+        if op == 'remove':
+            elementdict.pop(elid, None)
+        else:
+            value['id'] = elid
+            elementdict[elid] = value
+
+    def _patchEntry(self, record, path, op, value, fullpath=None):
+        logger.debug('Patch entry %s %s', op, path)
+        if fullpath is None:
+            fullpath = path
+        basepath, key = path.split('/', 1)
+        if isinstance(record, list):
+            record = record[int(basepath)]
+        else:
+            record = record[basepath]
+        if '/' in key:
+            return self._patchEntry(record, key, op, value, fullpath)
+        if isinstance(record, list):
+            idx = int(key)
+            if op == 'remove':
+                record[idx:idx + 1] = []
+            elif idx == len(record):
+                record.append(value)
+            elif idx < len(record) and op == 'replace':
+                record[idx] = value
+            else:
+                msg = f'Cannot {op} {fullpath}'
+                raise ValidationException(msg)
+        else:
+            if op != 'remove':
+                if op == 'add' and record[basepath][key]:
+                    msg = f'Cannot add {fullpath} as it already exists'
+                    raise ValidationException(msg)
+                record[key] = value
+            else:
+                record.pop(key, None)
+
+    def _patchAnnotation(self, annotation, patchlist):
+        """
+        Apply a patch list to an annotation.
+
+        :param annotation: an annotation doc.
+        :param patchlist: a patch list.
+        """
+        logger.debug('Patch annotation %r', annotation['_id'])
+        elementdict = {'empty': True}
+        for patch in patchlist:
+            if 'op' not in patch or 'path' not in patch:
+                msg = 'patch missing op or path'
+                raise ValidationException(msg)
+            op = patch['op']
+            path = patch['path'].strip('/')
+            value = patch.get('value')
+            if op not in {'add', 'replace', 'remove'} or value is None and op != 'remove':
+                msg = 'patch has invalid op'
+                raise ValidationException(msg)
+            try:
+                if path.startswith('elements/id:'):
+                    self._patchElement(
+                        annotation['annotation']['elements'], path, op, value, elementdict)
+                elif '/' not in path and path != 'elements':
+                    if op != 'remove':
+                        if op == 'add' and annotation['annotation'][path]:
+                            msg = f'Cannot add {path} as it already exists'
+                            raise ValidationException(msg)
+                        annotation['annotation'][path] = value
+                    else:
+                        annotation['annotation'].pop(path, None)
+                elif not path.startswith('elements/'):
+                    self._patchEntry(annotation['annotation'], path, op, value)
+                else:
+                    msg = f'patch path {path} is not handled'
+                    raise ValidationException(msg)
+            except (KeyError, ValueError, TypeError):
+                msg = f'patch path {path} does not exist'
+                raise ValidationException(msg)
+        if 'empty' not in elementdict:
+            annotation['annotation']['elements'] = list(elementdict.values())
+        return annotation
+
+    @describeRoute(
+        Description('Patch an annotation or its elements.')
+        .param('id', 'The ID of the annotation.', paramType='path')
+        .param('body', 'A JSON object containing the annotation patch.  This '
+               'is a list.  Each entry is an operation that contains "op", '
+               '"path", and possibly "value".  "op" can be any of "replace", '
+               '"add", or "remove".  "path" is either a root property (e.g., '
+               '"name"), or "elements/id:{element id}".  Any path to a '
+               'dictionary or list can be extended via .../(key or index) '
+               'components.  Add and replace operations must include the '
+               'value.',
+               paramType='body', required=True)
+        # This isn't an error, but girder's swagger wrapper only exposes this
+        # method to add to possible responses
+        .errorResponse('No Content; the annotation was successfully updated '
+                       'but is not returned', 204)
+        .errorResponse('Write access was denied for the item.', 403)
+        .errorResponse('Invalid JSON passed in request body.')
+        .errorResponse("Validation Error: JSON doesn't follow schema."),
+    )
+    @access.user(scope=TokenScope.DATA_WRITE)
+    @loadmodel(model='annotation', plugin='large_image', level=AccessType.WRITE)
+    def patchAnnotation(self, annotation, params):
+        setResponseTimeLimit(86400)
+        user = self.getCurrentUser()
+        patchlist = self.getBodyJson()
+        annotation = self._patchAnnotation(annotation, patchlist)
+        annotation = Annotation().updateAnnotation(annotation, updateUser=user)
+        cherrypy.response.status = 204
+        return ''
 
     @describeRoute(
         Description('Delete an annotation.')

--- a/girder_annotation/test_annotation/test_annotations.py
+++ b/girder_annotation/test_annotation/test_annotations.py
@@ -51,6 +51,34 @@ sampleAnnotationWithMetadata = {
         'height': 15.0,
     }],
 }
+sampleAnnotationWithPointsAndMetadata = {
+    'name': 'sample',
+    'attributes': {
+        'key1': 'value1',
+    },
+    'elements': [{
+        'lineColor': 'rgb(255, 0, 0)',
+        'fillColor': 'rgba(255, 0, 0, 0.25)',
+        'type': 'point',
+        'center': [25608, 21928, 0],
+        'id': '0123456789abcdef01234560',
+        'group': 'Red',
+    }, {
+        'lineColor': 'rgb(255, 0, 0)',
+        'fillColor': 'rgba(255, 0, 0, 0.25)',
+        'type': 'point',
+        'center': [19259, 20750, 0],
+        'id': '0123456789abcdef01234561',
+        'group': 'Red',
+    }, {
+        'lineColor': 'rgb(255, 0, 0)',
+        'fillColor': 'rgba(255, 0, 0, 0.25)',
+        'type': 'point',
+        'center': [16652, 25502, 0],
+        'id': '0123456789abcdef01234562',
+        'group': 'Red',
+    }],
+}
 
 
 def makeLargeSampleAnnotation():


### PR DESCRIPTION
This modifies an existing annotation via a list of patch instructions.  Each entry is an operation that contains "op", "path", and possibly "value".  "op" can be any of "replace", "add", or "remove".  "path" is either a root property (e.g., "name"), or "elements/id:{element id}".  Any path to a dictionary or list can be extended via .../(key or index) components.