### PR TITLE
Fix annotation caching with different users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed recursion in the create large images in a folder endpoint ([#1993](../../pull/1993))
 - When overlaying many image annotations, some showed artifacts ([#1998](../../pull/1998))
+- Fix annotation caching with different users ([#1999](../../pull/1999))
 
 ## 1.33.3
 

--- a/girder_annotation/girder_large_image_annotation/web_client/models/AnnotationModel.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/models/AnnotationModel.js
@@ -327,10 +327,11 @@ const AnnotationModel = AccessControlledModel.extend({
         }
 
         opts = opts || {};
+        var user = getCurrentUser();
         var restOpts = {
             url: (this.altUrl || this.resourceName) + '/' + this.get('_id'),
             /* Add our region request into the query */
-            data: Object.assign({}, this._region, {_: (this.get('updated') || this.get('created')) + '_' + this.get('_version')})
+            data: Object.assign({}, this._region, {_: (this.get('updated') || this.get('created')) + (user && user.id ? '_' + user.id : '') + '_' + this.get('_version')})
         };
         if (opts.extraPath) {
             restOpts.url += '/' + opts.extraPath;


### PR DESCRIPTION
We were allowing annotations to be cached which included a response about the edit permissions of the current user; this must only be cached on a per-user basis.