### PR TITLE
Ensure a valid gdal version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.32.12
+
+### Changes
+
+- Ensure a valid gdal version ([#1945](../../pull/1945))
+
 ## 1.32.11
 
 ### Improvements

--- a/sources/gdal/setup.py
+++ b/sources/gdal/setup.py
@@ -34,7 +34,8 @@ setup(
     ],
     install_requires=[
         f'large-image{limit_version}',
-        'gdal',
+        'gdal ; python_version >= "3.9"',
+        'gdal<3.11 ; python_version < "3.9"',
         'packaging',
         'pyproj>=3.5.0',
     ],


### PR DESCRIPTION
GDAL >= 3.11 requires Python >= 3.9.  For now, just encode this in the requirements; we will drop 3.8 support soon.