### PR TITLE
Improve large annotation load and display speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Speed up annotation centroid queries ([#1981](../../pull/1981))
+- Improve large annotation load and display speed ([#1982](../../pull/1982))
 
 ## 1.33.0
 

--- a/girder_annotation/girder_large_image_annotation/rest/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/rest/annotation.py
@@ -115,8 +115,8 @@ class AnnotationResource(Resource):
         fields = list(
             (
                 'annotation.name', 'annotation.description',
-                'annotation.attributes', 'annotation.display',
-                'access', 'groups', '_version',
+                'annotation.attributes', 'annotation.display', 'access',
+                'groups', '_version', '_elementCount', '_detailsCount',
             ) + Annotation().baseFields)
         return Annotation().findWithPermissions(
             query, sort=sort, fields=fields, user=self.getCurrentUser(),


### PR DESCRIPTION
This makes a number of improvements to loading large annotations.  This has been tested with a set that is around 1/3 million polygons.

- When saving annotations, we now store the number of elements and "details" count on the annotation document and percolate this through so that a client gets this information (if available) with the base annotation (without its elements).  This allows a client to know a priori whether it will need to page elements and fetch centroids.

- When loading an annotation with element and details count, if we know the element will need to be paged, we skip the first partial load and go straight to loading the centroids.  Once the centroids are loaded we load the view-specific elements as usual.

- When panning (or loading in general), we were fetching the elements, loading them into the backbone model, then, if needed, asking to fetch more elements.  The effect of this on continual panning is that we had to finish a previous fetch, load the results, then start the new fetch for further panning.  This changes it so a follow-on fetch gets started _before_ loading the fetched elements into the backbone model so that the rest request is processing concurrently.  For large sets, this can reduce time between fetches substantially.

As a timing example:

Before: (a) fetch (1.81s) and load (0.2s) first set of elements, (b) fetch (3.42s) and load (0.67s) centroids.  Centroids are visible at 6.10s.  (c) fetch (2.14s) and load (0.30s) paged elements.  Fully resolved at 8.54s.   Then, zoom in, we have (a) fetch (2.52s) and load (2.52s) paged elements and then (b) fetch (1.72s) and load (0.72s) updated paged elements.  Resolved at 7.48s.

After: (a) fetch (3.52s) and load (0.46s) centroids.  Centroids are visible.  Centroids visible at 3.98s.  (b) fetch (2.11s) and load (0.31s) paged elements.  Fully resolved at 6.40s.  Then, zoom in, (a) fetch (2.50s) and short process (0.24s) and then (b) fetch (2.06s) and load (0.71s) updated paged elements.  Resolved at 5.51s.

Note the variation in times for zoom-in depends on where zoomed in and how much.

Follow on tasks:

- Populate element count and "details" count on existing annotations.

- Revisit speed up of paged queries.