### PR TITLE
Make it easier to rebind annotation models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Load some sources earlier in Girder ([#2004](../../pull/2004))
 - Increase number of annotation elements processed for metadata plots ([#2012](../../pull/2012))
 - More listed mimetypes ([#2013](../../pull/2013))
+- Make it easier to rebind annotation models ([#2014](../../pull/2014))
 
 ### Bug Fixes
 

--- a/girder_annotation/girder_large_image_annotation/web_client/models/AnnotationModel.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/models/AnnotationModel.js
@@ -82,7 +82,7 @@ const AnnotationModel = AccessControlledModel.extend({
 
     initialize() {
         if (!this.get('updated') && getCurrentUser()) {
-            this.attributes.updated = '' + Date.now(); // eslint-disable-line backbone/no-model-attributes
+            this.attributes.updated = (new Date()).toISOString(); // eslint-disable-line backbone/no-model-attributes
             this.attributes.updatedId = getCurrentUser().id; // eslint-disable-line backbone/no-model-attributes
         }
         this._region = {
@@ -99,18 +99,20 @@ const AnnotationModel = AccessControlledModel.extend({
             this.get('annotation').elements || []
         );
         this._elements.annotation = this;
-
-        this.listenTo(this._elements, 'change add remove reset', () => {
-            // copy the object to ensure a change event is triggered
-            var annotation = _.extend({}, this.get('annotation'));
-
-            annotation.elements = this._elements.toJSON();
-            this.set('annotation', annotation);
-        });
+        this.bindListeners();
+    },
+    bindListeners: function () {
+        this.listenTo(this._elements, 'change add remove reset', this.handleChangeEvent);
         this.listenTo(this._elements, 'change add', this.handleElementChanged);
         this.listenTo(this._elements, 'remove', this.handleElementRemoved);
     },
+    handleChangeEvent: function () {
+        // copy the object to ensure a change event is triggered
+        var annotation = _.extend({}, this.get('annotation'));
 
+        annotation.elements = this._elements.toJSON();
+        this.set('annotation', annotation);
+    },
     handleElementChanged: function (element, collection, options) {
         if (!this._centroids) {
             return;
@@ -521,7 +523,7 @@ const AnnotationModel = AccessControlledModel.extend({
         let xhr = false;
         if (!this.isNew()) {
             if (getCurrentUser()) {
-                this.attributes.updated = '' + Date.now(); // eslint-disable-line backbone/no-model-attributes
+                this.attributes.updated = (new Date()).toISOString(); // eslint-disable-line backbone/no-model-attributes
                 this.attributes.updatedId = getCurrentUser().id; // eslint-disable-line backbone/no-model-attributes
             }
             xhr = restRequest({


### PR DESCRIPTION
To allow clients to do less work when reloading models, make it easier to rebind annotation models.