### PR TITLE
Check the number of bands in a pil image via getbands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 - Added more options to the TestTileSource ([#2102](../../pull/2102))
+- Change a band-count check for a PIL image to getbands() instead of mode ([#2104](../../pull/2104))
 
 ### Bug Fixes
 

--- a/large_image/tilesource/base.py
+++ b/large_image/tilesource/base.py
@@ -2684,7 +2684,7 @@ class TileSource(IPyLeafletMixin):
         pixel['value'] = [v.item() for v in tile['tile'][0][0]]
         img = _imageToPIL(tile['tile'])
         if img.size[0] >= 1 and img.size[1] >= 1:
-            if len(img.mode) > 1:
+            if len(img.getbands()) > 1:
                 pixel.update(dict(zip(img.mode.lower(), img.load()[0, 0], strict=True)))
             else:
                 pixel.update(dict(zip([img.mode.lower()], [img.load()[0, 0]], strict=True)))


### PR DESCRIPTION
img.mode is OFTEN the same, but not always.