### PR TITLE
`getGeospatialRegion` Function

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -142,6 +142,40 @@ You can also specify a region with a single corner point and distances for width
             format=large_image.constants.TILE_FORMAT_NUMPY
         )
 
+Even if an image is not georeferenced, you can still get a region specified with geospatial coordinates by using the ``getGeospatialRegion`` function.
+Note that both ``pyproj`` and ``rasterio`` must be installed to use this function.
+This function requires that you specify ground control points for the source image since that georeferencing information does not exist within the image.
+In the following example, the ground control points are specified with EPSG:3857 coordinates and the target region is specified with EPSG:4326 coordinates.
+This function passes any additional arguments to ``getRegion``, so in the following example, ``frame`` and ``format`` are also passed as arguments.
+
+.. code-block:: python
+
+    import large_image
+    source = large_image.open('sample.tiff')
+
+    source_projection = 'epsg:3857'
+    source_gcps = [
+        # covers downtown DC
+        (-8578909.8696,4704125.8132, 0, 0),
+        (-8571075.0742,4710164.3385, source.sizeX, source.sizeY),
+    ]
+    target_projection = 'epsg:4326'
+    target_region = {
+        # covers US Capitol lot
+        'left': -77.015104,
+        'top': 38.887642,
+        'right': -77.005877,
+        'bottom': 38.892235,
+    }
+    getRegion_kwargs = dict(
+        frame=0,
+        format=large_image.constants.TILE_FORMAT_NUMPY,
+    )
+    nparray, mime_type = source.getGeospatialRegion(
+        source_projection, source_gcps, target_projection, target_region, **getRegion_kwargs
+    )
+
+
 Tile Serving
 ------------
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -2180,7 +2180,6 @@ class TileSource(IPyLeafletMixin):
         import pyproj
         import rasterio
 
-
         if any(len(gcp) != 4 for gcp in src_gcps):
             msg = 'Ground control points must contain four values in the form (cx, cy, px, py).'
             raise ValueError(msg)

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -2202,11 +2202,16 @@ class TileSource(IPyLeafletMixin):
         ) for gcp in converted_gcps]
 
         # transform dest_region to pixel coords
-        pixel_to_world = rasterio.transform.from_gcps(gcps)
-        world_to_pixel = ~pixel_to_world
-        px1, py1 = world_to_pixel * (dest_region.get('top'), dest_region.get('left'))
-        px2, py2 = world_to_pixel * (dest_region.get('bottom'), dest_region.get('right'))
-        pixel_region = dict(left=px1, top=py1, right=px2, bottom=py2)
+        transformer = rasterio.transform.GCPTransformer(gcps)
+        px1, py1 = transformer.rowcol(dest_region.get('top', 0), dest_region.get('left', 0))
+        px2, py2 = transformer.rowcol(dest_region.get('bottom', 0), dest_region.get('left', 0))
+        px3, py3 = transformer.rowcol(dest_region.get('top', 0), dest_region.get('right', 0))
+        px4, py4 = transformer.rowcol(dest_region.get('bottom', 0), dest_region.get('right', 0))
+        left = min(px1, px2, px3, px4)
+        top = min(py1, py2, py3, py4)
+        right = max(px1, px2, px3, px4)
+        bottom = max(py1, py2, py3, py4)
+        pixel_region = dict(left=left, top=top, right=right, bottom=bottom)
 
         # send pixel_region into getRegion
         return self.getRegion(region=pixel_region, **kwargs)

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -2154,7 +2154,7 @@ class TileSource(IPyLeafletMixin):
         dest_projection: str,
         dest_region: Dict[str, float],
         **kwargs,
-    ) -> np.ndarray:
+    ) -> Tuple[Union[np.ndarray, PIL.Image.Image, ImageBytes, bytes, pathlib.Path], str]:
         """
         This function requires pyproj and rasterio; it allows specifying georeferencing
         (even for non-geospatial images) and retrieving a region from geospatial coordinates.
@@ -2186,7 +2186,7 @@ class TileSource(IPyLeafletMixin):
             [
                 *crs_transform.transform(gcp[0], gcp[1]),
                 gcp[2], gcp[3],
-            ]for gcp in src_gcps
+            ] for gcp in src_gcps if len(gcp) == 4
         ]
 
         gcps = [rasterio.control.GroundControlPoint(

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -2180,6 +2180,11 @@ class TileSource(IPyLeafletMixin):
         import pyproj
         import rasterio
 
+
+        if any(len(gcp) != 4 for gcp in src_gcps):
+            msg = 'Ground control points must contain four values in the form (cx, cy, px, py).'
+            raise ValueError(msg)
+
         # convert gcps to dest_projection
         crs_transform = pyproj.Transformer.from_crs(src_projection, dest_projection)
         converted_gcps = [

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -2173,7 +2173,7 @@ class TileSource(IPyLeafletMixin):
             dest_region. This string can be an EPSG code or other format accepted
             by pyproj.CRS.from_string.
         :param dest_region: A dictionary describing the desired region to retrieve from the image.
-            Should specify values for "top", "bottom", "left", and "right" in the projected
+            Must specify values for "top", "bottom", "left", and "right" in the projected
             coordinate system specified by dest_projection.
         :param kwargs: Optional arguments passed to getRegion.
         """

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -413,21 +413,21 @@ def testGetGeospatialRegion():
 
     source_projection = 'epsg:3857'
     source_gcps = [
-        (-8573272.6388, 4705590.0601, 0, 0),
-        (-8573272.6388, 4706218.2769, 0, source.sizeY),
-        (-8572269.4028, 4706218.2769, source.sizeX, source.sizeY),
+        (-8579444.9288, 4699883.5582, 0, 0),
+        (-8579444.9288, 4709189.7664, 0, source.sizeY),
+        (-8568132.2486, 4709189.7664, source.sizeX, source.sizeY),
     ]
     target_projection = 'epsg:4326'
     target_region = {
-        'left': -77.015104,
-        'top': 38.888642,
-        'right': -77.005877,
-        'bottom': 38.892235,
+        'left': -77.010351,
+        'top': 38.889638,
+        'right': -77.009847,
+        'bottom': 38.889968,
     }
     region, _ = source.getGeospatialRegion(
         source_projection, source_gcps, target_projection, target_region, format='numpy',
     )
-    assert region.shape == (9492, 554, 3)
+    assert region.shape == (62, 290, 3)
 
 
 @pytest.mark.parametrize((

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -406,6 +406,29 @@ def testGetRegionAutoOffset():
     assert np.all(region2 == region1)
 
 
+def testGetGeospatialRegion():
+    imagePath = datastore.fetch('sample_image.ptif')
+    source = large_image.open(imagePath)
+    assert not source.geospatial
+
+    source_projection = 'epsg:3857'
+    source_gcps = [
+        (-8573272.6388, 4705590.0601, 0, 0),
+        (-8572269.4028, 4706218.2769, source.sizeX, source.sizeY),
+    ]
+    target_projection = 'epsg:4326'
+    target_region = {
+        'left': -77.015104,
+        'top': 38.888642,
+        'right': -77.005877,
+        'bottom': 38.892235,
+    }
+    region, _ = source.getGeospatialRegion(
+        source_projection, source_gcps, target_projection, target_region, format='numpy',
+    )
+    assert region.shape == (554, 10052, 3)
+
+
 @pytest.mark.parametrize((
     'options', 'lensrc', 'lenquads', 'frame10', 'src0', 'srclast', 'quads10',
 ), [

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -426,7 +426,7 @@ def testGetGeospatialRegion():
     region, _ = source.getGeospatialRegion(
         source_projection, source_gcps, target_projection, target_region, format='numpy',
     )
-    assert region.shape == (554, 10052, 3)
+    assert region.shape == (9492, 554, 3)
 
 
 @pytest.mark.parametrize((

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -414,6 +414,7 @@ def testGetGeospatialRegion():
     source_projection = 'epsg:3857'
     source_gcps = [
         (-8573272.6388, 4705590.0601, 0, 0),
+        (-8573272.6388, 4706218.2769, 0, source.sizeY),
         (-8572269.4028, 4706218.2769, source.sizeX, source.sizeY),
     ]
     target_projection = 'epsg:4326'


### PR DESCRIPTION
This PR adds `getGeospatialRegion` as a function on the `TileSource` base class and adds an example to the documentation.

Example usage:
```
import large_image
source = large_image.open('sample.tiff')
source.getGeospatialRegion(
    'epsg:3857', 
    [
        (-8578909.8696,4704125.8132, 0, 0),
        (-8571075.0742,4710164.3385, source.sizeX, source.sizeY),
    ],
    'epsg:4326', 
    {
          'left': -77.015104,
          'top': 38.887642,
          'right': -77.005877,
          'bottom': 38.892235,
    },
    frame=0,
    format='numpy',
)
```