### PR TITLE
Sometimes the annotation PATCH endpoint would report a duplicate ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Ensure a valid gdal version ([#1945](../../pull/1945))
 - Drop support for Python 3.8 ([#1950](../../pull/1950))
 
+### Bug Fixes
+
+- Sometimes the annotation PATCH endpoint would report a duplicate ID ([#1952](../../pull/1952))
+
 ## 1.32.11
 
 ### Improvements

--- a/girder_annotation/girder_large_image_annotation/rest/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/rest/annotation.py
@@ -409,7 +409,7 @@ class AnnotationResource(Resource):
         if 'empty' in elementdict:
             elementdict.pop('empty')
             for el in elements:
-                elementdict[el['id']] = el
+                elementdict[str(el['id'])] = el
         if '/' in elpath:
             return self._patchEntry(elementdict, elpath, op, value, fullpath)
         elid = elpath.split('/', 1)[0].lower()


### PR DESCRIPTION
This was caused by comparing a string to an ObjectId