### PR TITLE
Load some sources early in girder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Increase the detail threshold for large annotations ([#1995](../../pull/1995))
 - Update to work with tol-colors >= 2 ([#2000](../../pull/2000))
+- Load some sources earlier in Girder ([#2004](../../pull/2004))
 
 ### Bug Fixes
 

--- a/girder/girder_large_image/__init__.py
+++ b/girder/girder_large_image/__init__.py
@@ -832,6 +832,14 @@ class LargeImagePlugin(GirderPlugin):
 
     def load(self, info):
         try:
+            # the mapnik binary files can complain about TLS exhaustion if they
+            # aren't loaded early.  This seems to be somehow slightly
+            # intractable in linux, so just load them now, but fail quietly
+            # since they are optional
+            import large_image_source_mapnik  # noqa
+        except Exception:
+            pass
+        try:
             getPlugin('worker').load(info)
         except Exception:
             logger.debug('worker plugin is unavailable')


### PR DESCRIPTION
The mapnik binary files can complain about TLS (thread local storage, transitively from libc) exhaustion if they aren't loaded early.  This seems to be somehow slightly intractable in linux, so just load them now, but fail quietly since they are optional.