### PR TITLE
Don't try to change annotation visibility if it isn't loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Speed up annotation centroid queries ([#1981](../../pull/1981))
 - Improve large annotation load and display speed ([#1982](../../pull/1982))
 
+### Bug Fixes
+
+- Add a guard to avoid a javascript except if annotations are not loaded enough ([#1983](../../pull/1983))
+
 ## 1.33.0
 
 ### Features

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -503,6 +503,9 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                     if (annotation._centroids && centroidFeature) {
                         if (centroidFeature.verticesPerFeature) {
                             this.viewer.scheduleAnimationFrame(() => {
+                                if (!annotation._shownIds) {
+                                    return;
+                                }
                                 const centroidFeature = featureList.find((f) => f._centroidFeature);
                                 const count = centroidFeature.data().length;
                                 const shown = new Float32Array(count);

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1257,8 +1257,8 @@ class TileSource(IPyLeafletMixin):
             else:
                 color = PIL.ImageColor.getcolor(self.edge, mode)
                 tile = tile.copy()
-                tile[:, contentWidth:] = color
-                tile[contentHeight:] = color
+                cast(np.ndarray, tile)[:, contentWidth:] = color
+                cast(np.ndarray, tile)[contentHeight:] = color
         if isinstance(tile, np.ndarray) and numpyAllowed:
             return tile
         tile = _imageToPIL(tile)


### PR DESCRIPTION
Add a guard to avoid a javascript except if annotations are not loaded enough