### PR TITLE
Delete stale pip vendor files in the docker image

### DIFF
--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -97,6 +97,8 @@ RUN pyenv update && \
     rm -rf /tmp/* /var/tmp/* /root/.cache/* && \
     find /.pyenv '(' -name '*.so' -o -name '*.a' -o -name '*.so.*' ')' -exec strip --strip-unneeded -p -D {} \; && \
     find /.pyenv -name 'libpython*.a' -delete && \
+    find /.pyenv -name 'vendor.txt' -delete && \
+    find /.pyenv -name 'bom.cdx.json' -delete && \
     # This makes duplicate python library files hardlinks of each other \
     rdfind -minsize 8192 -makehardlinks true -makeresultsfile false /.pyenv
 


### PR DESCRIPTION
These cause false positives from trivy's scan.  Trivy should detect _actual_ versions and report correctly.