### PR TITLE
Add python 3.14 to our test.Dockerfile

### DIFF
--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LANG=en_US.UTF-8 \
     PYENV_ROOT="/.pyenv" \
     PATH="/.pyenv/bin:/.pyenv/shims:$PATH" \
-    PYTHON_VERSIONS="3.11 3.9 3.10 3.12 3.13"
+    PYTHON_VERSIONS="3.11 3.9 3.10 3.12 3.13 3.14"
 
 # Consumers of this package aren't expecting an existing ubuntu user (there
 # wasn't one in the ubuntu:22.04 base)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  test-py{39,310,311,312,313}
+  test-py{39,310,311,312,313,314}
   docs
   lint
   lintclient
@@ -62,7 +62,7 @@ setenv =
 
 # Versions that do have all tile sources.  Using the requirements-dev.txt file
 # installs in editable mode, which then includes results in coverage.
-[testenv:test-py{39,310,311,312,313}]
+[testenv:test-py{39,310,311,312,313,314}]
 # Don't package for tests where we use editable modes
 package = editable
 passenv = {[testenv:test]passenv}
@@ -83,45 +83,6 @@ allowlist_externals = {[testenv:test]allowlist_externals}
 commands = {[testenv:test]commands}
 setenv = {[testenv:test]setenv}
 
-[testenv:monkeytype-py{39,310,311,312,313}]
-passenv = {[testenv:test]passenv}
-deps =
-  -rrequirements-dev.txt
-  coverage
-  mock
-  pooch
-  pytest
-  pytest-cov
-  pytest-asyncio
-  pytest-custom-exit-code
-  pytest-girder
-  pytest-monkeytype
-  pytest-rerunfailures
-  pytest-xdist
-allowlist_externals = {[testenv:test]allowlist_externals}
-commands =
-  rm -rf build/test/coverage/web_temp
-  -rm ./monkeytype.sqlite3
-  girder build --dev
-  pytest --numprocesses 0 -m 'not notebook' --no-cov --suppress-no-test-exit-code --monkeytype-output=./monkeytype.sqlite3 {posargs}
-  - npx nyc report --temp-dir build/test/coverage/web_temp --report-dir build/test/coverage --reporter cobertura --reporter text-summary
-# After running tox, you can do
-# build/tox/monkeytype-py311/bin/monkeytype list-modules
-# and apply the results via
-# build/tox/monkeytype-py311/bin/monkeytype apply <module>
-setenv =
-  NPM_CONFIG_FUND=false
-  NPM_CONFIG_AUDIT=false
-  NPM_CONFIG_AUDIT_LEVEL=high
-  NPM_CONFIG_LOGLEVEL=warn
-  NPM_CONFIG_PROGRESS=false
-  NPM_CONFIG_PREFER_OFFLINE=true
-  PIP_FIND_LINKS=https://girder.github.io/large_image_wheels
-  PIP_PREFER_BINARY=1
-  GDAL_PAM_ENABLED=no
-  GDAL_HTTP_MAX_RETRY=5
-  GDAL_HTTP_RETRY_DELAY=5
-
 [testenv:server]
 description = Run all tests except Girder client
 deps = {[testenv:test]deps}
@@ -129,7 +90,7 @@ commands =
   pytest --numprocesses 0 -m 'singular and not girder_client' --cov-config tox.ini --suppress-no-test-exit-code {posargs}
   pytest --numprocesses {env:PYTEST_NUMPROCESSES:logical} -m 'not singular and not girder_client' --cov-config tox.ini --cov-append --suppress-no-test-exit-code {posargs}
 
-[testenv:server-py{39,310,311,312,313}]
+[testenv:server-py{39,310,311,312,313,314}]
 deps = {[testenv:server]deps}
 commands = {[testenv:server]commands}
 
@@ -157,7 +118,7 @@ commands =
   pytest --numprocesses 0 -m 'singular and not girder' --cov-config tox.ini --suppress-no-test-exit-code {posargs}
   pytest --numprocesses {env:PYTEST_NUMPROCESSES:logical} -m 'not singular and not girder and not notebook' --cov-config tox.ini --cov-append --suppress-no-test-exit-code {posargs}
 
-[testenv:core-py{39,310,311,312,313}]
+[testenv:core-py{39,310,311,312,313,314}]
 deps = {[testenv:core]deps}
 commands = {[testenv:core]commands}
 
@@ -214,7 +175,7 @@ deps =
 commands =
   mypy --config-file tox.ini {posargs}
 
-[testenv:type-py{39,310,311,312,313}]
+[testenv:type-py{39,310,311,312,313,314}]
 description = {[testenv:type]description}
 skipsdist = true
 deps = {[testenv:type]deps}
@@ -306,12 +267,12 @@ use_deveop = {[testenv:dev]use_deveop}
 deps = -rrequirements-dev-osx.txt
 commands = {[testenv:dev]commands}
 
-[testenv:dev-py{39,310,311,312,313}]
+[testenv:dev-py{39,310,311,312,313,314}]
 usedevelop = true
 deps = {[testenv:dev]deps}
 commands = {[testenv:dev]commands}
 
-[testenv:dev-osx-py{39,310,311,312,313}]
+[testenv:dev-osx-py{39,310,311,312,313,314}]
 usedevelop = true
 deps = {[testenv:dev-osx]deps}
 commands = {[testenv:dev-osx]commands}
@@ -353,7 +314,7 @@ commands =
   python -c "import test.datastore;test.datastore.fetch_all()"
   python {toxinidir}/test/lisource_compare.py --all build/tox/externaldata/* 'https://data.kitware.com/api/v1/file/hashsum/sha512/5e56cdb8fb1a02615698a153862c10d5292b1ad42836a6e8bce5627e93a387dc0d3c9b6cfbd539796500bc2d3e23eafd07550f8c214e9348880bbbc6b3b0ea0c/download' test/test_files/rgb*.tiff --projection= --projection=EPSG:3857 --yaml=build/tox/compare.yaml --out=build/tox/compare.txt
 
-[testenv:compare-py{39,310,311,312,313}]
+[testenv:compare-py{39,310,311,312,313,314}]
 description = {[testenv:compare]description}
 passenv = {[testenv:compare]passenv}
 setenv = {[testenv:compare]setenv}


### PR DESCRIPTION
A number of sources need other packages to release wheels for python 3.14; full Python 3.14 tests will be added when those exist