### PR TITLE
Better handle partially complete items in the folder/tiles endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - When reading raw files via the PIL source, fix handling uint16 data ([#2030](../../pull/2030))
 - When copying an item via girder, ensure permissions on annotations are granted to the owner of the destination folder ([#2033](../../pull/2033))
+- The large_image/folder/{}/tiles endpoint didn't always handle partially complete items ([#2038](../../pull/2038))
 
 ## 1.33.5
 

--- a/girder/girder_large_image/rest/large_image_resource.py
+++ b/girder/girder_large_image/rest/large_image_resource.py
@@ -507,10 +507,13 @@ class LargeImageResource(Resource):
                 item, user, createJobs, localJobs, cancelJobs, redo, result)
         return result
 
-    def _createLargeImagesItem(
+    def _createLargeImagesItem(  # noqa
             self, item, user, createJobs, localJobs, cancelJobs, redo, result):
         if item.get('largeImage'):
-            previousFileId = item['largeImage'].get('originalId', item['largeImage']['fileId'])
+            try:
+                previousFileId = item['largeImage'].get('originalId', item['largeImage']['fileId'])
+            except Exception:
+                previousFileId = None
             if item['largeImage'].get('expected'):
                 if not cancelJobs:
                     result['itemsSkipped'] += 1


### PR DESCRIPTION
The large_image/folder/{}/tiles endpoint didn't always handle partially complete items.  It would throw in some conditions.