### PR TITLE
Fix subtile dx/dy slicing

### DIFF
--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -1236,7 +1236,7 @@ class TileSource(IPyLeafletMixin):
                 self._bandCount = tile.shape[-1] if len(tile.shape) == 3 else 1
             elif isinstance(tile, PIL.Image.Image):
                 self._dtype = np.uint8 if ';16' not in tile.mode else np.uint16
-                self._bandCount = len(tile.mode)
+                self._bandCount = len(tile.getbands())
             else:
                 _img = _imageToNumpy(tile)[0]
                 self._dtype = np.dtype(_img.dtype)
@@ -1633,7 +1633,7 @@ class TileSource(IPyLeafletMixin):
                         x * scale + newX, y * scale + newY, z,
                         pilImageAllowed=False, numpyAllowed='always',
                         sparseFallback=True, edge=False, frame=kwargs.get('frame'))
-                    subtile = subtile[dx::scale, dy::scale]
+                    subtile = subtile[dy::scale, dx::scale]
                     nptile[ty:ty + subtile.shape[0], tx:tx + subtile.shape[1]] = subtile
             return nptile, TILE_FORMAT_NUMPY
         while z - basez > self._maxSkippedLevels:


### PR DESCRIPTION
- fix subtile dx/dy slicing
- use tile.getbands() instead of tile.mode