### PR TITLE
Eliminate a javascript exception in the histogram viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Sometimes the annotation PATCH endpoint would report a duplicate ID ([#1952](../../pull/1952))
 - Harden reading ometiff that have certain planar configurations ([#1956](../../pull/1956))
 - If a tile is larger than expected, guard its size ([#1955](../../pull/1955))
+- Zarr Write: Prevent multiple values for the overwrite kwarg ([#1965](../../pull/1965))
+- Eliminate a javascript exception in the histogram viewer ([#1967](../../pull/1967))
 
 ## 1.32.11
 

--- a/large_image/widgets/HistogramEditor.vue
+++ b/large_image/widgets/HistogramEditor.vue
@@ -308,7 +308,7 @@ module.exports = {
             );
         },
         initializePositions() {
-            if (!this.histogram) return;
+            if (!this.histogram || !this.$refs.minHandle || !this.$refs.maxHandle) return;
 
             const currentMinPosition = parseFloat(this.$refs.minHandle.getAttribute('x1'));
             const currentMaxPosition = parseFloat(this.$refs.maxHandle.getAttribute('x1'));


### PR DESCRIPTION
We could try to get the range values before they had been created