### PR TITLE
Generate a notification on annotation reversion.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Improve DocumentDB support ([#1941](../../pull/1941))
+- Generate a specific annotation revert notification in Girder ([#1943](../../pull/1943))
 
 ### Bug Fixes
 

--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -1255,6 +1255,12 @@ class Annotation(AccessControlledModel):
             if not force:
                 self.requireAccess(annotation, user=user, level=AccessType.WRITE)
             annotation = Annotation().updateAnnotation(annotation, updateUser=user)
+            Notification().createNotification(
+                type='large_image_annotation.revert',
+                data={'_id': annotation['_id'], 'itemId': annotation['itemId']},
+                user=user,
+                expires=datetime.datetime.now(datetime.timezone.utc) +
+                datetime.timedelta(seconds=1))
         return annotation
 
     def findAnnotatedImages(self, imageNameFilter=None, creator=None,


### PR DESCRIPTION
This allows clients more options to hook into changes.