### PR TITLE
Fix openslide reads at lower levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 - Fix updating annotation updated dates in the girder web client ([#1942](../../pull/1942))
+- Fix openslide reads at lower levels ([#1944](../../pull/1944))
 
 ## 1.32.10
 


### PR DESCRIPTION
Peculiarly, openslide has a "downsample" factor which isn't the power of 2 one would expect.  This is computed based on the actual dimensions of levels, but since higher-resolution levels are not fully populated at the right and bottom, this ends up with not the actual downsampling, but some slightly higher number (e.g., 16.0018 rather than 16).  Internally, when asking for a region for anything other than the maximum resolution lever, the openslide library is passed coordinates in what _seems_ to be base image coordinates, but is actually inflated by the ratio of their downsample value and the actual downsample value (e.g., 16.0018 / 16). We multiple our values by this ratio so when openslide misapplies its downsampling we get the region we actually want.

Prior to this commit, we were asking for regions as openslide documentation specified.