### PR TITLE
Show all annotations when zoomed in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - When saving annotation elements in javascript, use PATCH endpoint if possible ([#1915](../../pull/1915))
+- When zoomed in with a power of two of the max zoom and showing annotations, make sure all of the annotation in view are fully loaded ([#1917](../../pull/1917))
 
 ## 1.32.6
 

--- a/girder_annotation/girder_large_image_annotation/web_client/models/AnnotationModel.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/models/AnnotationModel.js
@@ -466,10 +466,9 @@ const AnnotationModel = AccessControlledModel.extend({
             this._region.top = Math.max(0, bounds.top - yoverlap);
             this._region.right = Math.min(sizeX || 1e6, bounds.right + xoverlap);
             this._region.bottom = Math.min(sizeY || 1e6, bounds.bottom + yoverlap);
+            this._region.maxDetails = zoom + 1 < maxZoom ? this.get('maxDetails') : undefined;
             this._lastZoom = zoom;
-            /* Don't ask for a minimum size; we show centroids if the data is
-             * incomplete. */
-            if (['left', 'top', 'right', 'bottom', 'minimumSize'].every((key) => this._region[key] === lastRegion[key])) {
+            if (['left', 'top', 'right', 'bottom', 'maxDetails'].every((key) => this._region[key] === lastRegion[key])) {
                 return;
             }
         }


### PR DESCRIPTION
When zoomed in with a power of two of the max zoom and showing annotations, make sure all of the annotation in view are fully loaded. Before, this was still subject to detail limits, which meant that it was possible to fail to resolve some annotations regardless of zoom level.