### PR TITLE
Find public config files blocked by private ones

### DIFF
--- a/girder/girder_large_image/__init__.py
+++ b/girder/girder_large_image/__init__.py
@@ -596,9 +596,13 @@ def yamlConfigFile(folder, name, user):
     """
     addConfig = None
     last = False
+    isGlobalConfig = False
     while folder:
         item = Item().findOne({'folderId': folder['_id'], 'name': name})
-        if item:
+        # If the user can't access the folder and it is not a global config mechanism,
+        # skip this folder. Keep walking up the chain to merge other publically available
+        # configuration in the hierarchy.
+        if item and (isGlobalConfig or Folder().hasAccess(folder, user, AccessType.READ)):
             for file in Item().childFiles(item):
                 if file['size'] > 10 * 1024 ** 2:
                     logger.info('Not loading %s -- too large', file['name'])
@@ -627,6 +631,7 @@ def yamlConfigFile(folder, name, user):
                     'parentId': folder['parentId'],
                     'parentCollection': folder['parentCollection'],
                     'name': '.config'})
+                isGlobalConfig = True
             else:
                 last = 'setting'
             if not folder or last == 'setting':
@@ -635,8 +640,10 @@ def yamlConfigFile(folder, name, user):
                     break
                 folder = Folder().load(folderId, force=True)
                 last = True
+                isGlobalConfig = True
         else:
-            folder = Folder().load(folder['parentId'], user=user, level=AccessType.READ)
+            folder = Folder().load(folder['parentId'], force=True)
+            isGlobalConfig = False
 
     addConfig = {} if addConfig is None else addConfig
     addSettingsToConfig(addConfig, user, name)

--- a/girder/test_girder/test_large_image.py
+++ b/girder/test_girder/test_large_image.py
@@ -666,6 +666,38 @@ def testYAMLConfigFileInherit(server, admin, user, fsAssetstore):
     assert resp.json['keyE'] == 'value7'
 
 
+@pytest.mark.usefixtures('unbindLargeImage')
+@pytest.mark.plugin('large_image')
+def testYAMLConfigFileSkipPrivate(server, admin, user, fsAssetstore):
+    collection = Collection().createCollection(
+        'collection A', admin, public=False)
+    colFolderA = Folder().createFolder(
+        collection, 'folder A', parentType='collection',
+        creator=admin, public=True)
+    colFolderB = Folder().createFolder(
+        colFolderA, 'folder B', parentType='folder',
+        creator=admin, public=False)
+    colFolderC = Folder().createFolder(
+        colFolderB, 'folder C', parentType='folder',
+        creator=admin, public=True)
+    # Public config
+    utilities.uploadText(
+        json.dumps({
+            'keyA': 'publicValue',
+        }), admin, fsAssetstore, colFolderA, 'sample.json',
+    )
+    # Private config
+    utilities.uploadText(
+        json.dumps({
+            'keyA': 'privateValue',
+        }), admin, fsAssetstore, colFolderB, 'sample.json',
+    )
+    resp = server.request(
+        path='/folder/%s/yaml_config/sample.json' % str(colFolderC['_id']), user=None)
+    assert utilities.respStatus(resp) == 200
+    assert resp.json['keyA'] == 'publicValue'
+
+
 @pytest.mark.singular
 @pytest.mark.usefixtures('unbindLargeImage')
 @pytest.mark.plugin('large_image')


### PR DESCRIPTION
Prevents returning a `401`/`403` when retrieving a YAML config if an attempt is made to read a config file in a private folder.

Instead, the traversal of the hierarchy skips folders that are inaccessible to the current user, and continues to find publicly available config files (up to and including the root collection/user and the .config directory).