### PR TITLE
Improve mongo indices for annotation elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Annotation list checkboxes ([#1884](../../pull/1884))
 - The frame-viewer histogram widget will only be visible if it can be used ([#1924](../../pull/1924))
 - Add the dicom mime-type to the openslide source ([#1925](../../pull/1925))
+- Add a getGeospatialRegion function to tile sources ([#1922](../../pull/1922))
+- Add another index for annotation elements ([#1928](../../pull/1928))
 
 ### Bug Fixes
 

--- a/girder_annotation/girder_large_image_annotation/models/annotationelement.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotationelement.py
@@ -61,20 +61,6 @@ class Annotationelement(Model):
             '_version',
             ([
                 ('annotationId', SortDir.ASCENDING),
-                ('bbox.lowx', SortDir.DESCENDING),
-                ('bbox.highx', SortDir.ASCENDING),
-                ('bbox.size', SortDir.DESCENDING),
-            ], {
-                'name': 'annotationBboxIdx',
-            }),
-            ([
-                ('annotationId', SortDir.ASCENDING),
-                ('bbox.size', SortDir.DESCENDING),
-            ], {
-                'name': 'annotationBboxSizeIdx',
-            }),
-            ([
-                ('annotationId', SortDir.ASCENDING),
                 ('_version', SortDir.DESCENDING),
                 ('element.group', SortDir.ASCENDING),
             ], {
@@ -92,11 +78,20 @@ class Annotationelement(Model):
                 ('_version', SortDir.ASCENDING),
             ], {}),
             'element.girderId',
+            ([
+                ('annotationId', SortDir.ASCENDING),
+                ('_version', SortDir.DESCENDING),
+                ('bbox.size', SortDir.DESCENDING),
+            ], {}),
         ])
 
         self.exposeFields(AccessType.READ, (
             '_id', '_version', 'annotationId', 'created', 'element'))
         self.versionId = None
+
+    def _createIndex(self, index):
+        """This creates indices in the background."""
+        threading.Thread(target=super()._createIndex, args=(index,)).start()
 
     def getNextVersionValue(self):
         """


### PR DESCRIPTION
With multiple versions of large annotations, this change speeds up queries.