### PR TITLE
Make the json representation of some annotation elements more compact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add the dicom mime-type to the openslide source ([#1925](../../pull/1925))
 - Add a getGeospatialRegion function to tile sources ([#1922](../../pull/1922))
 - Add another index for annotation elements ([#1928](../../pull/1928))
+- Make the json representation of some annotation elements more compact ([#1930](../../pull/1930))
 
 ### Bug Fixes
 

--- a/girder_annotation/docs/annotations.rst
+++ b/girder_annotation/docs/annotations.rst
@@ -117,8 +117,8 @@ Point
     "center": [123.3, 144.6, -123]     # Coordinate.  Required
   }
 
-Polyline
-~~~~~~~~
+Polyline (Polygons and Lines)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When closed, this is a polygon. When open, this is a continuous line.
 

--- a/girder_annotation/girder_large_image_annotation/rest/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/rest/annotation.py
@@ -248,6 +248,14 @@ class AnnotationResource(Resource):
                 # use a json encoder in the most compact form.
                 if isinstance(element, dict):
                     element['id'] = str(element['id'])
+                    if 'points' in element:
+                        element['points'] = [
+                            [int(x) if isinstance(x, float) and x.is_integer() else x for x in sub]
+                            for sub in element['points']]
+                    if 'holes' in element:
+                        element['holes'] = [[
+                            [int(x) if isinstance(x, float) and x.is_integer() else x for x in sub]
+                            for sub in hole] for hole in element['holes']]
                 else:
                     element = struct.pack(
                         '>QL', int(element[0][:16], 16), int(element[0][16:24], 16),


### PR DESCRIPTION
For points and holes, coordinates that have no fractional part are transmitted as integers.  For a sampling of polygons with all-integer coordinates, this reduces data volume by 25%.