### PR TITLE
Change how we use filelocks across processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Bug Fixes
 
-- Fix zarr sink multi-process concurrency for python 3.14 ([#2098](../../pull/2098))
+- Fix zarr sink multi-process concurrency for python 3.14 ([#2098](../../pull/2098), [#2100](../../pull/2100))
 
 ## 1.35.0
 

--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -146,7 +146,6 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         self._editable = True
         self._bandRanges = None
         self._threadLock = threading.RLock()
-        self._processLock = filelock.FileLock(os.path.join(str(self._tempdir), '.zarr_flock'))
         self._framecount = 0
         self._minWidth = None
         self._minHeight = None
@@ -165,6 +164,12 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         if not self._created:
             with contextlib.suppress(Exception):
                 self._validateZarr()
+
+    def _processLock(self):
+        """
+        This is a function to avoid pickling issues.
+        """
+        return filelock.FileLock(os.path.join(str(self._tempdir), '.zarr_flock'))
 
     def __del__(self):
         if not hasattr(self, '_derivedSource'):
@@ -739,7 +744,7 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         }
         tile, mask, placement, axes = self._validateNewTile(tile, mask, placement, axes)
 
-        with self._threadLock and self._processLock:
+        with self._threadLock and self._processLock():
             old_axes = self._axes if hasattr(self, '_axes') else {}
             self._axes = {k: i for i, k in enumerate(axes)}
             new_axes = {k: i for k, i in self._axes.items() if k not in old_axes}
@@ -841,7 +846,7 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
             with an image.  The numpy array can have 2 or 3 dimensions.
         """
         data, _ = _imageToNumpy(image)
-        with self._threadLock and self._processLock:
+        with self._threadLock and self._processLock():
             if imageKey is None:
                 # Each associated image should be in its own group
                 num_existing = len(self.getAssociatedImagesList())
@@ -897,7 +902,7 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         Metadata structure adheres to OME schema from https://ngff.openmicroscopy.org/latest/
         """
         self._checkEditable()
-        with self._threadLock and self._processLock:
+        with self._threadLock and self._processLock():
             name = str(self._tempdir.name).split('/')[-1]
             arrays = dict(self._zarr.arrays())
             datasets = []


### PR DESCRIPTION
filelock 3.30 complains because filelocks are really not pickleable, so change how we are using them.  This will be slower.

Strictly, this could be done in a more complicated way by changing how we pickle (reduce) and unpickle the class, but that involves its own overhead.  This is conceptually simple, and we can revisit it if it seems like it is not faster enough.