### PR TITLE
Set an expiry duration on redis cache entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - In Girder, by default include Updated in lists; do not show controls in dialog lists ([#2078](../../pull/2078))
 
+### Changes
+- Set an expiry duration on redis cache entries ([#2092](../../pull/2092))
+
 ### Bug Fixes
 
 - Fixed a typo in the word "description" in the multi-source and annotation schemas ([#2082](../../pull/2082))

--- a/large_image/cache_util/rediscache.py
+++ b/large_image/cache_util/rediscache.py
@@ -44,6 +44,11 @@ class RedisCache(BaseCache):
         from redis.client import Redis
 
         self.redis = redis
+        # The expiry_ttl is in seconds.  If redis is started with
+        # maxmemory-policy set to volatile-lru, tiles will be evicted under
+        # memory pressure.  This should be an arbitrarily high value unless
+        # actual TTL is desired.
+        self.expiry_ttl = 86400 * 100
         self._redisCls = Redis
         super().__init__(0, getsizeof=getsizeof)
         self._cache_key_prefix = 'large_image_'
@@ -101,7 +106,7 @@ class RedisCache(BaseCache):
     def __setitem__(self, key: str, value: Any) -> None:
         _key = self._cache_key_prefix + self._hashKey(key)
         try:
-            self._client.set(_key, pickle.dumps(value))
+            self._client.set(_key, pickle.dumps(value), ex=self.expiry_ttl)
         except (TypeError, KeyError) as exc:
             valueSize = value.shape if hasattr(value, 'shape') else (
                 value.size if hasattr(value, 'size') else (


### PR DESCRIPTION
This sets a long-duration TTL.  When redis is started with a max-memory policy of 'volatile-lru', any key that has ANY expiry becomes a candidate under memory pressure.  Redis says it samples keys and evicts the least used value.  The key functionally gets evicted when its TTL expires, so we want a long horizon to not prematurely evict values.

There are two eviction mechanisms in redis.  There is some lazy background process that checks for and removes expired keys.  These are functionally missing if accessed (and, maybe removed when that happens). Otherwise, when memory is full, if the 'volatile-lru' option is set, sampled low-usage keys are evicted.  The 'allkeys-lru' acts like it has functionally set a expiry that is very-very long on any key that doesn't otherwise have an expiry time.

The main virtue of this change is that we can use a redis cache set to volatile-lru and it will honor persistent keys.  If other keys have a TTL, they, too, may get evicted, and the expiry is not part of the LRU selection process.

Closes #2081