### PR TITLE
Test the fix for subtile slicing for certain empty layer interpolations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bug Fixes
 
 - Fix zarr sink multi-process concurrency for python 3.14 ([#2098](../../pull/2098), [#2100](../../pull/2100))
+- Fix subtile slicing for certain empty layer interpolations ([#2101](../../pull/2101))
 
 ## 1.35.0
 

--- a/test/test_source_base.py
+++ b/test/test_source_base.py
@@ -885,3 +885,17 @@ def testKnownExtensionList():
     assert len(large_image.tilesource.listSources()['extensions']) > 100
     assert len(large_image.listExtensions()) > 100
     assert len(large_image.listMimeTypes()) > 10
+
+
+def testSubtileSlicing():
+    """
+    This specifically exercises the code in _getTileFromEmptyLevel when we get
+    one tile per pixel.  See PR #2101 for the fix that this checks
+    """
+    import large_image_source_test
+
+    ts = large_image_source_test.TestTileSource(
+        minLevel=9, tileWidth=20, tileHeight=30, sizeX=20 * 2 ** 9,
+        sizeY=30 * 2 ** 7, monochrome=True, failBelowMinLevel=False)
+    data = ts.getTile(1, 0, 2, pilImageAllowed=False, numpyAllowed='always')
+    assert np.amin(data) > 0


### PR DESCRIPTION
This is a test that would fail before #2101 and succeeds after the fix.