### PR TITLE
When overlaying many image annotations, some showed artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - Fixed recursion in the create large images in a folder endpoint ([#1993](../../pull/1993))
+- When overlaying many image annotations, some showed artifacts ([#1998](../../pull/1998))
 
 ## 1.33.3
 


### PR DESCRIPTION
Specifically, when we switched over to canvas renderers, the canvas renderer requires tiles to be cleaned at the edges.