### PR TITLE
Better handle images with adjacent files in the same girder item

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,14 +66,14 @@ repos:
           - '--options'
           - './girder/girder_large_image/web_client/package.json'
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.20.0
     hooks:
       - id: pyupgrade
         args:
           - --py38-plus
           - --keep-percent-format
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.8
+    rev: v0.12.0
     hooks:
       - id: ruff
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Improve DocumentDB support ([#1937](../../pull/1937))
+- Better handle images with adjacent files in the same girder item ([#1940](../../pull/1940))
 
 ### Changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ lint.ignore = [
     "PT011",  # pytest-raises-too-broad
     "PT012",  # pytest-raises-with-multiple-statements
     "PT017",  # pytest-assert-in-except
+    "PT030",
     "RET503",  # implict-return on function that can return non-none
     "RET504",  # unncessary-assign before return
 ]

--- a/sources/openslide/large_image_source_openslide/girder_source.py
+++ b/sources/openslide/large_image_source_openslide/girder_source.py
@@ -28,5 +28,5 @@ class OpenslideGirderTileSource(OpenslideFileTileSource, GirderTileSource):
     cacheName = 'tilesource'
     name = 'openslide'
 
-    extensionsWithAdjacentFiles = {'mrxs'}
-    mimeTypesWithAdjacentFiles = {'image/mirax'}
+    extensionsWithAdjacentFiles = {'mrxs', 'dcm', 'dicom'}
+    mimeTypesWithAdjacentFiles = {'image/mirax', 'application/dicom'}

--- a/utilities/tasks/large_image_tasks/tasks.py
+++ b/utilities/tasks/large_image_tasks/tasks.py
@@ -94,6 +94,7 @@ def convert_image_job(job):
 
     from girder_jobs.constants import JobStatus
     from girder_jobs.models.job import Job
+    from girder_large_image.models.image_item import ImageItem
 
     from girder.constants import AccessType
     from girder.models.file import File
@@ -106,6 +107,8 @@ def convert_image_job(job):
     toFolder = kwargs.pop('toFolder', True)
     item = Item().load(kwargs.pop('itemId'), force=True)
     fileObj = File().load(kwargs.pop('fileId'), force=True)
+
+    mayHaveAdjacent = ImageItem().mayHaveAdjacentFiles(item)
     userId = kwargs.pop('userId', None)
     user = User().load(userId, force=True) if userId else None
     if toFolder:
@@ -131,7 +134,8 @@ def convert_image_job(job):
             try:
                 inputPath = File().getGirderMountFilePath(
                     fileObj,
-                    **({'preferFlat': True} if 'preferFlat' in inspect.signature(
+                    **({'preferFlat': True} if mayHaveAdjacent != 'local' and
+                        'preferFlat' in inspect.signature(
                         File.getGirderMountFilePath).parameters else {}))
             except Exception:
                 pass


### PR DESCRIPTION
When opening images that are uploaded or otherwise not imported from a filesystem assetstore, we use the fuse mount to read the images.  If we think the image is composed of adjacent files, we were using the flat mount point, where individual items in girder each appear as single files.  But, when the image item has multiple files that are part of the image, this does not work.  The detection is that if the format might have adjacent files and we are reading an unconverted file, and the item has multiple files with the same mimetype as the main file, then we prefer the non-flat mount.

This has the potential to fail; someone could upload multiple files and have the same mimetype even though the image is spread across multiple items.  But, without it, merged dicoms, for instance, may not work.