### PR TITLE
Fix tile overlap handling in LazyTileDict

### DIFF
--- a/large_image/tilesource/tiledict.py
+++ b/large_image/tilesource/tiledict.py
@@ -220,11 +220,12 @@ class LazyTileDict(dict):
                     pilImageAllowed=True,
                     numpyAllowed='always' if TILE_FORMAT_NUMPY in self.format else True,
                     sparseFallback=True, frame=self.frame)
-                if self.crop:
-                    tileData, _ = _imageToNumpy(tileData)
-                    tileData = tileData[self.crop[1]:self.crop[3], self.crop[0]:self.crop[2]]
             else:
                 tileData = self._retileTile()
+
+            if self.crop:
+                tileData, _ = _imageToNumpy(tileData)
+                tileData = tileData[self.crop[1]:self.crop[3], self.crop[0]:self.crop[2]]
 
             pilData = None
             # resample if needed


### PR DESCRIPTION
`crop` is silently ignored when `retile` is active:

- Location: [`__getitem__`](https://github.com/girder/large_image/blob/master/large_image/tilesource/tiledict.py#L227)
- When both `self.retile` and `self.crop` is truthy, current codebase will ignore the `crop` operation entirely. A user who requests a cropped retiled region receives the full uncropped retile instead.

The following code will show the difference in tile size:

```python
import large_image

slide = large_image.open("a_test_tiff.tiff")

img_dict = slide.getSingleTile(
    x=1000,
    y=1000,
    width=1000,
    height=1000,
    format=large_image.tilesource.TILE_FORMAT_PIL,
    tile_size={"width": 256, "height": 256},
    level=0,
    tile_overlap={"x": 10, "y": 10, "edges": True}, # set edges to True to enable the crop
)
print(img_dict)

'''
{'x': 0, 'y': 0, 'width': 256, 'height': 256, 'level': 10, 'level_x': 0, 'level_y': 0, 'magnification': 100.0, 'mm_x': 7.47581845238095e-05, 'mm_y': 7.47581845238095e-05, 'tile_position': {'level_x': 0, 'level_y': 0, 'region_x': 0, 'region_y': 0, 'position': 0}, 'iterator_range': {'level_x_min': 0, 'level_y_min': 0, 'level_x_max': 601, 'level_y_max': 1314, 'region_x_max': 601, 'region_y_max': 1314, 'position': 789714}, 'tile_overlap': {'left': 0, 'top': 0, 'right': 5, 'bottom': 5}, 'tile': None, 'format': None, 'gx': 0.0, 'gy': 0.0, 'gwidth': 256.0, 'gheight': 256.0}
'''

img = img_dict["tile"]
print(img.size) # will print (251, 251), but the expected size should be (246, 246)
```

