### PR TITLE
Use maxUnknown parameter with tifftools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add support for Python 3.14 ([#2022](../../pull/2022), [#2026](../../pull/2026))
 - In Jupyter, set edge value of tilesource to transparent ([#2019](../../pull/2019))
+- When reading tiff files via the tiff or openslide reader, stop reading sooner if they are corrupt ([#2037](../../pull/2037))
 
 ### Changes
 

--- a/sources/openslide/large_image_source_openslide/__init__.py
+++ b/sources/openslide/large_image_source_openslide/__init__.py
@@ -89,7 +89,7 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             msg = 'File will not be opened via OpenSlide.'
             raise TileSourceError(msg)
         try:
-            self._tiffinfo = tifftools.read_tiff(self._largeImagePath)
+            self._tiffinfo = tifftools.read_tiff(self._largeImagePath, maxUnknown=32)
             if tifftools.Tag.ICCProfile.value in self._tiffinfo['ifds'][0]['tags']:
                 self._iccprofiles = [self._tiffinfo['ifds'][0]['tags'][
                     tifftools.Tag.ICCProfile.value]['data']]

--- a/sources/openslide/setup.py
+++ b/sources/openslide/setup.py
@@ -40,7 +40,7 @@ setup(
         'openslide-bin; platform_system=="Windows" and platform_machine=="AMD64"',
         'openslide-bin; platform_system=="Darwin" and platform_machine=="arm64"',
         'openslide-bin; platform_system=="Darwin" and platform_machine=="x86_64"',
-        'tifftools>=1.2.0',
+        'tifftools>=1.7.0',
     ],
     extras_require={
         'girder': f'girder-large-image{limit_version}',

--- a/sources/tiff/large_image_source_tiff/__init__.py
+++ b/sources/tiff/large_image_source_tiff/__init__.py
@@ -45,7 +45,7 @@ with contextlib.suppress(importlib.metadata.PackageNotFoundError):
 
 @cachetools.cached(cache=cachetools.LRUCache(maxsize=10))
 def _cached_read_tiff(path):
-    return tifftools.read_tiff(path)
+    return tifftools.read_tiff(path, maxUnknown=32)
 
 
 class TiffFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):

--- a/sources/tiff/setup.py
+++ b/sources/tiff/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=[
         f'large-image{limit_version}',
         'pylibtiff',
-        'tifftools>=1.2.0',
+        'tifftools>=1.7.0',
     ],
     extras_require={
         'all': [


### PR DESCRIPTION
When reading tiff files via the tiff or openslide reader, stop reading sooner if they are corrupt.