### PR TITLE
Better detect available memory in containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.35.3
+
+### Improvements
+
+- Better detect available memory in containers ([#2115](../../pull/2115))
+
 ## 1.35.2
 
 ### Improvements

--- a/large_image/config.py
+++ b/large_image/config.py
@@ -186,12 +186,14 @@ def total_memory() -> int:
     mem = 0
     if HAS_PSUTIL:
         mem = psutil.virtual_memory().total
-    try:
-        cgroup = int(open('/sys/fs/cgroup/memory/memory.limit_in_bytes').read().strip())
-        if 1024 ** 3 <= cgroup < 1024 ** 4 and (mem is None or cgroup < mem):
-            mem = cgroup
-    except Exception:
-        pass
+    caps = {'/sys/fs/cgroup/memory/memory.limit_in_bytes', '/sys/fs/cgroup/memory.max'}
+    for cap in caps:
+        try:
+            cgroup = int(open(cap).read().strip())
+            if 1024 ** 3 <= cgroup < 1024 ** 4 and (mem is None or cgroup < mem):
+                mem = cgroup
+        except Exception:
+            pass
     if mem:
         return mem
     return 8 * 1024 ** 3


### PR DESCRIPTION
Kernels using cgroup protocol v2 have a different location where memory limits are stored.  This is tied to the linux kernel version.  Try both v1 and v2 locations.  Without this, containers run with memory limits get the host memory rather than their available memory.