### PR TITLE
Fix copied annotation permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@
 
 ### Changes
 
-- Refactored internal code to use contextlib.suppress where appropriate ([#2030](../../pull/2030))
-- Drop support for Python 3.9 ([#2031](../../pull/2031))
+- Refactored internal code to use contextlib.suppress where appropriate ([#2031](../../pull/2031))
+- Drop support for Python 3.9 ([#2032](../../pull/2032))
 
 ### Bug Fixes
 
-- When reading raw files via the PIL source, fix handling uint16 data ([#2029](../../pull/2029))
+- When reading raw files via the PIL source, fix handling uint16 data ([#2030](../../pull/2030))
+- When copying an item via girder, ensure permissions on annotations are granted to the owner of the destination folder ([#2033](../../pull/2033))
 
 ## 1.33.5
 

--- a/girder_annotation/girder_large_image_annotation/models/annotation.py
+++ b/girder_annotation/girder_large_image_annotation/models/annotation.py
@@ -733,6 +733,7 @@ class Annotation(AccessControlledModel):
         destItemId = destItem['_id']
         folder = Folder().load(destItem['folderId'], force=True)
         count = 0
+        user = None
         for annotation in annotations:
             logger.info('Copying annotation %d of %d from %s to %s',
                         count + 1, total, srcItemId, destItemId)
@@ -748,7 +749,11 @@ class Annotation(AccessControlledModel):
             # as the item's folder.
             annotation.pop('access', None)
             self.copyAccessPolicies(destItem, annotation, save=False)
-            self.setPublic(annotation, folder.get('public'), save=False)
+            self.setPublic(annotation, folder.get('public') or False, save=False)
+            if user is None:
+                user = User().load(folder['creatorId'], force=True)
+            if user is not None:
+                self.setUserAccess(annotation, user, AccessType.ADMIN, force=True, save=False)
             self.save(annotation)
             count += 1
         logger.info('Copied %d annotations from %s to %s ',


### PR DESCRIPTION
When copying an item via girder, ensure permissions on annotations are granted to the owner of the destination folder