### PR TITLE
Speed up annotation centroid queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.33.1
+
+### Improvements
+
+- Speed up annotation centroid queries ([#1981](../../pull/1981))
+
 ## 1.33.0
 
 ### Features

--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -940,6 +940,7 @@ class Annotation(AccessControlledModel):
         _elementQuery = annotation.pop('_elementQuery', None)
         annotation.pop('_active', None)
         annotation.pop('_annotationId', None)
+        annotation.pop('_versionId', None)
         if annotation['annotation'] and not annotation['annotation'].get('name'):
             now = datetime.datetime.now(datetime.timezone.utc)
             annotation['annotation']['name'] = now.strftime('Annotation %Y-%m-%d %H:%M')

--- a/girder_annotation/girder_large_image_annotation/models/annotationelement.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotationelement.py
@@ -240,17 +240,21 @@ class Annotationelement(Model):
         queryLimit = max(minElements, maxDetails) if maxDetails and (
             not limit or max(minElements, maxDetails) < limit) else limit
         offset = int(region['offset']) if region.get('offset') else 0
-        logger.debug('element query %r for %r', query, region)
         fields = {'_id': True, 'element': True, 'bbox.details': True, 'datafile': True}
         centroids = str(region.get('centroids')).lower() == 'true'
         if centroids:
-            # fields = {'_id': True, 'element': True, 'bbox': True}
             fields = {
                 '_id': True,
                 'element.id': True,
-                'bbox': True}
+                'bbox.lowx': True,
+                'bbox.lowy': True,
+                'bbox.highx': True,
+                'bbox.highy': True,
+                'bbox.size': True,
+            }
             proplist = []
-            propskeys = ['type', 'fillColor', 'lineColor', 'lineWidth', 'closed']
+            # MUST match below
+            propskeys = ('type', 'fillColor', 'lineColor', 'lineWidth', 'closed')
             # This should match the javascript
             defaultProps = {
                 'fillColor': 'rgba(0,0,0,0)',
@@ -263,12 +267,10 @@ class Annotationelement(Model):
             info['centroids'] = True
             info['props'] = proplist
             info['propskeys'] = propskeys
-        elif region.get('bbox'):
-            fields.pop('bbox.details')
-            fields['bbox'] = True
-        if bbox:
+        elif region.get('bbox') or bbox:
             fields.pop('bbox.details', None)
             fields['bbox'] = True
+        logger.debug('element query %r (%r) for %r', query, fields, region)
         elementCursor = self.find(
             query=query, sort=[(sortkey, sortdir)], limit=queryLimit,
             offset=offset, fields=fields)
@@ -288,19 +290,23 @@ class Annotationelement(Model):
             info['limit'] = limit
         for entry in elementCursor:
             element = entry['element']
-            element.setdefault('id', entry['_id'])
             if centroids:
                 bbox = entry.get('bbox')
                 if not bbox or 'lowx' not in bbox or 'size' not in bbox:
                     continue
-                prop = tuple(
-                    element.get(key, defaultProps.get(key)) for key in propskeys
-                    if element.get(key, defaultProps.get(key)) is not None)
+                # MUST match above; faster than
+                #   prop = tuple(element.get(key) for key in propskeys)
+                prop = (
+                    element.get('type'),
+                    element.get('fillColor'),
+                    element.get('lineColor'),
+                    element.get('lineWidth'),
+                    element.get('closed'))
                 if prop not in props:
                     props[prop] = len(props)
-                    proplist.append(list(prop))
+                    proplist.append([element.get(key, defaultProps.get(key)) for key in propskeys])
                 yield [
-                    str(element['id']),
+                    str(element.get('id') or entry['_id']),
                     (bbox['lowx'] + bbox['highx']) / 2,
                     (bbox['lowy'] + bbox['highy']) / 2,
                     bbox['size'] if entry.get('type') != 'point' else 0,
@@ -308,6 +314,7 @@ class Annotationelement(Model):
                 ]
                 details += 1
             else:
+                element.setdefault('id', entry['_id'])
                 if entry.get('datafile'):
                     datafile = entry['datafile']
                     chunksize = 1024 ** 2

--- a/girder_annotation/girder_large_image_annotation/web_client/models/AnnotationModel.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/models/AnnotationModel.js
@@ -77,7 +77,7 @@ const AnnotationModel = AccessControlledModel.extend({
         annotation: {},
         minElements: 5000,
         maxDetails: 250000,
-        maxCentroids: 2000000
+        maxCentroids: 5000000
     },
 
     initialize() {
@@ -227,10 +227,7 @@ const AnnotationModel = AccessControlledModel.extend({
         var restOpts = {
             url: url,
             data: {
-                sort: 'size',
-                sortdir: -1,
                 centroids: true,
-                limit: this.get('maxCentroids'),
                 _: (this.get('updated') || this.get('created')) + '_' + this.get('_version')
             },
             xhrFields: {
@@ -238,7 +235,11 @@ const AnnotationModel = AccessControlledModel.extend({
             },
             error: null
         };
-
+        if ((this.get('_elementQuery') || {}).count && (this.get('_elementQuery') || {}).count > this.get('maxCentroids')) {
+            restOpts.data.sort = 'size';
+            restOpts.data.sortdir = -1;
+            restOpts.data.limit = this.get('maxCentroids');
+        }
         return restRequest(restOpts).done((resp) => {
             let dv = new DataView(resp);
             let z0 = 0, z1 = dv.byteLength - 1;


### PR DESCRIPTION
Much of the time is just getting data back from mongo.  On a ~1/3 million annotation test, before these changes it took ~4.19s to ~3.69s (12% improvement).  If we stop sorting the results, this improves further to ~3.50s (total 16% improvement).  Here, we've stopped sorting unless it could matter.

As a further (future) improvement, we could precompute or cache the response so the response would effectively be serving a static file.

Some experiments which were not effective:

- Switching to precomputing the data in a mongo aggregation to avoid some work in python.  This was slower no matter what I tried.

- Using a covering index where all values used were in the index (huge and not helpful)

- Changing the struct.pack in the rest response to try to use tobytes or numpy serialization.  This didn't change speed much and, in some instance, slowed things down.  It _seems_ like it would be faster to change how we serialized ids, but struct.pack is not the bottleneck.

- Removing the sort in the query helps.