### PR TITLE
Add FORCE_GDAL_VSIS3 configuration option

### DIFF
--- a/docs/config_options.rst
+++ b/docs/config_options.rst
@@ -128,6 +128,12 @@ Some functionality of large_image is controlled through configuration parameters
      - ``bool | str: one of PIL.ImageCms.Intents``
      - ``True``
 
+       .. _config_force_gdal_vsis3:
+   * - ``force_gdal_vsis3`` :ref:`🔗 <config_force_gdal_vsis3>`
+     - If True, remote URLs opened through GDAL-based tile sources use GDAL's ``/vsis3/`` virtual file system instead of ``/vsicurl/``.  ``s3://`` URLs already use ``/vsis3/``; this setting forces the same for ``http``/``https`` URLs by mapping the URL path to ``/vsis3/<path>``.  ``ftp`` URLs continue to use ``/vsicurl/`` and emit a warning, since ``/vsis3/`` cannot serve FTP.  Use this with MinIO or other S3-compatible stores when ``AWS_S3_ENDPOINT`` (and related AWS/GDAL credentials) are configured so GDAL authenticates via the S3 API rather than plain HTTP.
+     - ``bool``
+     - ``False``
+
        .. _config_max_annotation_input_file_length:
    * - ``max_annotation_input_file_length`` :ref:`🔗 <config_max_annotation_input_file_length>`
      - When an annotation file is uploaded through Girder, it is loaded into memory, validated, and then added to the database.  This is the maximum number of bytes that will be read directly.  Files larger than this are ignored.
@@ -154,6 +160,8 @@ Configuration from Environment
 All configuration parameters can be specified as environment parameters by prefixing their uppercase names with ``LARGE_IMAGE_``.  For instance, ``LARGE_IMAGE_CACHE_BACKEND=python`` specifies the cache backend.  If the values can be decoded as json, they will be parsed as such.  That is, numerical values will be parsed as numbers; to parse them as strings, surround them with double quotes.
 
 As another example, to use the least memory possible, set ``LARGE_IMAGE_CACHE_BACKEND=python LARGE_IMAGE_CACHE_PYTHON_MEMORY_PORTION=1000 LARGE_IMAGE_CACHE_TILESOURCE_MAXIMUM=2``.  The first setting specifies caching tiles in the main process and not in memcached or an external cache.  The second setting asks to use 1/1000th of the memory for a tile cache.  The third settings caches no more than 2 tile sources (2 is the minimum).
+
+When using MinIO (or another S3-compatible endpoint) with GDAL, set ``LARGE_IMAGE_FORCE_GDAL_VSIS3=true`` so remote object URLs are opened via ``/vsis3/`` instead of ``/vsicurl/``.  Pair this with GDAL/AWS settings such as ``AWS_S3_ENDPOINT``, ``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``, and typically ``AWS_VIRTUAL_HOSTING=FALSE`` / ``AWS_HTTPS=NO`` as appropriate for your MinIO local development (see https://gdal.org/en/stable/user/virtual_file_systems.html for more details).
 
 Configuration within the Girder Plugin
 --------------------------------------

--- a/large_image/config.py
+++ b/large_image/config.py
@@ -82,6 +82,11 @@ ConfigValues = {
     # Any path that matches here will only be opened by a source that matches
     # extension or mime type.
     'all_sources_ignored_names': r'(\.mrxs|\.vsi)$',
+
+    # If True, make_vsi uses /vsis3/ for http(s) URLs instead of /vsicurl/.
+    # Useful with MinIO when AWS_S3_ENDPOINT (and related GDAL/AWS env vars)
+    # are configured.
+    'force_gdal_vsis3': False,
 }
 
 

--- a/large_image/tilesource/geo.py
+++ b/large_image/tilesource/geo.py
@@ -9,6 +9,7 @@ import numpy as np
 import PIL.Image
 
 from ..cache_util import CacheProperties, methodcache
+from ..config import getConfig, getLogger
 from ..constants import SourcePriority, TileInputUnits
 from ..exceptions import TileSourceError
 from .base import FileTileSource
@@ -30,12 +31,32 @@ if 'GDAL_PAM_ENABLED' not in os.environ:
 
 
 def make_vsi(url: str | pathlib.Path | dict[Any, Any], **options) -> str:
-    if str(url).startswith('s3://'):
-        s3_path = str(url).replace('s3://', '')
+    """
+    Build a GDAL Virtual File System path for a remote URL.
+
+    ``s3://`` URLs always use ``/vsis3/``.  Other URLs use ``/vsicurl/``
+    unless the ``force_gdal_vsis3`` config option is set, in which case
+    ``http``/``https`` URL paths are mapped to ``/vsis3/`` (intended for MinIO
+    and similar S3-compatible stores used with ``AWS_S3_ENDPOINT``).  ``ftp``
+    URLs always use ``/vsicurl/``; if ``force_gdal_vsis3`` is set, a warning is
+    logged because ``/vsis3/`` cannot serve FTP.
+    """
+    url_str = str(url)
+    parsed = urlparse(url_str)
+    force_vsis3 = getConfig('force_gdal_vsis3')
+    if url_str.startswith('s3://') or (force_vsis3 and parsed.scheme in {'http', 'https'}):
+        if url_str.startswith('s3://'):
+            s3_path = url_str.replace('s3://', '', 1)
+        else:
+            s3_path = parsed.path.lstrip('/')
         vsi = f'/vsis3/{s3_path}'
     else:
+        if force_vsis3 and parsed.scheme == 'ftp':
+            getLogger().warning(
+                'force_gdal_vsis3 is set but ftp:// URLs cannot use /vsis3/; '
+                'using /vsicurl/ for %s', url_str)
         gdal_options = {
-            'url': str(url),
+            'url': url_str,
             'use_head': 'no',
             'list_dir': 'no',  # don't search for adjacent files
             'empty_dir': 'yes',  # don't probe for sidecar files

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -78,3 +78,22 @@ def testRasterioDefaultNoProjection():
     path = 'test/test_files/test_orient1.tif'
     src = large_image_source_rasterio.open(path)
     assert src.projection is None
+
+
+def testMakeVsiForceGdalVsis3():
+    from large_image.tilesource.geo import make_vsi
+
+    http_url = 'http://minio:9000/mybucket/path/to/image.tif'
+    ftp_url = 'ftp://example.com/path/to/image.tif'
+    assert make_vsi(http_url).startswith('/vsicurl?')
+
+    setConfig('force_gdal_vsis3', True)
+    try:
+        assert make_vsi(http_url) == '/vsis3/mybucket/path/to/image.tif'
+        assert make_vsi('https://minio:9000/mybucket/path/to/image.tif') == (
+            '/vsis3/mybucket/path/to/image.tif')
+        assert make_vsi('s3://mybucket/path/to/image.tif') == '/vsis3/mybucket/path/to/image.tif'
+        # ftp cannot use /vsis3/; keep /vsicurl/ and warn
+        assert make_vsi(ftp_url).startswith('/vsicurl?')
+    finally:
+        setConfig('force_gdal_vsis3', False)


### PR DESCRIPTION
resolves #2110 

- Adds new Configuration/Environment variable of `FORCE_GDAL_VSIS3`
- Allows forcing GDAL to make_vsi path that utilizes VSIS3 even when the URL does not contain `s3://`.
    - This is so MinIO and local development can utilize VSIS3 and not fall back to vsicurl 
- Updates the `make_vsi` function to utilize the new forcing configuration value
    - For `ftp:` it will swap to `vsicurl` and warn in the logger that vsis3 doesn't support `ftp:`
 - Adds tests for the config and the `ftp` corner case
 - Updates documentation to include new configuration option as well as referencing the need for the GDAL environment variables to be configured/set like `AWS_SECRET_KEY` and `AWS_ACCESS_KEY`

