### PR TITLE
Improve reading certain tiles via tiff source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.32.12
 
+### Improvements
+
+- Improve reading certain tiles via tiff source ([#1946](../../pull/1946))
+
 ### Changes
 
 - Ensure a valid gdal version ([#1945](../../pull/1945))

--- a/sources/tiff/large_image_source_tiff/tiff_reader.py
+++ b/sources/tiff/large_image_source_tiff/tiff_reader.py
@@ -796,7 +796,10 @@ class TiledTiffDirectory:
                 } and (
                     self._tiffInfo.get('compression') != libtiff_ctypes.COMPRESSION_JPEG or
                     self._tiffInfo.get('photometric') != libtiff_ctypes.PHOTOMETRIC_YCBCR))):
-            return self._getUncompressedTile(tileNum)
+            try:
+                return self._getUncompressedTile(tileNum)
+            except Exception:
+                pass
 
         imageBuffer = io.BytesIO()
 


### PR DESCRIPTION
When reading certain jpeg compressed tiles and wanting them uncompressed, we were defaulting to asking libtiff to read the uncompressed tile in an attempt to use the more optimized path of libtiff doing the decompressed, but sometimes this did not behave as expected.  When so asked, if this fails, we fall back to decoding the jpeg in our code.