### PR TITLE
Add a guard against out of bound pixelmap access.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - When overlaying many image annotations, some showed artifacts ([#1998](../../pull/1998))
 - Fix annotation caching with different users ([#1999](../../pull/1999))
 - Work around how bioformats handles DICOMs in Monochrome1 ([#1834](../../pull/1834))
+- Guard a missing data field in pixelmap annotation actions ([#2010](../../pull/2010), [#2011](../../pull/2011))
 
 ## 1.33.3
 

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -161,7 +161,6 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             extraArg = extraArg || '';
             // For pixelmap overlays, there are additional parameters to set
             layerParams.keepLower = false;
-            // DWM::
             if (_.isFunction(layerParams.url) || levelDifference) {
                 layerParams.url = (x, y, z) => getApiRoot() + '/item/' + pixelmapElement.girderId + `/tiles/zxy/${z - levelDifference}/${x}/${y}?encoding=PNG` + extraArg;
             } else {
@@ -180,12 +179,15 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
             const boundaries = pixelmapElement.boundaries;
             layerParams.style = {
                 color: (d, i) => {
-                    if (d < 0 || d >= categoryMap.length) {
+                    if (d < 0 || d >= categoryMap.length || d === undefined) {
                         console.warn(`No category found at index ${d} in the category map.`);
                         return 'rgba(0, 0, 0, 0)';
                     }
                     let color;
                     const category = categoryMap[d];
+                    if (!category) {
+                        return 'rgba(0, 0, 0, 0)';
+                    }
                     if (boundaries) {
                         color = (i % 2 === 0) ? category.fillColor : category.strokeColor;
                     } else {


### PR DESCRIPTION
Explicitly support 255,255,255 as the no-category category (requires a geojs update to fully be implemented).