### PR TITLE
Use some raw bson handling to speed up annotationelement serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Improve large annotation load and display speed ([#1982](../../pull/1982))
 - Denormalize some values in the annotation collection to support improving display speed ([#1984](../../pull/1984))
 - Improve indices for annotationelement queries ([#1985](../../pull/1985))
+- Use some raw bson handling to speed up annotationelement serialization ([#1986](../../pull/1986))
 
 ### Bug Fixes
 


### PR DESCRIPTION
For some non-centroid annotation queries, handle raw-er BSON.  Delayed resolution of raw BSON improves speed when serializing points from polygons.

On a particular test query, the total response time for a large region dropped from 1.62s to 1.27s.