### PR TITLE
Remove locking in reading nd2 tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Clearer error messages on jsonschema issues in the multi source ([#1951](../../pull/1951))
 - Add an option to the image converter to preserve float datatypes ([#1968](../../pull/1968))
 - Specify that geospatial girder sources could be multi-file to better find adjacent files to a vrt ([#1971](../../pull/1971))
+- Remove locking in reading nd2 tiles ([#1977](../../pull/1977))
 
 ### Changes
 


### PR DESCRIPTION
When locking was added around 3 years ago, it was necessary to prevent memory from leaking between concurrent tile reads.  Shortly after that, we switched dask to use a single-threaded mode to avoid certain failures to release memory (see #797, #994, #1260, and others).  Since then, both the nd2 library and dask have improved and this is no longer necessary. In tests with converting a large multi-frame nd2 file, is appears 4 to 5 times faster to remove these locks and thread requirements with the only downside that more cpu is used at a time.

dask can use processes instead of threads, but this is slower.  It can also limit the number of workers, but at the level we are running compute, this seems to be the limit per tile and not actually useful.