### PR TITLE
Avoid unclosed sqlite db when opening zarr source

### DIFF
--- a/sources/zarr/large_image_source_zarr/__init__.py
+++ b/sources/zarr/large_image_source_zarr/__init__.py
@@ -105,15 +105,15 @@ class ZarrFileTileSource(FileTileSource, metaclass=LruCacheMetaclass):
         self._frameUnits = None
         if not os.path.isfile(self._largeImagePath) and '//:' not in self._largeImagePath:
             raise TileSourceFileNotFoundError(self._largeImagePath) from None
-        try:
-            self._zarr = zarr.open(zarr.SQLiteStore(self._largeImagePath), mode='r')
-        except Exception:
-            try:
+        if os.path.basename(self._largeImagePath) in {'.zgroup', '.zattrs', '.zarray'}:
+            with contextlib.suppress(Exception):
+                self._zarr = zarr.open(os.path.dirname(self._largeImagePath), mode='r')
+        if self._zarr is None:
+            with contextlib.suppress(Exception):
                 self._zarr = zarr.open(self._largeImagePath, mode='r')
-            except Exception:
-                if os.path.basename(self._largeImagePath) in {'.zgroup', '.zattrs', '.zarray'}:
-                    with contextlib.suppress(Exception):
-                        self._zarr = zarr.open(os.path.dirname(self._largeImagePath), mode='r')
+        if self._zarr is None:
+            with contextlib.suppress(Exception):
+                self._zarr = zarr.open(zarr.SQLiteStore(self._largeImagePath), mode='r')
         if self._zarr is None:
             if not os.path.isfile(self._largeImagePath):
                 raise TileSourceFileNotFoundError(self._largeImagePath) from None


### PR DESCRIPTION
This PR is in response to a [CI failure on geodatalytics](https://github.com/OpenGeoscience/geodatalytics/actions/runs/32761399267/job/97540839340), wherein we leverage the zarr source to write a multiframe flood raster and then convert it to COG via the large image converter.

The failure occurs because of two instances of the same warning, raised for two different `sqlite.Connection` objects: `ResourceWarning: unclosed database in <sqlite3.Connection object at 0x7fa59257c6d0>`. 

Here's how an unclosed sqlite db is created:
1. In `large_image_source_zarr.write`, `convert` is called on the `.zattrs` file ([x](https://github.com/girder/large_image/blob/6e75e57bed6d01a97a64cb67d75e93de01567b65/sources/zarr/large_image_source_zarr/__init__.py#L1440))
2. In `convert`, `_data_from_large_image` is called on that file to get some basic metadata ([x](https://github.com/girder/large_image/blob/6e75e57bed6d01a97a64cb67d75e93de01567b65/utilities/converter/large_image_converter/__init__.py#L1040))
3. In `_data_from_large_image`, `large_image.open` is called on that file ([x](https://github.com/girder/large_image/blob/6e75e57bed6d01a97a64cb67d75e93de01567b65/utilities/converter/large_image_converter/__init__.py#L78))
4. The zarr source is used to open the `.zattrs` file, so `_initOpen` will attempt to open the file in a few different ways. One of the first things tried is to open it as a `SQLiteStore` ([x](https://github.com/girder/large_image/blob/6e75e57bed6d01a97a64cb67d75e93de01567b65/sources/zarr/large_image_source_zarr/__init__.py#L109))
5. In the constructor for the `SQLiteStore` from `zarr-python`, a sqlite connection is created ([x](https://github.com/zarr-developers/zarr-python/blob/3ad97b9c783fecef6e9528c41e44aad417ca2447/zarr/storage.py#L2686)), and then a few lines later, that connection is used to initialize a database ([x](https://github.com/zarr-developers/zarr-python/blob/3ad97b9c783fecef6e9528c41e44aad417ca2447/zarr/storage.py#L2702))
6. Since the `.zattrs` file is not a valid sqlite db, an exception is raised in the `SQLiteStore` constructor after the connection is made, but the connection is not closed.
7. `_initOpen` will catch the exception and continue trying other ways to open the file ([x](https://github.com/girder/large_image/blob/6e75e57bed6d01a97a64cb67d75e93de01567b65/sources/zarr/large_image_source_zarr/__init__.py#L110)), but the sqlite connection is still never closed

This problem would be resolved more completely if we could wrap [this line](https://github.com/zarr-developers/zarr-python/blob/3ad97b9c783fecef6e9528c41e44aad417ca2447/zarr/storage.py#L2702) from the `SQLiteStore` constructor in a `try-except-raise` like so:

```
try:
    self.cursor.execute("CREATE TABLE IF NOT EXISTS zarr(k TEXT PRIMARY KEY, v BLOB)")
except:
    self.db.close()
    raise
```

But we can't make any upstream contributions for this because we intentionally use an out-of-date version of `zarr-python` ([x](https://github.com/girder/large_image/blob/6e75e57bed6d01a97a64cb67d75e93de01567b65/sources/zarr/setup.py#L38)), since v3 removes the `SQLiteStore`.

One possible solution for this problem is just to reorder the logic in the zarr source's `_initOpen` function, like I did in [78c0014](https://github.com/girder/large_image/commit/78c001496bdbddea14033ee7280aba9651d5ad08). If we try other methods of opening the file first, it will be less likely (but not impossible) to reach the attempt to create a `SQLiteStore` with a file not meant for that store type. This solution at least resolves the test failure I linked above.

But I would also want to find a more complete solution that could prevent those unclosed db connections entirely. Maybe we could add some kind of check before we attempt to construct a `SQLiteStore`.