### PR TITLE
Add an option to merge dicom files in the same series and study

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Add a PATCH annotation endpoint ([#1904](../../pull/1904))
+- Add an option to merge dicom files in the same series and study and folder ([#1912](../../pull/1912))
 
 ### Changes
 

--- a/girder/girder_large_image/__init__.py
+++ b/girder/girder_large_image/__init__.py
@@ -174,6 +174,42 @@ def _updateJob(event):
                      datetime.timedelta(seconds=30)))
 
 
+def checkForMergeDicom(item):
+    item = ImageItem().load(item['_id'], force=True)
+    if item['largeImage']['sourceName'] not in {'dicom', 'openslide'}:
+        return
+    if len(list(Item().childFiles(item=item, limit=2))) != 1:
+        return
+    intMetadata = ImageItem().getInternalMetadata(item)
+    try:
+        seriesUID = (
+            intMetadata['openslide']['dicom.SeriesInstanceUID']
+            if 'openslide' in intMetadata else
+            intMetadata['dicom']['SeriesInstanceUID'])
+        studyUID = (
+            intMetadata['openslide']['dicom.StudyInstanceUID']
+            if 'openslide' in intMetadata else
+            intMetadata['dicom']['StudyInstanceUID'])
+    except Exception:
+        return
+    base = list(Item().find({
+        'folderId': item['folderId'],
+        'largeImage.dicomSeriesUID': seriesUID,
+        'largeImage.dicomStudyUID': studyUID}, limit=2))
+    if len(base) > 1:
+        return
+    if len(base) == 0:
+        item['largeImage']['dicomSeriesUID'] = seriesUID
+        item['largeImage']['dicomStudyUID'] = studyUID
+        ImageItem().save(item)
+        return
+    file = File().load(item['largeImage']['fileId'], force=True)
+    girder.logger.info(f'Merging dicom file {str(file["_id"])} to item {str(base[0]["_id"])}')
+    file['itemId'] = base[0]['_id']
+    File().save(file)
+    Item().remove(item)
+
+
 def checkForLargeImageFiles(event):  # noqa
     file = event.info
     if 'file.save' in event.name and 's3FinalizeRequest' in file:
@@ -196,6 +232,11 @@ def checkForLargeImageFiles(event):  # noqa
         return
     try:
         ImageItem().createImageItem(item, file, createJob=False)
+        if Setting().get(constants.PluginSettings.LARGE_IMAGE_MERGE_DICOM):
+            try:
+                checkForMergeDicom(item)
+            except Exception:
+                girder.logger.exception('Failed to check for DICOM')
         return
     except Exception:
         pass
@@ -653,6 +694,7 @@ def yamlConfigFileWrite(folder, name, user, yaml_config, user_context):
     constants.PluginSettings.LARGE_IMAGE_SHOW_THUMBNAILS,
     constants.PluginSettings.LARGE_IMAGE_SHOW_VIEWER,
     constants.PluginSettings.LARGE_IMAGE_NOTIFICATION_STREAM_FALLBACK,
+    constants.PluginSettings.LARGE_IMAGE_MERGE_DICOM,
 })
 def validateBoolean(doc):
     val = doc['value']
@@ -755,6 +797,7 @@ SettingDefault.defaults.update({
     constants.PluginSettings.LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE: 4096,
     constants.PluginSettings.LARGE_IMAGE_NOTIFICATION_STREAM_FALLBACK: True,
     constants.PluginSettings.LARGE_IMAGE_ICC_CORRECTION: True,
+    constants.PluginSettings.LARGE_IMAGE_MERGE_DICOM: False,
 })
 
 

--- a/girder/girder_large_image/constants.py
+++ b/girder/girder_large_image/constants.py
@@ -23,6 +23,7 @@ class PluginSettings:
     LARGE_IMAGE_ICC_CORRECTION = 'large_image.icc_correction'
     LARGE_IMAGE_MAX_SMALL_IMAGE_SIZE = 'large_image.max_small_image_size'
     LARGE_IMAGE_MAX_THUMBNAIL_FILES = 'large_image.max_thumbnail_files'
+    LARGE_IMAGE_MERGE_DICOM = 'large_image.merge_dicom'
     LARGE_IMAGE_NOTIFICATION_STREAM_FALLBACK = 'large_image.notification_stream_fallback'
     LARGE_IMAGE_SHOW_EXTRA = 'large_image.show_extra'
     LARGE_IMAGE_SHOW_EXTRA_ADMIN = 'large_image.show_extra_admin'

--- a/girder/girder_large_image/web_client/templates/largeImageConfig.pug
+++ b/girder/girder_large_image/web_client/templates/largeImageConfig.pug
@@ -23,6 +23,17 @@ form#g-large-image-form(role="form")
     input.input-sm.form-control.g-large-image-max-small-image-size(
       type="text", value=settings['large_image.max_small_image_size'], title="The maximum size in pixels.  0 to not use regular images.", placeholder="0 to not use regular images.")
   .form-group
+    label Auto-merge Dicom files into single items
+    p.g-large-image-description
+      | When uploading or importing multiple dicom files into the same folder, if they share the same SeriesInstanceUID and StudyInstanceUID, they can automatically be moved to be multiple files in the same item rather than as multiple items
+    .g-large-image-merge-dicom-container
+      label.radio-inline
+        input.g-large-image-merge-dicom-leave(type="radio", name="g-large-image-merge-dicom", checked=settings['large_image.merge_dicom'] !== true ? 'checked': undefined)
+        | Don't merge
+      label.radio-inline
+        input.g-large-image-merge-dicom-merge(type="radio", name="g-large-image-merge-dicom", checked=settings['large_image.merge_dicom'] !== true ? undefined : 'checked')
+        | Merge
+  .form-group
     label
       | Maximum number of thumbnail files to save per item
     p.g-large-image-description

--- a/girder/girder_large_image/web_client/views/configView.js
+++ b/girder/girder_large_image/web_client/views/configView.js
@@ -63,6 +63,9 @@ var ConfigView = View.extend({
             }, {
                 key: 'large_image.icc_correction',
                 value: this.$('.g-large-image-icc-correction').prop('checked')
+            }, {
+                key: 'large_image.merge_dicom',
+                value: this.$('.g-large-image-merge-dicom-merge').prop('checked')
             }]);
         },
         'click .g-open-browser': '_openBrowser'


### PR DESCRIPTION
If multiple dicom files from the same series and study are uploaded or imported to the same folder, and the option is selected, all of the files will be moved to a single item (the first so located).  This makes browsing WSI dicoms easier, as they appear as single items, but may have repercussions.

This feature should be viewed as provisional until tested more thoroughly in the field.