### PR TITLE
Do not check if items are used as annotation elements in DocumentDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changes
 
+- Do not check if items are used as annotation elements in DocumentDB ([#1949](../../pull/1949))
 - Ensure a valid gdal version ([#1945](../../pull/1945))
 
 ## 1.32.11

--- a/girder_annotation/girder_large_image_annotation/rest/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/rest/annotation.py
@@ -1080,23 +1080,68 @@ class AnnotationResource(Resource):
 
     @access.public(scope=TokenScope.DATA_READ)
     @autoDescribeRoute(
-        Description('Get annotation counts for a list of items.')
+        Description(
+            'Get annotation counts for a list of items.  If using actual a '
+            'database other than DocumentDB, this also indicates if items are '
+            'referenced as annotations.')
         .param('items', 'A comma-separated list of item ids.')
         .errorResponse(),
     )
     def getItemListAnnotationCounts(self, items):
+        from girder_large_image.models.image_item import ImageItem
+
         user = self.getCurrentUser()
         results = {}
-        for itemId in items.split(','):
-            item = Item().load(itemId, level=AccessType.READ, user=user)
-            annotations = Annotation().findWithPermissions(
-                {'_active': {'$ne': False}, 'itemId': item['_id']},
-                user=self.getCurrentUser(), level=AccessType.READ, limit=-1)
-            results[itemId] = annotations.count()
-            if Annotationelement().findOne({'element.girderId': itemId}):
+        oids = [ObjectId(itemId.strip()) for itemId in items.split(',')]
+        pipeline = [{
+            '$match': {'$and': [
+                {'_id': {'$in': oids}},
+                Item().permissionClauses(user, level=AccessType.READ),
+            ]},
+        }, {
+            '$lookup': {
+                'from': 'annotation',
+                'let': {'itemId': '$_id'},
+                'pipeline': [{'$match': {'$expr': {'$and': [
+                    {'$eq': ['$itemId', '$$itemId']},
+                    {'$ne': ['$_active', False]},
+                    Annotation().permissionClauses(user, level=AccessType.READ),
+                ]}}}],
+                'as': 'annotations',
+            },
+        }, {
+            '$lookup': {
+                'from': 'annotationelement',
+                'let': {'itemId': '$_id'},
+                'pipeline': [{
+                    '$match': {'$expr': {
+                        '$eq': ['$element.girderId', '$$itemId'],
+                    }},
+                }, {
+                    '$limit': 1,
+                }],
+                'as': 'used',
+            },
+        }, {
+            '$project': {
+                '_id': 1,
+                'annotationCount': {'$size': '$annotations'},
+                'used': {'$gt': [{'$size': '$used'}, 0]},
+            },
+        }]
+        if ImageItem().checkForDocumentDB():
+            pipeline[-2:] = [{
+                '$project': {
+                    '_id': 1,
+                    'annotationCount': {'$size': '$annotations'},
+                },
+            }]
+        for record in Item().collection.aggregate(pipeline):
+            results[str(record['_id'])] = record['annotationCount']
+            if record.get('used'):
                 if 'referenced' not in results:
                     results['referenced'] = {}
-                results['referenced'][itemId] = True
+                results['referenced'][str(record['_id'])] = True
         return results
 
     @access.user(scope=TokenScope.DATA_WRITE)


### PR DESCRIPTION
We query via element.girderId, but DocumentDB 5.0 doesn't support multi-key indices, so this is glacially slow.  Just skip this query and accept reduced functionality.

Resolves #1948.