### PR TITLE
Zarr Write: Prevent multiple values for the `overwrite` kwarg

### DIFF
--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -1443,8 +1443,9 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             params = {}
             if lossy and self.dtype == np.uint8:
                 params['compression'] = 'jpeg'
+            params['overwrite'] = overwriteAllowed
             params.update(converterParams)
-            convert(str(attrs_path), path, overwrite=overwriteAllowed, **params)
+            convert(str(attrs_path), path, **params)
 
             self._applyGeoReferencing(path)
 


### PR DESCRIPTION
This PR fixes the following bug I encountered:

```
  File "large_image/sources/zarr/large_image_source_zarr/__init__.py", line 1448, in write
    convert(str(attrs_path), path, overwrite=overwriteAllowed, **params)
TypeError: large_image_converter.convert() got multiple values for keyword argument 'overwrite'
```

To reproduce:
```
import large_image_source_zarr
import numpy as np

sink = large_image_source_zarr.new()
sink.addTile(
    np.random.randint(0, 255, size=(255, 255, 1)), x=0, y=0
)
sink.write('test.tif', overwrite=True)
```