### PR TITLE
Add an option to preserve float value dtype in image conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Improve reading certain tiles via tiff source ([#1946](../../pull/1946))
 - Clearer error messages on jsonschema issues in the multi source ([#1951](../../pull/1951))
+- Add an option to the image converter to preserve float datatypes ([#1968](../../pull/1968))
 
 ### Changes
 

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -135,6 +135,15 @@ def testConvertTiffFloatPixels(tmpdir):
             tifftools.constants.SampleFormat.uint.value)
 
 
+def testConvertTiffPreserveFloatPixels(tmpdir):
+    imagePath = datastore.fetch('d042-353.crop.small.float32.tif')
+    outputPath = os.path.join(tmpdir, 'out.tiff')
+    large_image_converter.convert(imagePath, outputPath, keepFloat=True)
+    info = tifftools.read_tiff(outputPath)
+    assert (info['ifds'][0]['tags'][tifftools.Tag.SampleFormat.value]['data'][0] ==
+            tifftools.constants.SampleFormat.float.value)
+
+
 def testConvertJp2kCompression(tmpdir):
     imagePath = datastore.fetch('sample_Easy1.png')
     outputPath = os.path.join(tmpdir, 'out.tiff')


### PR DESCRIPTION
For pixel intensity images, switching to a int data type is often more efficient, but for images that represent other forms of data (depth in meters as an example), this is undesirable.