### PR TITLE
Generalize clearer error messages on jsonschema validation errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## 1.33.0
 
+### Features
+
+- Multi-source Thin Plate Spline Warping ([#1947](../../pull/1947))
+
 ### Improvements
 
 - Improve reading certain tiles via tiff source ([#1946](../../pull/1946))
+- Clearer error messages on jsonschema issues in the multi source ([#1951](../../pull/1951))
 
 ### Changes
 
@@ -40,7 +45,7 @@
 
 ### Improvements
 
-- Clearer error messages on bad annotations and don't keep the bad file ([#1922](../../pull/1922))
+- Clearer error messages on bad annotations and don't keep the bad file ([#1923](../../pull/1923))
 - Annotation list checkboxes ([#1884](../../pull/1884))
 - The frame-viewer histogram widget will only be visible if it can be used ([#1924](../../pull/1924))
 - Add the dicom mime-type to the openslide source ([#1925](../../pull/1925))

--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -1147,21 +1147,9 @@ class Annotation(AccessControlledModel):
                     lastTime = time.time()
             annot['elements'] = elements
         except jsonschema.ValidationError as exp:
-            try:
-                error_freq = {}
-                for err in exp.context:
-                    key = err.schema_path[0]
-                    error_freq.setdefault(key, [])
-                    error_freq[key].append(err)
-                min_error = min(error_freq.values(), key=lambda k: (len(k), k[0].schema_path))[0]
-                for key in dir(min_error):
-                    if not key.startswith('_'):
-                        try:
-                            setattr(exp, key, getattr(min_error, key))
-                        except Exception:
-                            pass
-            except Exception:
-                pass
+            from large_image.exceptions import _improveJsonschemaValidationError
+
+            _improveJsonschemaValidationError(exp)
             raise ValidationException(exp)
         if time.time() - startTime > 10:
             logger.info('Validated in %5.3fs' % (time.time() - startTime))

--- a/large_image/exceptions.py
+++ b/large_image/exceptions.py
@@ -1,4 +1,5 @@
 import errno
+from typing import Any
 
 
 class TileGeneralError(Exception):
@@ -40,6 +41,24 @@ class TileCacheError(TileGeneralError):
 
 class TileCacheConfigurationError(TileCacheError):
     pass
+
+
+def _improveJsonschemaValidationError(exp):
+    try:
+        error_freq: dict[str, Any] = {}
+        for err in exp.context:
+            key = err.schema_path[0]
+            error_freq.setdefault(key, [])
+            error_freq[key].append(err)
+        min_error = min(error_freq.values(), key=lambda k: (len(k), k[0].schema_path))[0]
+        for key in dir(min_error):
+            if not key.startswith('_'):
+                try:
+                    setattr(exp, key, getattr(min_error, key))
+                except Exception:
+                    pass
+    except Exception:
+        pass
 
 
 TileGeneralException = TileGeneralError

--- a/sources/multi/large_image_source_multi/__init__.py
+++ b/sources/multi/large_image_source_multi/__init__.py
@@ -442,9 +442,12 @@ class MultiFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             self._largeImagePath = '.'
             try:
                 self._validator.validate(self._info)
-            except jsonschema.ValidationError:
-                msg = 'File cannot be validated via multi-source reader.'
-                raise TileSourceError(msg)
+            except jsonschema.ValidationError as exp:
+                from large_image.exceptions import _improveJsonschemaValidationError
+
+                _improveJsonschemaValidationError(exp)
+                msg = f'File cannot be validated via multi-source reader {str(exp)}.'
+                raise TileSourceError(msg) from None
         elif not os.path.isfile(self._largeImagePath):
             try:
                 possibleYaml = self._largeImagePath.split('multi://', 1)[-1]
@@ -473,9 +476,12 @@ class MultiFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
                 raise TileSourceError(msg)
             try:
                 self._validator.validate(self._info)
-            except jsonschema.ValidationError:
-                msg = 'File cannot be validated via multi-source reader.'
-                raise TileSourceError(msg)
+            except jsonschema.ValidationError as exp:
+                from large_image.exceptions import _improveJsonschemaValidationError
+
+                _improveJsonschemaValidationError(exp)
+                msg = f'File cannot be validated via multi-source reader {str(exp)}.'
+                raise TileSourceError(msg) from None
             self._basePath = Path(self._largeImagePath).parent
         self._basePath /= Path(self._info.get('basePath', '.'))
         for axis in self._info.get('axes', []):


### PR DESCRIPTION
This reuses some of #1923 to improve multi source json validation reports.