### PR TITLE
Shrink the test docker by removing ensurepip

### DIFF
--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -97,6 +97,7 @@ RUN pyenv update && \
     rm -rf /tmp/* /var/tmp/* /root/.cache/* && \
     find /.pyenv '(' -name '*.so' -o -name '*.a' -o -name '*.so.*' ')' -exec strip --strip-unneeded -p -D {} \; && \
     find /.pyenv -name 'libpython*.a' -delete && \
+    find /.pyenv -name ensurepip -type d -exec rm -r {} \+ && \
     # This makes duplicate python library files hardlinks of each other \
     rdfind -minsize 8192 -makehardlinks true -makeresultsfile false /.pyenv
 


### PR DESCRIPTION
ensurepip for older pythons vendors in an older setuptools that trivy is now showing CVEs against, so this both reduces the docker size and coincidentally reduces the CVE complaints (for something that should be unreachable).