### PR TITLE
Histograms Widget

### DIFF
--- a/large_image/widgets/CompositeLayers.vue
+++ b/large_image/widgets/CompositeLayers.vue
@@ -57,15 +57,17 @@ module.exports = {
         frameHistograms() {
             if (this.queuedRequests) {
                 let requests = this.queuedRequests[this.currentFrame];
-                if (!requests) this.queuedRequests = undefined;
                 const receivedFrames = Object.keys(this.frameHistograms).map((v) => parseInt(v));
-                requests = requests.filter((r) => !receivedFrames.includes(r.frame));
-                if (!requests.length) this.queuedRequests = undefined;
+                if (!requests) this.queuedRequests = undefined;
                 else {
-                    this.getFrameHistogram(requests[0]);
-                    this.queuedRequests = {
-                        [this.currentFrame]: requests.slice(1)
-                    };
+                    requests = requests.filter((r) => !receivedFrames.includes(r.frame));
+                    if (!requests.length) this.queuedRequests = undefined;
+                    else {
+                        this.getFrameHistogram(requests[0]);
+                        this.queuedRequests = {
+                            [this.currentFrame]: requests.slice(1)
+                        };
+                    }
                 }
             }
         }
@@ -461,15 +463,8 @@ module.exports = {
                   @input="(e) => updateLayerAutoRange(layerName, e.target.value)"
                 >
               </span>
-              <i
-                :class="expandedRows.includes(index) ? 'expand-btn icon-up-open fa fa-angle-up' : 'expand-btn icon-down-open fa fa-angle-down'"
-                @click="() => toggleExpanded(index)"
-              ></i>
             </td>
-            <td
-              v-if="expandedRows.includes(index)"
-              class="advanced-section"
-            >
+            <td>
               <histogram-editor
                 :item-id="itemId"
                 :layer-index="index"
@@ -486,6 +481,8 @@ module.exports = {
                 :update-min="(v, d) => updateLayerMin(layerName, v, d)"
                 :update-max="(v, d) => updateLayerMax(layerName, v, d)"
                 :update-auto-range="(v) => updateLayerAutoRange(layerName, v)"
+                :expanded="expandedRows.includes(index)"
+                :expand="() => toggleExpanded(index)"
               />
             </td>
           </tr>
@@ -607,13 +604,6 @@ module.exports = {
     position: absolute;
     right: 10px;
     top: 5px;
-}
-.advanced-section {
-    position: absolute;
-    left: 0px;
-    top: 30px;
-    width: calc(100% - 10px);
-    height: 40px;
 }
 .icon-keyboard {
     font-size: 20px;

--- a/large_image/widgets/CompositeLayers.vue
+++ b/large_image/widgets/CompositeLayers.vue
@@ -19,6 +19,7 @@ module.exports = {
         return {
             enabledLayers: [],
             compositeLayerInfo: {},
+            histogramRows: [],
             expandedRows: [],
             autoRangeForAll: undefined,
             showKeyboardShortcuts: false,
@@ -36,6 +37,12 @@ module.exports = {
                 style: this.histogramParamStyle,
                 roundRange: true
             };
+        },
+        showExpandAllButton() {
+            if (this.histogramRows.length) {
+                return document.getElementsByClassName('expand-btn').length > 0;
+            }
+            return false;
         }
     },
     watch: {
@@ -403,6 +410,7 @@ module.exports = {
                 </span>
               </div>
               <i
+                v-if="showExpandAllButton"
                 :class="expandedRows.length === layers.length ? 'expand-btn icon-up-open fa fa-angle-up' : 'expand-btn icon-down-open fa fa-angle-down'"
                 @click="toggleAllExpanded"
               ></i>
@@ -481,6 +489,7 @@ module.exports = {
                 :update-min="(v, d) => updateLayerMin(layerName, v, d)"
                 :update-max="(v, d) => updateLayerMax(layerName, v, d)"
                 :update-auto-range="(v) => updateLayerAutoRange(layerName, v)"
+                :mounted="() => histogramRows.push(index)"
                 :expanded="expandedRows.includes(index)"
                 :expand="() => toggleExpanded(index)"
               />

--- a/large_image/widgets/HistogramEditor.vue
+++ b/large_image/widgets/HistogramEditor.vue
@@ -123,6 +123,7 @@ module.exports = {
         'updateAutoRange',
         'expanded',
         'expand',
+        'mounted'
     ],
     data() {
         return {
@@ -200,6 +201,9 @@ module.exports = {
                 return [this.histogram.min, this.histogram.max];
             }
         }
+    },
+    mounted() {
+        this.mounted();
     },
     methods: {
         fetchHistogram() {

--- a/large_image/widgets/components.py
+++ b/large_image/widgets/components.py
@@ -15,6 +15,8 @@ with open(parent / 'CompositeLayers.vue') as f:
 with open(parent / 'HistogramEditor.vue') as f:
     histogram_editor = f.read()
 
+ipyvue.register_component_from_string('histogram-editor', histogram_editor)
+
 
 class FrameSelector(ipyvue.VueTemplate):  # type: ignore
     template_file = __file__, 'FrameSelector.vue'
@@ -33,7 +35,6 @@ class FrameSelector(ipyvue.VueTemplate):  # type: ignore
     components = traitlets.Dict({
         'dual-input': dual_input,
         'composite-layers': composite_layers,
-        'histogram-editor': histogram_editor,
     }).tag(sync=True)
 
     def vue_frameUpdate(self, data=None):


### PR DESCRIPTION
This PR refactors the HistogramEditor component to include the expand button. 

The HistogramEditor component does not render in the Google Colab environment since ipyvue in the Colab environment has a maximum component tree depth of 1. Without a better solution to allow the HistogramEditor component to render in Colab, this PR makes it so that the button to expand each row in the CompositeLayers tab is not visible if the HistogramEditor component is not rendered. The same is true for the "expand all" button in the header of the CompositeLayers table.

CompositeLayers table in Google Colab:
![image](https://github.com/user-attachments/assets/ba2dff93-90d7-4e5d-8cf7-e59f3a9d10bb)

CompositeLayers table in a local Jupyter environment:
![image](https://github.com/user-attachments/assets/d34bda9c-9765-4f1d-8861-430929f3821c)
