### PR TITLE
Fixed an issue emitting geojson annotations with rotated rectangles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fix annotation caching with different users ([#1999](../../pull/1999))
 - Work around how bioformats handles DICOMs in Monochrome1 ([#1834](../../pull/1834))
 - Guard a missing data field in pixelmap annotation actions ([#2010](../../pull/2010), [#2011](../../pull/2011))
+- Fixed an issue emitting geojson annotations with rotated rectangles and ellipses ([#2015](../../pull/2015))
 
 ## 1.33.3
 

--- a/girder_annotation/girder_large_image_annotation/utils/__init__.py
+++ b/girder_annotation/girder_large_image_annotation/utils/__init__.py
@@ -149,7 +149,7 @@ class AnnotationGeoJSON:
         sinr = math.sin(r)
         x -= cx
         y -= cy
-        return [x * cosr - y * sinr + cx, x * sinr + y * sinr + cy, z]
+        return [x * cosr - y * sinr + cx, x * sinr + y * cosr + cy, z]
 
     def circleType(self, element, geom, prop):
         x, y, z = element['center']


### PR DESCRIPTION
This was a type.  This also affects ellipses