### PR TITLE
Specify that gdal and rasterio sources could be multifile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Improve reading certain tiles via tiff source ([#1946](../../pull/1946))
 - Clearer error messages on jsonschema issues in the multi source ([#1951](../../pull/1951))
 - Add an option to the image converter to preserve float datatypes ([#1968](../../pull/1968))
+- Specify that geospatial girder sources could be multi-file to better find adjacent files to a vrt ([#1971](../../pull/1971))
 
 ### Changes
 

--- a/sources/gdal/large_image_source_gdal/girder_source.py
+++ b/sources/gdal/large_image_source_gdal/girder_source.py
@@ -35,6 +35,8 @@ class GDALGirderTileSource(GDALFileTileSource, GirderTileSource):
     name = 'gdal'
     cacheName = 'tilesource'
 
+    _mayHaveAdjacentFiles = True
+
     @staticmethod
     def getLRUHash(*args, **kwargs):
         return GirderTileSource.getLRUHash(*args, **kwargs) + ',%s,%s' % (

--- a/sources/rasterio/large_image_source_rasterio/girder_source.py
+++ b/sources/rasterio/large_image_source_rasterio/girder_source.py
@@ -30,6 +30,8 @@ class RasterioGirderTileSource(RasterioFileTileSource, GirderTileSource):
     name = 'rasterio'
     cacheName = 'tilesource'
 
+    _mayHaveAdjacentFiles = True
+
     @staticmethod
     def getLRUHash(*args, **kwargs):
         projection = kwargs.get(


### PR DESCRIPTION
In Girder, this allows path-relative adjacent files (such as from vrt files) to be found properly