### PR TITLE
Clearer error messages on bad annotations and don't keep the bad file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Change Log
 
-## 1.32.8
+## 1.32.9
 
+### Improvements
+
+- Clearer error messages on bad annotations and don't keep the bad file ([#1922](../../pull/1922))
+
+## 1.32.8
 
 ### Bug Fixes
 

--- a/girder_annotation/girder_large_image_annotation/handlers.py
+++ b/girder_annotation/girder_large_image_annotation/handlers.py
@@ -139,6 +139,8 @@ def process_annotations(event):  # noqa: C901
         data = orjson.loads(b''.join(data).decode())
     except Exception:
         logger.error('Could not parse annotation file')
+        if str(file['itemId']) == str(item['_id']):
+            File().remove(file)
         raise
     if time.time() - startTime > 10:
         logger.info('Decoded json in %5.3fs', time.time() - startTime)
@@ -161,6 +163,8 @@ def process_annotations(event):  # noqa: C901
             Annotation().createAnnotation(item, user, annotation)
         except Exception:
             logger.error('Could not create annotation object from data')
+            if str(file['itemId']) == str(item['_id']):
+                File().remove(file)
             raise
     if str(file['itemId']) == str(item['_id']):
         File().remove(file)

--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -1147,6 +1147,21 @@ class Annotation(AccessControlledModel):
                     lastTime = time.time()
             annot['elements'] = elements
         except jsonschema.ValidationError as exp:
+            try:
+                error_freq = {}
+                for err in exp.context:
+                    key = err.schema_path[0]
+                    error_freq.setdefault(key, [])
+                    error_freq[key].append(err)
+                min_error = min(error_freq.values(), key=lambda k: (len(k), k[0].schema_path))[0]
+                for key in dir(min_error):
+                    if not key.startswith('_'):
+                        try:
+                            setattr(exp, key, getattr(min_error, key))
+                        except Exception:
+                            pass
+            except Exception:
+                pass
             raise ValidationException(exp)
         if time.time() - startTime > 10:
             logger.info('Validated in %5.3fs' % (time.time() - startTime))


### PR DESCRIPTION
When uploading an annotation that fails to decode or validate, don't keep the file.  On a validation failure, try to print the most likely cause of the failure rather than entire schema.