### PR TITLE
Allow customizing unselected annotation dimming

### DIFF
--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -29,7 +29,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
         this._globalAnnotationOpacity = settings.globalAnnotationOpacity || 1.0;
         this._globalAnnotationFillOpacity = settings.globalAnnotationFillOpacity || 1.0;
         this._unselectedOpacityMultiplier = typeof settings.unselectedOpacityMultiplier !== 'number'
-            ? 0.25
+            ? 0.33
             : settings.unselectedOpacityMultiplier;
         this.listenTo(events, 's:widgetDrawRegionEvent', this.drawRegion);
         this.listenTo(events, 's:widgetClearRegion', this.clearRegion);
@@ -957,7 +957,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
 
         setUnselectedOpacityMultiplier: function (opacityMultiplier) {
             this._unselectedOpacityMultiplier = typeof opacityMultiplier !== 'number'
-                ? 0.25
+                ? 0.33
                 : opacityMultiplier;
             if (this.featureLayer) {
                 _.each(this._annotations, (layer, annotationId) => {

--- a/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
+++ b/girder_annotation/girder_large_image_annotation/web_client/views/imageViewerWidget/geojs.js
@@ -28,10 +28,14 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
         this._unclampBoundsForOverlay = true;
         this._globalAnnotationOpacity = settings.globalAnnotationOpacity || 1.0;
         this._globalAnnotationFillOpacity = settings.globalAnnotationFillOpacity || 1.0;
+        this._unselectedOpacityMultiplier = typeof settings.unselectedOpacityMultiplier !== 'number'
+            ? 0.25
+            : settings.unselectedOpacityMultiplier;
         this.listenTo(events, 's:widgetDrawRegionEvent', this.drawRegion);
         this.listenTo(events, 's:widgetClearRegion', this.clearRegion);
         this.listenTo(events, 'g:startDrawMode', this.startDrawMode);
         this._hoverEvents = settings.hoverEvents;
+
         return initialize.apply(this, _.rest(arguments));
     });
 
@@ -603,7 +607,8 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                     highlightannot: this._highlightAnnotation,
                     highlightelem: this._highlightElement,
                     hideannot: this._hideAnnotation,
-                    hideelem: this._hideElement
+                    hideelem: this._hideElement,
+                    unselectedOpacityMultiplier: this._unselectedOpacityMultiplier
                 };
 
                 if (_.isMatch(feature._lastFeatureProp, prop)) {
@@ -627,8 +632,8 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                         fillOpacityArray[i] = fillOpacity;
                         strokeOpacityArray[i] = strokeOpacity;
                     } else {
-                        fillOpacityArray[i] = fillOpacity * 0.25;
-                        strokeOpacityArray[i] = strokeOpacity * 0.25;
+                        fillOpacityArray[i] = fillOpacity * this._unselectedOpacityMultiplier;
+                        strokeOpacityArray[i] = strokeOpacity * this._unselectedOpacityMultiplier;
                     }
                 }
 
@@ -644,7 +649,7 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
                     if (overlayLayer) {
                         let newOpacity = (overlay.opacity || 1) * this._globalAnnotationOpacity;
                         if (this._highlightAnnotation && annotationId !== this._highlightAnnotation) {
-                            newOpacity = newOpacity * 0.25;
+                            newOpacity = newOpacity * this._unselectedOpacityMultiplier;
                         }
                         overlayLayer.opacity(newOpacity);
                     }
@@ -940,6 +945,20 @@ var GeojsImageViewerWidgetExtension = function (viewer) {
 
         setGlobalAnnotationFillOpacity: function (opacity) {
             this._globalAnnotationFillOpacity = opacity;
+            if (this.featureLayer) {
+                _.each(this._annotations, (layer, annotationId) => {
+                    const features = layer.features;
+                    this._mutateFeaturePropertiesForHighlight(annotationId, features);
+                });
+                this.viewer.scheduleAnimationFrame(this.viewer.draw);
+            }
+            return this;
+        },
+
+        setUnselectedOpacityMultiplier: function (opacityMultiplier) {
+            this._unselectedOpacityMultiplier = typeof opacityMultiplier !== 'number'
+                ? 0.25
+                : opacityMultiplier;
             if (this.featureLayer) {
                 _.each(this._annotations, (layer, annotationId) => {
                     const features = layer.features;

--- a/girder_annotation/test_annotation/web_client_specs/geojsSpec.js
+++ b/girder_annotation/test_annotation/web_client_specs/geojsSpec.js
@@ -949,6 +949,20 @@ $(function () {
                 checkFeatureOpacity(annotation2.id, 0.5, 1);
             });
 
+            it('handles custom unselected opacity multiplier', function () {
+                viewer.setUnselectedOpacityMultiplier(0.5);
+                viewer.highlightAnnotation(annotation1.id);
+
+                checkFeatureOpacity(annotation1.id, 0.5, 1);
+                checkFeatureOpacity(annotation2.id, 0.5 * 0.5, 0.5);
+
+                viewer.highlightAnnotation();
+                viewer.setUnselectedOpacityMultiplier();
+
+                checkFeatureOpacity(annotation1.id, 0.5, 1);
+                checkFeatureOpacity(annotation2.id, 0.5, 1);
+            });
+
             it('hide an element', function () {
                 viewer.hideAnnotation(annotation2.id, element21);
 

--- a/girder_annotation/test_annotation/web_client_specs/geojsSpec.js
+++ b/girder_annotation/test_annotation/web_client_specs/geojsSpec.js
@@ -927,14 +927,14 @@ $(function () {
                 viewer.highlightAnnotation(annotation1.id);
 
                 checkFeatureOpacity(annotation1.id, 0.5, 1);
-                checkFeatureOpacity(annotation2.id, 0.5 * 0.25, 0.25);
+                checkFeatureOpacity(annotation2.id, 0.5 * 0.33, 0.33);
             });
 
             it('highlight a single element', function () {
                 viewer.highlightAnnotation(annotation2.id, element21);
 
-                checkFeatureOpacity(annotation1.id, 0.5 * 0.25, 0.25);
-                checkFeatureOpacity(annotation2.id, 0.5 * 0.25, 0.25, function (data) {
+                checkFeatureOpacity(annotation1.id, 0.5 * 0.33, 0.33);
+                checkFeatureOpacity(annotation2.id, 0.5 * 0.33, 0.33, function (data) {
                     return data.id !== element21;
                 });
                 checkFeatureOpacity(annotation2.id, 0.5, 1, function (data) {


### PR DESCRIPTION
Prerequisite for: https://github.com/DigitalSlideArchive/HistomicsUI/pull/542

Allow passing in `unselectedOpacityMultiplier` to the `settings` object for the GeoJS Image Viewer widget class. If no value is passed (or a non-numerical value is passed), fall back to the `0.25` as the default (the current hard-coded value).

This value is used to determine the opacity for non-selected annotation elements.