### PR TITLE
Fix zarr sink multi-process concurrency for python 3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add a few missing type annotations ([#2074](../../pull/2074))
 
+### Bug Fixes
+
+- Fix zarr sink multi-process concurrency for python 3.14 ([#2098](../../pull/2098))
+
 ## 1.35.0
 
 ### Features

--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -2,7 +2,6 @@ import contextlib
 import importlib.metadata
 import json
 import math
-import multiprocessing
 import os
 import shutil
 import tempfile
@@ -11,6 +10,7 @@ import uuid
 import warnings
 from pathlib import Path
 
+import filelock
 import numpy as np
 import packaging.version
 
@@ -146,7 +146,7 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         self._editable = True
         self._bandRanges = None
         self._threadLock = threading.RLock()
-        self._processLock = multiprocessing.Lock()
+        self._processLock = filelock.FileLock(os.path.join(str(self._tempdir), '.zarr_flock'))
         self._framecount = 0
         self._minWidth = None
         self._minHeight = None

--- a/sources/zarr/setup.py
+++ b/sources/zarr/setup.py
@@ -41,6 +41,7 @@ setup(
         'numcodecs<0.16',
         # Without imagecodecs-numcodecs, some jpeg encoded data cannot be read
         'imagecodecs-numcodecs!=2024.9.22',
+        'filelock',
     ],
     extras_require={
         'girder': f'girder-large-image{limit_version}',

--- a/test/test_sink.py
+++ b/test/test_sink.py
@@ -534,7 +534,6 @@ def _add_tile_from_seed_data(sink, seed_data, position):
     )
 
 
-@pytest.mark.skipif(sys.version_info > (3, 14), reason='This fails in 3.14. See issues')
 @pytest.mark.singular
 def testConcurrency(tmp_path):
     output_file = tmp_path / 'test.db'


### PR DESCRIPTION
Use filelock instead of multiprocessing lock.  This should work on all python versions; multiprocessing lock is not actually cross process in python 3.14 (?!).

Closes #2023.