### PR TITLE
Handle a recent change in pylibtiff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.33.3
+
+### Changes
+
+- Handle a recent change in pylibtiff ([#1992](../../pull/1992))
+
 ## 1.33.2
 
 ### Bug Fixes

--- a/sources/tiff/large_image_source_tiff/tiff_reader.py
+++ b/sources/tiff/large_image_source_tiff/tiff_reader.py
@@ -80,6 +80,8 @@ def patchLibtiff():
     libtiff_ctypes.TIFFDataType.TIFF_SLONG8 = 17
     # BigTIFF 64-bit unsigned integer (offset)
     libtiff_ctypes.TIFFDataType.TIFF_IFD8 = 18
+    # Some versions of pylibtiff specify an argtypes where they shouldn't
+    libtiff_ctypes.libtiff.TIFFGetField.argtypes = None
 
 
 patchLibtiff()


### PR DESCRIPTION
pylibtiff 0.7.0 specifies, incorrectly, a constant argtype for a c call that breaks getting field values.  This code works around it and should do no harm on older versions