### PR TITLE
Change some source priorities for tiff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.32.6
+
+### Changes
+
+- Tweak a few source priorities ([#1913](../../pull/1913))
+
 ## 1.32.5
 
 ### Improvements
@@ -9,7 +15,7 @@
 
 ### Changes
 
-- Tweak a few source priorities ([#1907](../../pull/1907), [#19098](../../pull/19098))
+- Tweak a few source priorities ([#1907](../../pull/1907), [#1908](../../pull/1908))
 
 ### Bug Fixes
 

--- a/sources/openslide/large_image_source_openslide/__init__.py
+++ b/sources/openslide/large_image_source_openslide/__init__.py
@@ -54,7 +54,7 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         'mrxs': SourcePriority.PREFERRED,  # MIRAX
         'ndpi': SourcePriority.PREFERRED,  # Hamamatsu
         'scn': SourcePriority.LOW,  # Leica
-        'svs': SourcePriority.PREFERRED,
+        'svs': SourcePriority.HIGH,
         'svslide': SourcePriority.PREFERRED,
         'tif': SourcePriority.MEDIUM,
         'tiff': SourcePriority.MEDIUM,

--- a/sources/tiff/large_image_source_tiff/__init__.py
+++ b/sources/tiff/large_image_source_tiff/__init__.py
@@ -60,8 +60,8 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
     name = 'tiff'
     extensions = {
         None: SourcePriority.HIGH,
-        'tif': SourcePriority.HIGH,
-        'tiff': SourcePriority.HIGH,
+        'tif': SourcePriority.PREFERRED,
+        'tiff': SourcePriority.PREFERRED,
         'ptif': SourcePriority.PREFERRED,
         'ptiff': SourcePriority.PREFERRED,
         'qptiff': SourcePriority.PREFERRED,
@@ -69,8 +69,8 @@ class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
     }
     mimeTypes = {
         None: SourcePriority.FALLBACK,
-        'image/tiff': SourcePriority.HIGH,
-        'image/x-tiff': SourcePriority.HIGH,
+        'image/tiff': SourcePriority.PREFERRED,
+        'image/x-tiff': SourcePriority.PREFERRED,
         'image/x-ptif': SourcePriority.PREFERRED,
     }
 


### PR DESCRIPTION
The tiff source should always be preferred for a file with a tiff extension