### PR TITLE
Handle openslide keys in internal metadata with poor names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,6 +370,7 @@ workflows:
                 - master
                 # Create a branch of this name to push to docker hub
                 - testdocker
+                - girder-3
       - testdocker-lts:
           filters:
             branches:
@@ -377,6 +378,7 @@ workflows:
                 - master
                 # Create a branch of this name to push to docker hub
                 - testdocker
+                - girder-3
       - py310:
           filters:
             tags:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.34.2
+
+### Improvements
+
+- Handle openslide keys in internal metadata with poor names ([#2061](../../pull/2061))
+
 ## 1.34.1
 
 ### Improvements

--- a/girder/setup.py
+++ b/girder/setup.py
@@ -40,7 +40,7 @@ setup(
     extras_require={
         'tasks': [
             f'large-image-tasks[girder]{limit_version}',
-            'girder-worker[girder]>=0.6.0',
+            'girder-worker[girder]>=0.6.0,<5',
         ],
     },
     include_package_data=True,

--- a/large_image/tilesource/geo.py
+++ b/large_image/tilesource/geo.py
@@ -152,7 +152,7 @@ class GDALBaseFileTileSource(GeoBaseFileTileSource):
                           if 'bands' in cast(JSONDict, self.style) else [self.style])
             for styleBand in styleBands:
 
-                styleBand = styleBand.copy()
+                styleBand = cast(JSONDict, styleBand).copy()
                 # Default to band 1 -- perhaps we should default to gray or
                 # green instead.
                 styleBand['band'] = self._bandNumber(styleBand.get('band', 1))
@@ -198,7 +198,8 @@ class GDALBaseFileTileSource(GeoBaseFileTileSource):
             styleBands = (cast(JSONDict, self.style)['bands']
                           if 'bands' in cast(JSONDict, self.style) else [self.style])
             if not len(styleBands) or (len(styleBands) == 1 and isinstance(
-                    styleBands[0].get('band', 1), int) and styleBands[0].get('band', 1) <= 0):
+                    cast(JSONDict, styleBands[0]).get('band', 1), int) and
+                    cast(JSONDict, styleBands[0]).get('band', 1) <= 0):
                 del self._style
         style = self._styleBands()
         if len(style):

--- a/sources/openslide/large_image_source_openslide/__init__.py
+++ b/sources/openslide/large_image_source_openslide/__init__.py
@@ -316,6 +316,8 @@ class OpenslideFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         """
         results = {'openslide': {}}
         for key in self._openslide.properties:
+            if not key or not len(key) or key.endswith('.'):
+                continue
             results['openslide'][key] = self._openslide.properties[key]
             if key == 'openslide.comment':
                 leader = self._openslide.properties[key].split('\n', 1)[0].strip()

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
   pytest-cov
   pytest-asyncio
   pytest-custom-exit-code
-  pytest-girder
+  pytest-girder<5
   pytest-rerunfailures
   pytest-xdist
 allowlist_externals =
@@ -76,7 +76,7 @@ deps =
   pytest-cov
   pytest-asyncio
   pytest-custom-exit-code
-  pytest-girder
+  pytest-girder<5
   pytest-rerunfailures
   pytest-xdist
 allowlist_externals = {[testenv:test]allowlist_externals}

--- a/utilities/tasks/setup.py
+++ b/utilities/tasks/setup.py
@@ -39,18 +39,18 @@ setup(
     python_requires='>=3.10',
     install_requires=[
         # Packages required by both producer and consumer side installations
-        'girder-worker-utils>=0.8.5',
+        'girder-worker-utils>=0.8.5,<5',
     ],
     extras_require={
         'girder': [
             # Dependencies required on the producer (Girder) side.
             f'large-image-converter{limit_version}',
-            'girder-worker[girder]>=0.6.0',
+            'girder-worker[girder]>=0.6.0,<5',
         ],
         'worker': [
             # Dependencies required on the consumer (Girder Worker) side.
             f'large-image-converter[sources]{limit_version}',
-            'girder-worker[worker]>=0.6.0',
+            'girder-worker[worker]>=0.6.0,<5',
         ],
     },
     entry_points={


### PR DESCRIPTION
Some redacted data ends up with key names of 'aperio.' which causes issues elsewhere.  Strip this from internal metadata.