### PR TITLE
Move the pillow-jpls module out of common install extras.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.32.10
+
+### Changes
+
+- Move the pillow-jpls module out of common install extras ([#1935](../../pull/1935))
+
 ## 1.32.9
 
 ### Improvements

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ extraReqs['common'] = list(set(itertools.chain.from_iterable(extraReqs[key] for 
     'deepzoom', 'dicom', 'multi', 'nd2', 'openslide', 'test', 'tifffile',
     'zarr',
 })) | {
-    f'large-image-source-pil[all]{limit_version}',
+    f'large-image-source-pil[common]{limit_version}',
     f'large-image-source-rasterio[all]{limit_version}',
 })
 

--- a/sources/pil/setup.py
+++ b/sources/pil/setup.py
@@ -39,9 +39,15 @@ setup(
         'all': [
             'rawpy',
             'pillow-heif',
-            'pillow-jxl-plugin < 1.3 ; python_version < "3.8"',
+            'pillow-jxl-plugin < 1.3 ; python_version < "3.9"',
             'pillow-jxl-plugin ; python_version >= "3.9"',
-            'pillow-jpls',
+            'pillow-jpls ; python_version < "3.13"',
+        ],
+        'common': [
+            'rawpy',
+            'pillow-heif',
+            'pillow-jxl-plugin < 1.3 ; python_version < "3.9"',
+            'pillow-jxl-plugin ; python_version >= "3.9"',
         ],
         'girder': f'girder-large-image{limit_version}',
     },


### PR DESCRIPTION
It doesn't have binary wheels for some platforms and python versions