### PR TITLE
Change the reading method for some file conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 - Move the pillow-jpls module out of common install extras ([#1935](../../pull/1935))
+- Change the reading method for some file conversions ([#1939](../../pull/1939))
 
 ## 1.32.9
 


### PR DESCRIPTION
When converting files, prefer not reading some file via vips even if possible.

In the large_image converter we have three different methods of reading the source (a) vips, (b) any of large_image's sources, or (c) gdal. (c) is only used if doing a geospatial conversion.  Prior to the referenced PR, vips was preferred if it claimed it would read a file, as it should have efficiency in that it should be smart enough to copy tiles from sources to destinations without any analysis if they don't need reencoding.  But, for some files, the individual frames aren't tiled, yet we were asking vips to do the reading (vips is still doing the writing), and, something in the vips process was taking ages to convert the strips to tiles (though this should be a bookkeeping operation only).  Instead, we read the frames via large_image and write via vips.

This may have the implication for some other files that we aren't using the most efficient path, but for a sample which had a 5000 frame strip-based set of images, that vastly reduces the time.