### PR TITLE
Improve indices used in large image associated files in girder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Denormalize some values in the annotation collection to support improving display speed ([#1984](../../pull/1984))
 - Improve indices for annotationelement queries ([#1985](../../pull/1985))
 - Use some raw bson handling to speed up annotationelement serialization ([#1986](../../pull/1986))
+- Improve indices used in large image associated files in girder ([#1988](../../pull/1988))
 
 ### Changes
 

--- a/girder/girder_large_image/models/image_item.py
+++ b/girder/girder_large_image/models/image_item.py
@@ -50,14 +50,16 @@ class ImageItem(Item):
         self.ensureIndices(['largeImage.fileId'])
         File().ensureIndices([
             ([
-                ('isLargeImageThumbnail', pymongo.ASCENDING),
-                ('attachedToType', pymongo.ASCENDING),
                 ('attachedToId', pymongo.ASCENDING),
+                ('attachedToType', pymongo.ASCENDING),
+                ('isLargeImageThumbnail', pymongo.ASCENDING),
+                ('thumbnailKey', pymongo.ASCENDING),
             ], {}),
             ([
-                ('isLargeImageData', pymongo.ASCENDING),
-                ('attachedToType', pymongo.ASCENDING),
                 ('attachedToId', pymongo.ASCENDING),
+                ('attachedToType', pymongo.ASCENDING),
+                ('isLargeImageData', pymongo.ASCENDING),
+                ('thumbnailKey', pymongo.ASCENDING),
             ], {}),
         ])
 


### PR DESCRIPTION
Reorder so that the attachedToId comes first and thumbnailKey is included.  This should cause mongo to use these indices more.