### PR TITLE
Avoid a recent release of a package

### DIFF
--- a/sources/zarr/setup.py
+++ b/sources/zarr/setup.py
@@ -40,7 +40,7 @@ setup(
         # 0.16 requires zarr 3 (but does specify such)
         'numcodecs<0.16',
         # Without imagecodecs-numcodecs, some jpeg encoded data cannot be read
-        'imagecodecs-numcodecs!=2024.9.22',
+        'imagecodecs-numcodecs!=2024.9.22,!=2026.8.16',
         'filelock',
     ],
     extras_require={


### PR DESCRIPTION
The most recent release of imagecodecs-numcodecs isn't installing cleanly.  Avoid that version